### PR TITLE
Windows binary metadata + branded installer icon

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,6 +40,15 @@
     "active": true,
     "targets": "all",
     "createUpdaterArtifacts": true,
+    "publisher": "Pane",
+    "copyright": "© 2026 Pane contributors (MIT)",
+    "shortDescription": "AI usage limits in your system tray",
+    "longDescription": "Pane shows how much of your session and weekly limits each AI tool has left, directly from the Windows system tray.",
+    "windows": {
+      "nsis": {
+        "installerIcon": "icons/icon.ico"
+      }
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
From the laptop security-scan feedback: the exe's CompanyName was the Cargo author name, copyright was empty, and the setup exe wore NSIS's stock icon — all of which make unsigned binaries look sketchy to scanners and humans alike. Now: publisher/CompanyName **Pane**, copyright + descriptions set, installer icon = Pane icon. Verified on a fresh build:

```
CompanyName     : Pane
LegalCopyright  : © 2026 Pane contributors (MIT)
ProductVersion  : 0.4.1
```

The v0.4.1 release binary will be built from exactly this config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->