### PR TITLE
New-install defaults: 1-min refresh, pacing, alerts, dark, compact

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,21 +67,24 @@ fn config_with_defaults(mut cfg: Value) -> Value {
         cfg = json!({});
     }
     let obj = cfg.as_object_mut().unwrap();
-    obj.entry("refreshMinutes").or_insert(json!(5));
+    // Out-of-the-box experience: 1-min refresh, pacing always visible,
+    // all three quota alerts on, dark + compact. (Autostart defaults on
+    // in setup; tray icon defaults to Auto via pinned = null.)
+    obj.entry("refreshMinutes").or_insert(json!(1));
     obj.entry("disabled").or_insert(json!([]));
     obj.entry("pinned").or_insert(Value::Null);
     obj.entry("trayProviders").or_insert(json!([]));
-    obj.entry("pacingAlways").or_insert(json!(false));
-    obj.entry("notifyAlmostOut").or_insert(json!(false));
-    obj.entry("notifyCuttingClose").or_insert(json!(false));
-    obj.entry("notifyWillRunOut").or_insert(json!(false));
+    obj.entry("pacingAlways").or_insert(json!(true));
+    obj.entry("notifyAlmostOut").or_insert(json!(true));
+    obj.entry("notifyCuttingClose").or_insert(json!(true));
+    obj.entry("notifyWillRunOut").or_insert(json!(true));
     obj.entry("spendTab").or_insert(json!("today"));
     obj.entry("showUsed").or_insert(json!(false));
     obj.entry("resetExact").or_insert(json!(false));
     obj.entry("timeFormat").or_insert(json!("auto"));
     obj.entry("layout").or_insert(Value::Null);
-    obj.entry("appearance").or_insert(json!("system"));
-    obj.entry("density").or_insert(json!("regular"));
+    obj.entry("appearance").or_insert(json!("dark"));
+    obj.entry("density").or_insert(json!("compact"));
     obj.entry("shortcut").or_insert(json!(""));
     obj.entry("proxy").or_insert(json!({ "enabled": false, "url": "" }));
     obj.entry("showTotalSpend").or_insert(json!(true));


### PR DESCRIPTION
Fresh installs now start with the recommended configuration (screenshot-matched): refresh every **1 min**, **Start with Windows** on (already was), **Always show pacing** on, tray icon **Auto**, time format **Auto**, appearance **Dark**, **Compact layout** on, **Show Total Spend** on, no global shortcut, and **all three notification triggers** on.

Implementation is the `config_with_defaults` table, so it only fills keys that are absent — existing users' saved choices are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->