### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.4.1 — 2026-07-08
+
+First-run and Customize fixes from fresh-install testing.
+
+### Fixed
+- Fresh installs now start with just Claude + Codex enabled (their
+  "connect me" cards are the onboarding); a PC with zero detected AI
+  tools no longer enables all 18 providers.
+- Rapidly toggling several providers off kept only the last change —
+  toggles now apply instantly and save through a serial delta queue.
+- Disabled providers disappear immediately from the dashboard, the
+  Total Spend donut, and the tray strip (previously they lingered until
+  the next refresh).
+- Total Spend shows a quiet "No spend data yet" card on machines whose
+  CLIs haven't logged usage, instead of no card at all.
+
 ## 0.4.0 — 2026-07-07
 
 ### New

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.0"
+version = "0.4.1"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump + changelog for the first-run/Customize fix batch (PR #13). This is the release that tests the auto-updater in the wild — existing 0.4.0 installs should offer it as a banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->