### PR TITLE
Kiro: hide the usage-fetch console window

### DIFF
--- a/src-tauri/src/providers/kiro.rs
+++ b/src-tauri/src/providers/kiro.rs
@@ -11,11 +11,16 @@ pub async fn snapshot() -> Snapshot {
 }
 
 async fn run_cli(args: &[&str], secs: u64) -> Option<String> {
+    // CREATE_NO_WINDOW: this runs on every refresh once kiro-cli is
+    // installed — without it, a console flashes over whatever the user is
+    // doing every five minutes.
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
     let out = tokio::time::timeout(
         std::time::Duration::from_secs(secs),
         tokio::process::Command::new("cmd")
             .args(["/C", "kiro-cli"])
             .args(args)
+            .creation_flags(CREATE_NO_WINDOW)
             .output(),
     )
     .await


### PR DESCRIPTION
The earlier console-flash fix covered Kiro's install-check but the actual usage fetch (`cmd /C kiro-cli chat /usage`) still spawned without CREATE_NO_WINDOW. Harmless for anyone without kiro-cli — but the moment it's installed (as of tonight on jazii's machine), a console flashed every refresh. One flag added; verified compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->