### PR TITLE
Parity polish: extra metric rows, Not-started state, popover keys

### DIFF
--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -121,19 +121,73 @@ async fn fetch() -> Result<Snapshot, String> {
     push_window(&mut metrics, usage.get("seven_day"), "Weekly", 7 * DAY);
     push_window(&mut metrics, usage.get("seven_day_sonnet"), "Sonnet weekly", 7 * DAY);
     push_window(&mut metrics, usage.get("seven_day_opus"), "Opus weekly", 7 * DAY);
+
+    // Newer per-model weeklies (Fable era) live in a `limits` array instead of
+    // legacy `seven_day_<model>` keys. Add any we don't already show.
+    for entry in usage.get("limits").and_then(Value::as_array).unwrap_or(&vec![]) {
+        if entry.get("kind").and_then(Value::as_str) != Some("weekly_scoped") {
+            continue;
+        }
+        let Some(name) = entry.pointer("/scope/model/display_name").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(percent) = entry.get("percent").and_then(Value::as_f64) else { continue };
+        let label = format!("{name} weekly");
+        if metrics.iter().any(|m| m.label == label) {
+            continue;
+        }
+        let resets_at = parse_reset(entry.get("resets_at"));
+        metrics
+            .push(Metric::progress(&label, percent, None).with_reset(resets_at, Some(7 * DAY)));
+    }
+
+    // Extra Usage: pay-as-you-go overage spend, in cents. Bounded meter when
+    // a monthly cap is set, plain dollars when uncapped, absent when unused.
+    if let Some(extra) = usage.get("extra_usage") {
+        let enabled = extra.get("is_enabled").and_then(Value::as_bool).unwrap_or(false);
+        let used_cents = extra.get("used_credits").and_then(Value::as_f64);
+        if enabled {
+            if let Some(used_cents) = used_cents {
+                let used = (used_cents.round()) / 100.0;
+                let cap = extra
+                    .get("monthly_limit")
+                    .and_then(Value::as_f64)
+                    .map(|c| c.round() / 100.0)
+                    .filter(|c| *c > 0.0);
+                if let Some(cap) = cap {
+                    metrics.push(Metric::progress(
+                        "Extra usage",
+                        (used / cap * 100.0).clamp(0.0, 100.0),
+                        Some(format!("${used:.2} of ${cap:.2} limit")),
+                    ));
+                } else if used > 0.0 {
+                    metrics.push(Metric::text("Extra usage", format!("${used:.2} spent")));
+                }
+            }
+        }
+    }
+
     if metrics.is_empty() {
         return Err("usage response had no recognizable limit windows".into());
     }
     Ok(Snapshot::ok(ID, NAME, plan, metrics))
 }
 
+/// `resets_at` arrives as ISO-8601 or epoch (seconds when < 1e10, else ms).
+fn parse_reset(v: Option<&Value>) -> Option<i64> {
+    match v? {
+        Value::String(s) => DateTime::parse_from_rfc3339(s).ok().map(|dt| dt.timestamp_millis()),
+        Value::Number(n) => {
+            let n = n.as_f64()?;
+            Some(if n.abs() < 1e10 { (n * 1000.0) as i64 } else { n as i64 })
+        }
+        _ => None,
+    }
+}
+
 fn push_window(metrics: &mut Vec<Metric>, node: Option<&Value>, label: &str, period_ms: i64) {
     let Some(node) = node else { return };
     let Some(used) = node.get("utilization").and_then(Value::as_f64) else { return };
-    let resets_at = node
-        .get("resets_at")
-        .and_then(Value::as_str)
-        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-        .map(|dt| dt.timestamp_millis());
+    let resets_at = parse_reset(node.get("resets_at"));
     metrics.push(Metric::progress(label, used, None).with_reset(resets_at, Some(period_ms)));
 }

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -174,6 +174,40 @@ async fn fetch() -> Result<Snapshot, String> {
         rate_limits.get("secondary_window").or_else(|| rate_limits.get("secondary")),
         "Weekly",
     );
+    // Spark (a separate metered model family) lives in additional_rate_limits;
+    // only the spark entry is shown, matching the Mac app.
+    if let Some(extra_limits) = usage.get("additional_rate_limits").and_then(Value::as_array) {
+        let spark = extra_limits.iter().find(|e| {
+            ["limit_name", "metered_feature"].iter().any(|k| {
+                e.get(*k)
+                    .and_then(Value::as_str)
+                    .is_some_and(|s| s.to_lowercase().contains("spark"))
+            })
+        });
+        if let Some(entry) = spark {
+            let rl = entry.get("rate_limit").unwrap_or(entry);
+            push_window_labeled(&mut metrics, rl.get("primary_window"), "Spark");
+            push_window_labeled(&mut metrics, rl.get("secondary_window"), "Spark Weekly");
+        }
+    }
+
+    // Extra Usage: pay-as-you-go credit balance ($0.04 per credit). A spent
+    // balance still reads "$0.00 · 0 credits" — that's information, not noise.
+    let credit_balance = usage
+        .pointer("/credits/balance")
+        .and_then(Value::as_f64)
+        .or_else(|| {
+            (usage.pointer("/credits/has_credits").and_then(Value::as_bool) == Some(false))
+                .then_some(0.0)
+        });
+    if let Some(balance) = credit_balance {
+        let credits = balance.floor().max(0.0);
+        metrics.push(Metric::text(
+            "Extra usage",
+            format!("${:.2} · {credits:.0} credits", credits * 0.04),
+        ));
+    }
+
     // Per-credit rows with exact expiry (and a Use button in the UI) from
     // the dedicated endpoint; fall back to the usage body's bare count.
     match fetch_reset_credits(&access, &account_id).await {
@@ -312,24 +346,54 @@ pub async fn redeem_credit(credit_id: &str) -> Result<String, String> {
 }
 
 fn push_window(metrics: &mut Vec<Metric>, node: Option<&Value>, fallback_label: &str) {
+    push_window_inner(metrics, node, fallback_label, false);
+}
+
+/// Like push_window but keeps the given label (Spark rows must not be
+/// auto-renamed to Session/Weekly by window length).
+fn push_window_labeled(metrics: &mut Vec<Metric>, node: Option<&Value>, label: &str) {
+    push_window_inner(metrics, node, label, true);
+}
+
+fn push_window_inner(metrics: &mut Vec<Metric>, node: Option<&Value>, label_in: &str, forced: bool) {
     let Some(node) = node else { return };
-    let Some(used) = node.get("used_percent").and_then(Value::as_f64) else { return };
+    let Some(mut used) = node.get("used_percent").and_then(Value::as_f64) else { return };
     let window_seconds = node
         .get("limit_window_seconds")
         .and_then(Value::as_i64)
         .or_else(|| node.get("window_minutes").and_then(Value::as_i64).map(|m| m * 60));
-    let label = match window_seconds {
-        Some(s) if s > 21_600 => "Weekly", // longer than 6 hours
-        Some(_) => "Session",
-        None => fallback_label,
+    let label = if forced {
+        label_in
+    } else {
+        match window_seconds {
+            Some(s) if s > 21_600 => "Weekly", // longer than 6 hours
+            Some(_) => "Session",
+            None => label_in,
+        }
     };
     let period_ms = window_seconds
         .map(|s| s * 1000)
-        .unwrap_or(if label == "Weekly" { 7 * 86_400_000 } else { 5 * 3_600_000 });
+        .unwrap_or(if label.contains("Weekly") { 7 * 86_400_000 } else { 5 * 3_600_000 });
+    let now_ms = Utc::now().timestamp_millis();
     let resets_at = node
-        .get("reset_after_seconds")
-        .or_else(|| node.get("resets_in_seconds"))
+        .get("reset_at")
         .and_then(Value::as_i64)
-        .map(|s| Utc::now().timestamp_millis() + s * 1000);
+        .map(|s| if s < 1_000_000_000_000 { s * 1000 } else { s })
+        .or_else(|| {
+            node.get("reset_after_seconds")
+                .or_else(|| node.get("resets_in_seconds"))
+                .and_then(Value::as_i64)
+                .map(|s| now_ms + s * 1000)
+        });
+    // Codex floors to whole percents and reports 1% on an untouched window.
+    // If the window is essentially full-length (fresh, with a grace for
+    // server-side reset_at staleness), normalize ≤1% to a true zero so the
+    // UI can say "Not started" (upstream issue #708).
+    if let Some(reset) = resets_at {
+        let grace = (period_ms / 100).max(60_000);
+        if used <= 1.0 && now_ms < reset && reset - now_ms >= period_ms - grace {
+            used = 0.0;
+        }
+    }
     metrics.push(Metric::progress(label, used, None).with_reset(resets_at, Some(period_ms)));
 }

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -151,6 +151,17 @@ async fn fetch() -> Result<Snapshot, String> {
     }
     metrics.truncate(4);
 
+    // Pay-as-you-go cap badge. proto3-as-JSON omits zero fields, so a
+    // missing onDemandCap simply means overage is disabled.
+    let cap = billing
+        .pointer("/config/onDemandCap/val")
+        .and_then(Value::as_f64)
+        .unwrap_or(0.0);
+    metrics.push(Metric::text(
+        "Extra usage",
+        if cap > 0.0 { format!("{cap:.0} cap") } else { "Disabled".to_string() },
+    ));
+
     let mut plan = None;
     if let Ok(resp) = settings_resp {
         if resp.status().is_success() {

--- a/src-tauri/src/providers/zai.rs
+++ b/src-tauri/src/providers/zai.rs
@@ -82,6 +82,31 @@ fn collect_quota_metrics(node: &Value, metrics: &mut Vec<Metric>) {
             }
         }
         Value::Object(map) => {
+            // TIME_LIMIT is the monthly web-search quota, with inverted field
+            // roles vs the other entries: `currentValue` = used, `usage` = cap.
+            let type_name = ["type", "name"]
+                .iter()
+                .find_map(|k| map.get(*k).and_then(Value::as_str));
+            if type_name == Some("TIME_LIMIT") {
+                let used = map.get("currentValue").and_then(Value::as_f64).unwrap_or(0.0).max(0.0);
+                let cap = map.get("usage").and_then(Value::as_f64).unwrap_or(0.0).max(0.0);
+                if cap > 0.0 {
+                    let resets_at = map
+                        .get("nextResetTime")
+                        .and_then(Value::as_i64)
+                        .filter(|ms| *ms > 0);
+                    metrics.push(
+                        Metric::progress(
+                            "Web Searches",
+                            (used / cap * 100.0).clamp(0.0, 100.0),
+                            Some(format!("{used:.0} of {cap:.0} searches")),
+                        )
+                        .with_reset(resets_at, Some(30 * 86_400_000)),
+                    );
+                }
+                return;
+            }
+
             let label = ["type", "name", "unit", "quotaType"]
                 .iter()
                 .find_map(|k| map.get(*k).and_then(Value::as_str))

--- a/src/main.ts
+++ b/src/main.ts
@@ -536,10 +536,18 @@ function renderMetric(m: Metric): string {
 
     let resetHtml = "";
     if (m.resets_at !== null && m.resets_at > Date.now()) {
-      const countdown = `Resets in ${fmtDuration(m.resets_at - Date.now())}`;
-      const exact = `Resets ${fmtExact(m.resets_at)}`;
-      const [text, alt] = config.resetExact ? [exact, countdown] : [countdown, exact];
-      resetHtml = `<span class="clickable" data-flip="reset" title="${escapeHtml(alt)}">${escapeHtml(text)}</span>`;
+      // A rolling session window (≤6h period) at exactly 0% hasn't begun —
+      // its clock starts on the first message, so a countdown would lie.
+      const notStarted =
+        used <= 0 && m.period_ms !== null && m.period_ms <= 6 * 3_600_000;
+      if (notStarted) {
+        resetHtml = `<span title="Sessions start after you send your first message.">Not started</span>`;
+      } else {
+        const countdown = `Resets in ${fmtDuration(m.resets_at - Date.now())}`;
+        const exact = `Resets ${fmtExact(m.resets_at)}`;
+        const [text, alt] = config.resetExact ? [exact, countdown] : [countdown, exact];
+        resetHtml = `<span class="clickable" data-flip="reset" title="${escapeHtml(alt)}">${escapeHtml(text)}</span>`;
+      }
     }
     const detailHtml = [m.detail ? escapeHtml(m.detail) : "", resetHtml].filter(Boolean).join(" · ");
     return `
@@ -2005,6 +2013,16 @@ window.addEventListener("DOMContentLoaded", () => {
     if (e.ctrlKey && e.key.toLowerCase() === "z" && customizeOpen) {
       e.preventDefault();
       undoLayout();
+    }
+    // Esc backs out of Customize/Settings (Mac parity).
+    if (e.key === "Escape") {
+      setDrawer(false);
+      setSettings(false);
+    }
+    // Ctrl+R refreshes data — and must NOT reload the webview.
+    if (e.ctrlKey && e.key.toLowerCase() === "r") {
+      e.preventDefault();
+      void refresh(true);
     }
   });
   void getVersion().then((v) => {


### PR DESCRIPTION
Closes the last meaningful gaps vs the macOS original (field specs ported from its source):

**New metric rows**
- **Claude**: per-model weeklies from the new `limits[]` array (Fable era — legacy `seven_day_*` keys are being retired) + **Extra Usage** overage dollars (bounded meter when a monthly cap is set)
- **Codex**: **Spark / Spark Weekly** windows + **Extra Usage** credit balance ("$X · N credits", $0.04/credit). Also normalizes Codex's floored 1% on untouched windows to a true 0 (their issue #708) and accepts `reset_at` epochs
- **Z.ai**: **Web Searches** monthly quota (the TIME_LIMIT entry has inverted field roles — `usage` is the cap)
- **Grok**: **Extra usage** badge — `2500 cap` or `Disabled`

**Behavior**
- Rolling session windows (≤6h period) at exactly 0% read **"Not started"** with an explainer tooltip instead of a countdown
- **Esc** backs out of Customize/Settings; **Ctrl+R** refreshes now (with the webview's own reload suppressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->