### PR TITLE
Docs: sync provider list to the real 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,26 @@
 ## Unreleased
 
 ### New
-- **Wave 12 provider pack** — ten providers whose CLIs/tools leave tokens on
-  disk or take an API key (provider research credit: steipete/CodexBar, MIT):
-  Codebuff (credits + weekly, CLI login or key), Kilo (credit blocks +
-  Kilo Pass, CLI login or key), Kiro (experimental CLI scrape of
-  `kiro-cli /usage`), Amp (CLI `amp usage`, or API token — free-tier
-  replenish ETA), Vertex AI (gcloud ADC identity + project), AWS Bedrock
-  (native SigV4 → Cost Explorer monthly spend, optional PANE_BEDROCK_BUDGET
-  progress bar, env keys or AWS_PROFILE via the AWS CLI), Poe (point
-  balance), Chutes (4-hour + monthly quotas), Warp (request credits +
-  bonus grants), Crof (daily requests + credit balance). 28 providers total.
+- **Three CLI-detected providers** (research credit: steipete/CodexBar, MIT):
+  Codebuff (credits + weekly limit, `codebuff login` file or key), Kilo
+  (credit blocks + Kilo Pass, CLI login file or key), and Kiro
+  (experimental — reads `kiro-cli /usage`). **18 providers total.**
+- **Auto-updater** — Pane checks GitHub releases on launch and every 4
+  hours; a banner offers one-click download + restart. Updates are
+  cryptographically signed and verified before install.
+
+### Removed
+- Deepgram, OpenAI, Venice, Poe, Chutes, Warp, Crof, Amp, Vertex AI, and
+  AWS Bedrock providers — cut to keep the lineup focused on the AI coding
+  tools people actually track. Saved layouts self-clean any retired ids.
+
+### Fixed
+- Terminal windows no longer flash during refreshes (provider CLI checks
+  now run windowless or scan the filesystem instead of spawning `cmd`).
+- Retired providers no longer linger as ghost rows in Customize.
+- Startup crash at higher provider counts (fetch futures now heap-boxed).
+- Clicking the tray icon always reopens on the main page, even if the app
+  was left on Settings or Customize.
 
 ## 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -124,19 +124,18 @@ Pane server, no account, and no telemetry — see [Privacy](#privacy).
 | DeepSeek | API key (Settings) → balance |
 | Moonshot (Kimi) | API key (Settings) → balance (global + CN endpoints) |
 | ElevenLabs | API key (Settings) → character quota with reset pacing |
-| Deepgram | API key (Settings) → project balances |
-| OpenAI | Admin API key (Settings) → org costs (Today / 30 days) |
-| Venice | API key (Settings) → USD/DIEM/VCU balances |
 | Ollama | Local server on :11434 — installed + loaded models, no key |
+| Codebuff | `codebuff login` credentials file or API key → credits + weekly limit |
+| Kilo | Kilo CLI login file or API key → credit blocks + Kilo Pass |
+| Kiro *(experimental)* | Reads `kiro-cli /usage` output → credits + bonus credits |
 
 *OpenCode has no public usage API yet
 ([anomalyco/opencode#10448](https://github.com/anomalyco/opencode/issues/10448));
 usage is computed locally from this machine's OpenCode history, the same
 data `opencode stats` uses.
 
-More on the way: CLI-token providers (Codebuff, Amp, Kilo, Kiro, Vertex AI,
-AWS Bedrock…), IDE-database providers (Windsurf, JetBrains AI, Zed…), and
-self-hosted proxies (LiteLLM & friends).
+More on the way: IDE-database providers (Windsurf, JetBrains AI…) and
+whatever the community asks for loudest.
 
 ## Features
 


### PR DESCRIPTION
README's provider table now matches what actually ships: Deepgram/OpenAI/Venice rows removed, Codebuff/Kilo/Kiro added (still exactly 18 — the trim and the Wave 12 keepers cancel out). "More on the way" now only promises Windsurf/JetBrains. Changelog Unreleased section rewritten to reflect reality: 3 providers added, 10 removed, auto-updater, and tonight's four fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->