### PR TITLE
Fix ghost provider rows + last console flash

### DIFF
--- a/src-tauri/src/providers/kiro.rs
+++ b/src-tauri/src/providers/kiro.rs
@@ -34,12 +34,16 @@ fn strip_ansi(s: &str) -> String {
 }
 
 async fn fetch() -> Result<Snapshot, String> {
-    // Installed at all? (`where` beats spawning the CLI to find out.)
-    let found = tokio::process::Command::new("cmd")
-        .args(["/C", "where", "kiro-cli"])
-        .output()
-        .await
-        .map(|o| o.status.success())
+    // Installed at all? Scan PATH ourselves — spawning `where` via cmd
+    // flashed a console window on every refresh for everyone without Kiro.
+    let found = std::env::var_os("PATH")
+        .map(|paths| {
+            std::env::split_paths(&paths).any(|dir| {
+                ["kiro-cli.exe", "kiro-cli.cmd", "kiro-cli.bat"]
+                    .iter()
+                    .any(|name| dir.join(name).is_file())
+            })
+        })
         .unwrap_or(false);
     if !found {
         return Ok(Snapshot::no_credentials(ID, NAME, "Kiro CLI (kiro-cli) is not installed."));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1544,6 +1544,23 @@ async function refresh(force = false): Promise<void> {
           layout: config.layout,
         }).catch(() => {});
       }
+
+      // Updates also RETIRE providers; saved layouts keep referencing their
+      // ids, which rendered ghost rows in Customize. Prune anything the app
+      // no longer knows.
+      const valid = new Set(ALL_PROVIDERS.map(([id]) => id));
+      const prunedOrder = config.layout.providerOrder.filter((id) => valid.has(id));
+      const staleLayout = Object.keys(config.layout.providers).filter((id) => !valid.has(id));
+      const prunedDisabled = config.disabled.filter((id) => valid.has(id));
+      if (
+        prunedOrder.length !== config.layout.providerOrder.length ||
+        staleLayout.length ||
+        prunedDisabled.length !== config.disabled.length
+      ) {
+        config.layout.providerOrder = prunedOrder;
+        for (const id of staleLayout) delete config.layout.providers[id];
+        await patchConfig({ layout: config.layout, disabled: prunedDisabled }).catch(() => {});
+      }
     }
     const firstData = lastSnapshots.length === 0;
     lastFetch = Date.now();


### PR DESCRIPTION
Two follow-ups to the provider trim:

- **Ghost rows in Customize**: saved layouts still referenced the 10 retired provider ids (rendered as raw ids like `amp`, `vertexai`). refresh() now prunes unknown ids from providerOrder, per-provider layout entries, and the disabled list — one-time self-heal on next refresh.
- **The remaining terminal pop-up**: Kiro's install-check spawned `cmd /C where kiro-cli` **without** CREATE_NO_WINDOW every refresh. Replaced with a filesystem PATH scan — no process spawned at all unless kiro-cli is actually installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->