### PR TITLE
Docs: launch-day sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 - **Auto-updater** — Pane checks GitHub releases on launch and every 4
   hours; a banner offers one-click download + restart. Updates are
   cryptographically signed and verified before install.
+- **Deeper metric rows** (Mac-parity polish): Claude per-model weeklies
+  from Anthropic's new `limits` API (Fable era) + Extra Usage overage
+  dollars; Codex Spark / Spark Weekly windows + Extra Usage credit
+  balance; Z.ai monthly Web Searches quota; Grok pay-as-you-go cap badge.
+- **"Not started"** — untouched 5-hour session windows say so (with an
+  explainer) instead of showing a countdown that hasn't begun; Codex's
+  floored 1%-on-fresh-window quirk is normalized to a true zero.
+- **Keyboard** — Esc backs out of Customize/Settings, Ctrl+R refreshes.
 
 ### Removed
 - Deepgram, OpenAI, Venice, Poe, Chutes, Warp, Crof, Amp, Vertex AI, and

--- a/README.md
+++ b/README.md
@@ -46,14 +46,17 @@ broader AI-workflow companion from there.
 
 Silent install (for scripts): `Pane_x.y.z_x64-setup.exe /S`
 
-### winget *(coming soon)*
+### winget *(pending review)*
 
-Once Pane has its first public release, it will be submitted to the winget
-community repo so this works:
+Pane 0.4.0 is [submitted to the winget community repo](https://github.com/microsoft/winget-pkgs/pull/399096).
+Once Microsoft's review merges it, this works:
 
 ```
-winget install ItsJazii.Pane
+winget install pane
 ```
+
+Pane keeps itself current after that either way — every install checks for
+signed updates and offers a one-click restart when a new version ships.
 
 ### Build from source
 
@@ -145,6 +148,8 @@ whatever the community asks for loudest.
   breakdown and a 30-day trend, priced with live model rates.
 - **Codex reset credits** — see each banked credit's exact expiry and
   redeem it with one click.
+- **Signed auto-updates** — checks GitHub releases on launch and every 4
+  hours; one click downloads, verifies, and restarts.
 - **Live tray numbers** — star up to two metrics per provider and they
   render as logo + percentage pairs directly in the tray.
 - **Customize** (☰) — reorder providers and metrics by drag, hide rows,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,20 @@
 # Roadmap — full Mac parity (and beyond)
 
-Feature audit vs robinebers/openusage @ 4d75562 (2026-07-06). Waves are
-ordered by dependency: the pace engine (Wave 1) feeds notifications
-(Wave 2); structured metric data from Wave 1 also unlocks Wave 4's
-toggles. Each wave ends with a shipped, installed build.
+**Status (v0.4.0, 2026-07-07): every wave below is shipped.** Pane has
+full feature parity with the macOS original (re-audited at its HEAD
+4d75562) plus 18 providers, signed auto-updates, and Codex reset-credit
+redemption. What comes next is demand-driven — open an issue for the
+provider or feature you're missing. Candidates on deck: Windsurf and
+JetBrains AI providers, a Re-detect Tools button, tray "Bars" icon
+style, code signing.
+
+---
+
+Original plan below, kept for history. Feature audit vs
+robinebers/openusage @ 4d75562 (2026-07-06). Waves are ordered by
+dependency: the pace engine (Wave 1) feeds notifications (Wave 2);
+structured metric data from Wave 1 also unlocks Wave 4's toggles. Each
+wave ends with a shipped, installed build.
 
 ## Wave 1 — Pace engine (the brain)
 - [x] Structured metric data: add `resets_at` (ms) + `period_ms` to Metric,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",


### PR DESCRIPTION
README winget section → real submission link + `winget install pane`; auto-updates in Features; CHANGELOG 0.4.0 gains the parity-polish items already shipping in the release binary; ROADMAP gets a shipped-status header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->