### PR TITLE
Rotate updater signing key to passphrase-protected key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm run tauri build
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
       - name: Generate latest.json (with sha256 — install.ps1 requires it)
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   is an opt-in origin allowlist, not a permissive default.
 - Release binaries are now built and published by GitHub Actions from the
   pushed tag (public build logs), instead of on the maintainer's machine.
+- The updater signing key was rotated to a passphrase-protected key
+  (2026-07-08). Installs of 0.4.1 and earlier trust the old public key, so
+  their auto-updater will decline the first release signed with the new
+  key — reinstall once via `irm https://pane.jazii.dev/install.ps1 | iex`
+  (or the release installer) and updates resume normally.
 
 ### Added
 - SECURITY.md (private vulnerability reporting), docs/privacy.md (every

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,10 +33,10 @@ All of this is auditable in the source — links go to the exact code.
   `Access-Control-Allow-Origin` header — so web pages you visit cannot
   read it from a browser ([`src-tauri/src/httpapi.rs`](src-tauri/src/httpapi.rs)).
 - **Updates are cryptographically verified.** The auto-updater accepts
-  only releases signed by the project's minisign key (held offline); the
-  public key is baked into the app. The install script verifies the
-  installer's SHA-256 against the release manifest and refuses to run on
-  mismatch ([`install.ps1`](install.ps1)).
+  only releases signed by the project's minisign key — passphrase-protected,
+  master copy held offline; the public key is baked into the app. The
+  install script verifies the installer's SHA-256 against the release
+  manifest and refuses to run on mismatch ([`install.ps1`](install.ps1)).
 - **Links are restricted.** The app can only open `http(s)://` URLs in
   your browser — nothing that could launch a program.
 - **API keys you paste** are stored in `%APPDATA%\Pane` on your PC,
@@ -52,12 +52,6 @@ All of this is auditable in the source — links go to the exact code.
   see [.github/workflows/release.yml](.github/workflows/release.yml);
   every release links public build logs proving the binary comes from
   the tagged source.
-- The updater signing key currently has **no passphrase**. In CI this is
-  not the weakness it sounds like — a passphrase would sit in the same
-  GitHub secret store as the key, so anything that leaks one leaks both.
-  It does matter for the offline master copy, and rotating to a
-  passphrase-protected key is planned while the install base is still
-  small enough to make rotation cheap.
 - Pane refreshes OAuth tokens and writes them back to the CLIs' own
   credential files (keeping your CLIs signed in). This means Pane has the
   same access to those accounts as the CLIs themselves — that's inherent

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,7 +33,7 @@
   "plugins": {
     "updater": {
       "endpoints": ["https://github.com/ItsJazii/pane/releases/latest/download/latest.json"],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDcxNDFDOUE4REE0QjI1RUMKUldUc0pVdmFxTWxCY1RwQmdpNXlKNFNrbmpDbDB5REFDSVlQSFNLSkJSbEpaUXZKQ2tSblZrSVcK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDhDRUI5RUYzRkVBMzlCQ0QKUldUTm02UCs4NTdyalB4dHhyci8wb2dzb1FUQzJpaCt1VWc5dDJCaGpoWlNMTlNlWTF3Z0F4NEEK"
     }
   },
   "bundle": {


### PR DESCRIPTION
Completes the key rotation approved during #19 review — the commit was pushed a few minutes after #19 merged, so it needs its own PR.

**What changed**
- New minisign public key in `tauri.conf.json` (private key is passphrase-protected; verified it refuses to sign without the passphrase and signs with it).
- `release.yml` now reads `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` from the repo secret instead of passing an empty string. Both secrets are already rotated on the repo.
- SECURITY.md: the passphrase-less-key limitation is replaced by the stronger property statement.
- CHANGELOG: documents that installs ≤ 0.4.1 trust the old key and need a one-time reinstall at the next release.

**Why merge promptly:** the repo secrets already hold the new key, so main is in a half-rotated state — a tag pushed before this merges would fail to sign in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->