### PR TITLE
One-line PowerShell installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ broader AI-workflow companion from there.
 ### One-liner (PowerShell)
 
 ```powershell
-irm https://raw.githubusercontent.com/ItsJazii/pane/main/install.ps1 | iex
+irm https://pane.jazii.dev/install.ps1 | iex
 ```
 
 Downloads the latest release, installs per-user (no admin), and launches

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ broader AI-workflow companion from there.
 
 ## Install
 
+### One-liner (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/ItsJazii/pane/main/install.ps1 | iex
+```
+
+Downloads the latest release, installs per-user (no admin), and launches
+Pane. Read [install.ps1](install.ps1) first if you like — it's 40 lines.
+
 ### Installer (recommended)
 
 1. Grab **`Pane_x.y.z_x64-setup.exe`** from the

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,40 @@
+# Pane quick installer
+#
+#   irm https://raw.githubusercontent.com/ItsJazii/pane/main/install.ps1 | iex
+#
+# Downloads the latest signed release from GitHub, installs per-user
+# (no admin), and launches Pane. Works on Windows PowerShell 5.1 and pwsh.
+
+$ErrorActionPreference = 'Stop'
+
+# TLS 1.2 for Windows PowerShell 5.1 (pwsh already defaults to it).
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor 3072
+
+Write-Host ''
+Write-Host '  Pane - AI usage limits in your system tray' -ForegroundColor Cyan
+Write-Host ''
+
+Write-Host '> Finding the latest release...'
+$release = Invoke-RestMethod 'https://api.github.com/repos/ItsJazii/pane/releases/latest' `
+    -Headers @{ 'User-Agent' = 'pane-installer' } -UseBasicParsing
+$asset = $release.assets | Where-Object { $_.name -match '^Pane_.+_x64-setup\.exe$' } | Select-Object -First 1
+if (-not $asset) { throw 'No installer found in the latest release - please report this at https://github.com/ItsJazii/pane/issues' }
+
+$dest = Join-Path $env:TEMP $asset.name
+Write-Host ("> Downloading {0} ({1:N1} MB)..." -f $asset.name, ($asset.size / 1MB))
+Invoke-WebRequest $asset.browser_download_url -OutFile $dest -UseBasicParsing
+
+Write-Host '> Installing (per-user, no admin needed)...'
+Get-Process -Name pane -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+Start-Sleep -Milliseconds 500
+$proc = Start-Process -FilePath $dest -ArgumentList '/S' -Wait -PassThru
+if ($proc.ExitCode -ne 0) { throw "Installer exited with code $($proc.ExitCode)" }
+
+$exe = Join-Path $env:LOCALAPPDATA 'Pane\pane.exe'
+if (-not (Test-Path $exe)) { throw 'Install finished but pane.exe was not found - please report this at https://github.com/ItsJazii/pane/issues' }
+
+Start-Process $exe
+Write-Host ''
+Write-Host ("  Pane {0} installed - look for the icon in your system tray (next to the clock)." -f $release.tag_name) -ForegroundColor Green
+Write-Host '  It auto-detects the AI tools you already use; add API keys via the gear icon.'
+Write-Host ''

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 # Pane quick installer
 #
-#   irm https://raw.githubusercontent.com/ItsJazii/pane/main/install.ps1 | iex
+#   irm https://pane.jazii.dev/install.ps1 | iex
 #
 # Downloads the latest signed release from GitHub, installs per-user
 # (no admin), and launches Pane. Works on Windows PowerShell 5.1 and pwsh.


### PR DESCRIPTION
Adds `install.ps1` + a README "One-liner" install section:

```powershell
irm https://raw.githubusercontent.com/ItsJazii/pane/main/install.ps1 | iex
```

Same pattern Claude Code / Codex / Scoop use. Finds the latest GitHub release, downloads the installer, stops any running Pane, silent per-user install, relaunch. PS 5.1-compatible. Tested end-to-end against the live v0.4.1 release on a real machine (fresh download → install → app running → API answering).

Coexists with winget permanently once #399096 merges — one-liner for README/site visitors, winget for catalog users, plain download for everyone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->