### PR TITLE
README overhaul: how it works, install guide, full credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,114 @@
+<div align="center">
+
 # Pane
 
-All your AI subscription limits in one liquid-glass tray popover for
-Windows. Click the tray icon next to the clock and see, at a glance, how
-much of your session/weekly limits each AI tool has left — with pace
-projections, local spend accounting, and live tray-icon numbers.
+**All your AI subscription limits in one liquid-glass tray popover for Windows.**
 
-Started as a Windows rebuild of the excellent
-[OpenUsage for macOS](https://github.com/robinebers/openusage) by Robin
-Ebers (MIT licensed), built from scratch with Tauri v2 + vanilla
-TypeScript, and growing beyond usage tracking from there.
+One click on the tray icon answers the questions every AI power user keeps
+asking: *How much of my Claude session is left? When does my Codex weekly
+reset? What did today actually cost me?*
+
+[Install](#install) · [How it works](#how-it-works) · [Providers](#providers-18-and-counting) · [Features](#features) · [Privacy](#privacy) · [Credits](#credits)
+
+<!-- TODO: screenshot — dark popover with Claude/Codex/Copilot cards -->
+
+</div>
+
+---
+
+## Why Pane
+
+If you use AI coding tools seriously, you're juggling half a dozen separate
+subscriptions — Claude Max, ChatGPT/Codex, Copilot, Cursor, and whatever
+else this month brought. Each one hides its limits behind its own dashboard,
+counts in its own units, and resets on its own schedule. The only time you
+find out you're running low is when you hit the wall mid-task.
+
+Pane puts all of them in one place, in your system tray, refreshed every few
+minutes, with pace warnings *before* you hit the wall. It started as a
+Windows rebuild of the excellent [OpenUsage for macOS](https://github.com/robinebers/openusage)
+by [Robin Ebers](https://github.com/robinebers) and is growing into a
+broader AI-workflow companion from there.
+
+## Install
+
+### Installer (recommended)
+
+1. Grab **`Pane_x.y.z_x64-setup.exe`** from the
+   [latest release](https://github.com/ItsJazii/pane/releases/latest).
+2. Run it. Pane installs per-user to `%LOCALAPPDATA%\Pane` — no admin
+   rights needed.
+3. Look for the Pane icon in the system tray (next to the clock). Click it.
+
+> **SmartScreen note:** the installer isn't code-signed yet, so Windows may
+> show "Windows protected your PC." Click **More info → Run anyway**. Code
+> signing is on the roadmap.
+
+Silent install (for scripts): `Pane_x.y.z_x64-setup.exe /S`
+
+### winget *(coming soon)*
+
+Once Pane has its first public release, it will be submitted to the winget
+community repo so this works:
+
+```
+winget install ItsJazii.Pane
+```
+
+### Build from source
+
+Prerequisites: Node.js 20+, Rust (stable-msvc), Visual Studio C++ Build
+Tools, WebView2 (bundled with Windows 11).
+
+```
+git clone https://github.com/ItsJazii/pane
+cd pane
+npm install
+npm run tauri dev     # run with hot reload
+npm run tauri build   # installer lands in src-tauri/target/release/bundle
+```
+
+## How it works
+
+Pane is a small Tauri v2 app: a Rust core doing the data work, a vanilla
+TypeScript UI doing the glass. No Electron, no background services — one
+~10 MB process idling around 90 MB of RAM.
+
+**1. Finding your accounts.** The official CLIs and editors you already use
+keep their login tokens in well-known per-user locations — Claude Code
+writes `%USERPROFILE%\.claude\.credentials.json`, Codex CLI writes
+`%USERPROFILE%\.codex\auth.json`, the GitHub CLI stores its token in
+Windows Credential Manager, and so on. Pane reads those same files (or
+takes an API key you paste into Settings) and shows a card for every tool
+it finds. Tools it can't find start disabled — no dead cards.
+
+**2. Asking the vendors.** Every few minutes, each provider's token is sent
+to **its own vendor's API only** — the exact usage endpoints the vendors'
+own apps use — and the card updates with sessions, weekly windows, credit
+balances, and reset times. Expired OAuth tokens are refreshed and written
+back, which keeps your CLIs signed in too. Failing providers get benched
+briefly and their last good data is shown with an "Outdated" tag instead of
+a blank card.
+
+**3. Pacing the burn.** Every metric with a reset window gets a projection:
+if you keep burning at this rate, will you make it to the reset? Bars turn
+amber/red as the math worsens and optional Windows toasts fire once per
+reset window ("Almost out", "Will run out").
+
+**4. Counting the money.** Your CLIs already log every request locally.
+Pane scans those logs (Claude, Codex, Grok, OpenCode, Cursor CSV), prices
+each request with live per-model rates (LiteLLM / models.dev, refreshed
+daily), and draws the Today / Yesterday / 30-day donut with a per-model
+breakdown. On a flat-rate plan this shows what your usage *would* cost at
+API prices — the best ad for your subscription you'll ever see. Events for
+models without a known price are excluded and flagged, never guessed.
+
+**5. Staying local.** All of the above happens on your machine. There is no
+Pane server, no account, and no telemetry — see [Privacy](#privacy).
 
 ## Providers (18 and counting)
 
-| Provider | Source of data |
+| Provider | How Pane connects |
 |---|---|
 | Claude (Claude Code) | `%USERPROFILE%\.claude\.credentials.json` + Anthropic usage API |
 | Codex (Codex CLI) | `%USERPROFILE%\.codex\auth.json` + ChatGPT usage API, incl. reset-credit redemption |
@@ -38,58 +134,78 @@ TypeScript, and growing beyond usage tracking from there.
 usage is computed locally from this machine's OpenCode history, the same
 data `opencode stats` uses.
 
-Tokens are read from the files the official tools already maintain and are
-sent only to their own vendor APIs. No telemetry, no middleman server.
-Expired OAuth tokens are refreshed and written back, keeping the CLIs
-signed in.
+More on the way: CLI-token providers (Codebuff, Amp, Kilo, Kiro, Vertex AI,
+AWS Bedrock…), IDE-database providers (Windsurf, JetBrains AI, Zed…), and
+self-hosted proxies (LiteLLM & friends).
 
 ## Features
 
 - **Pace projections** — colored bars and "will run out" warnings based on
   your burn rate within each reset window, plus optional Windows toasts.
 - **Local spend** — Today / Yesterday / 30 Days donut with per-model
-  breakdown and a 30-day trend, computed entirely from the CLIs' own logs
-  and priced with live model rates (LiteLLM / models.dev, refreshed daily).
+  breakdown and a 30-day trend, priced with live model rates.
 - **Codex reset credits** — see each banked credit's exact expiry and
   redeem it with one click.
-- **Customize** (☰) — reorder, hide, or star metrics; stars become live
-  tray icons (logo + number pairs). Ctrl+Z undoes layout changes.
-- **Liquid glass UI** — SDF lens refraction on the auto-hiding sidebar and
-  glass bars, magnetic minimap trail, circular day/night wipe.
+- **Live tray numbers** — star up to two metrics per provider and they
+  render as logo + percentage pairs directly in the tray.
+- **Customize** (☰) — reorder providers and metrics by drag, hide rows,
+  tuck rarely-needed ones behind an "On Demand" caret. Ctrl+Z undoes.
+- **Liquid glass UI** — real SDF lens refraction on the auto-hiding
+  sidebar and glass bars, magnetic minimap trail, circular day/night wipe.
 - **Share cards** — hover a card, click ⧉, paste the PNG anywhere.
 - **Quick links** — Status / Dashboard shortcuts on every card.
-- **Local HTTP API** — `GET http://127.0.0.1:6736/v1/usage`, same wire
-  format as the Mac app's documented API.
-- **Appearance** — System / Light / Dark, plus a Compact density.
-- **Global shortcut** — toggle the popover from anywhere (e.g. `Ctrl+Shift+U`).
+- **Local HTTP API** — `GET http://127.0.0.1:6736/v1/usage` for scripts,
+  Rainmeter widgets, stream overlays; same wire format as the Mac app.
+- **Appearance** — System / Light / Dark, compact density, global shortcut
+  (e.g. `Ctrl+Shift+U`), optional outbound proxy.
+
+## Privacy
+
+- **Zero telemetry.** Pane phones home to nobody — there is no "home".
+- **Tokens never leave their lane.** Each vendor's credential is sent only
+  to that vendor's own API, over HTTPS, and nowhere else.
+- **Keys stay on this PC** in `%APPDATA%\Pane`, readable only by your
+  Windows user.
+- **Spend accounting is local.** Your usage logs are parsed on your
+  machine; only anonymous price-table downloads (LiteLLM/models.dev) touch
+  the network, and those are one-way.
+- The local HTTP API binds to `127.0.0.1` only — nothing on your network
+  can reach it.
 
 ## Settings (gear icon)
 
-- Refresh interval (default: every 5 minutes)
-- Start with Windows
-- Which metric the tray icon displays
-- Appearance, compact layout, global shortcut, time format
-- Optional outbound proxy (`socks5://` or `http(s)://`)
-- API keys (stored only on this PC in `%APPDATA%\Pane`)
+Refresh interval · Start with Windows · tray metric picker · appearance &
+compact density · time format · global shortcut · notification toggles ·
+outbound proxy · API keys.
 
-## Development
+## Credits
 
-Prerequisites: Node.js, Rust (stable-msvc), Visual Studio C++ Build Tools,
-WebView2 (bundled with Windows 11).
+Pane exists because of
+**[OpenUsage for macOS](https://github.com/robinebers/openusage)** by
+**[Robin Ebers](https://github.com/robinebers)** (MIT). The hard part of a
+tool like this — knowing which credential files to read, which
+undocumented usage endpoints to call, and how to interpret their
+responses — is research Robin did first and published openly. Pane is an
+independent from-scratch rebuild for Windows (Rust + TypeScript instead of
+Swift), but it stands on that research and gladly says so. If you're on a
+Mac, use his app.
 
-```
-npm install
-npm run tauri dev     # run with hot reload
-npm run tauri build   # produce installer (src-tauri/target/release/bundle)
-```
+Additional thanks:
 
-## Credit & license
+- [Tauri](https://tauri.app/) — the app shell that keeps Pane tiny.
+- [prasen.dev](https://www.prasen.dev/) — the original SDF liquid-glass
+  lens technique the UI's refraction is ported from.
+- [LiteLLM](https://github.com/BerriAI/litellm) and
+  [models.dev](https://models.dev/) — open model-price catalogs powering
+  the spend engine.
+- [shadcn/ui](https://ui.shadcn.com/) — the zinc design tokens the theme
+  is built on.
 
-MIT — see [LICENSE](LICENSE).
+Pane is not affiliated with or endorsed by Robin Ebers or any of the AI
+vendors listed. Provider names and logos belong to their respective owners
+and are used only to identify the services.
 
-The provider research — which credential files to read, which endpoints to
-call — comes from the excellent macOS original:
-[robinebers/openusage](https://github.com/robinebers/openusage) (MIT).
-Pane is an independent project and is not affiliated with Robin Ebers or
-any of the AI vendors listed. Provider names and logos belong to their
-respective owners and are used only to identify the services.
+## License
+
+[MIT](LICENSE) — © 2026 Jazii, with provider research credit to Robin
+Ebers' OpenUsage (MIT).


### PR DESCRIPTION
## What this changes

Replaces the short feature-list README with a proper front page for the repo:

- **Why Pane** — the pitch, with the OpenUsage origin story up front
- **Install** — installer from Releases (with SmartScreen note + silent `/S` flag), winget (marked *coming soon* — needs a public release first), and build-from-source
- **How it works** — five-part plain-English walkthrough: account discovery from the CLIs' own credential files, per-vendor API calls, pace projections, local spend pricing, local-only design
- **Privacy** — dedicated section: zero telemetry, tokens only go to their own vendor, localhost-only HTTP API
- **Credits** — full paragraph for Robin Ebers and the original OpenUsage research, plus Tauri, prasen.dev (lens technique), LiteLLM/models.dev, shadcn/ui
- Provider table updated to all 18 + what's coming in future waves

## Notes

- Left a `<!-- TODO -->` placeholder for a hero screenshot
- winget section is intentionally aspirational — the manifest can only be submitted once the repo is public with a tagged release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/1" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->