### PR TITLE
Security hardening: strict CSP, minimal capabilities, Rust-side input validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@
   their auto-updater will decline the first release signed with the new
   key — reinstall once via `irm https://pane.jazii.dev/install.ps1 | iex`
   (or the release installer) and updates resume normally.
+- **Webview hardening pass** (from a community security review): a strict
+  Content-Security-Policy replaces the previous `csp: null`; the Tauri
+  capability set is trimmed to core IPC only (the UI never used the
+  opener/updater/process plugin APIs); `withGlobalTauri` is off; the
+  pinned-metric dropdown is built via DOM instead of HTML strings.
+- **Rust-side input validation:** `set_config` only accepts known config
+  keys; tray-strip updates only accept known provider ids (also fixes
+  unstarred tray icons of newer providers not being removed); pricing
+  supplement alias rules are size- and count-capped.
+- **Credential safety:** CLI credential files are copied to `*.pane-bak`
+  before Pane writes a refreshed token back.
 
 ### Added
 - SECURITY.md (private vulnerability reporting), docs/privacy.md (every

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,16 @@ All of this is auditable in the source — links go to the exact code.
   manifest and refuses to run on mismatch ([`install.ps1`](install.ps1)).
 - **Links are restricted.** The app can only open `http(s)://` URLs in
   your browser — nothing that could launch a program.
+- **The webview is locked down.** A strict Content-Security-Policy (no
+  remote scripts, no eval, no frames) plus a minimal Tauri capability set
+  — the UI can reach only Pane's own commands, no plugin APIs
+  ([`src-tauri/tauri.conf.json`](src-tauri/tauri.conf.json),
+  [`src-tauri/capabilities/default.json`](src-tauri/capabilities/default.json)).
+- **Config writes are schema-bound.** The UI can only write known config
+  keys; anything else is dropped and logged.
+- **Credential files are backed up before write.** When Pane writes a
+  refreshed OAuth token back to a CLI's credential file, it first copies
+  the original to `*.pane-bak` — a bad write can never cost you a login.
 - **API keys you paste** are stored in `%APPDATA%\Pane` on your PC,
   readable only by your Windows user, and sent only to their own vendor.
 
@@ -56,6 +66,17 @@ All of this is auditable in the source — links go to the exact code.
   credential files (keeping your CLIs signed in). This means Pane has the
   same access to those accounts as the CLIs themselves — that's inherent
   to what the app does.
+- The install script's SHA-256 check verifies the download against
+  `latest.json` **from the same GitHub release** — it defends against
+  corrupted or swapped downloads, not against a fully compromised release
+  (an attacker who can replace the installer can replace the manifest,
+  and the script itself, too). The cryptographic guarantee is the
+  auto-updater's minisign verification once installed; the first install
+  ultimately trusts GitHub.
+- Model prices (LiteLLM, models.dev, the OpenUsage supplement) are
+  fetched without signatures — tampered pricing data could at worst show
+  wrong *display* dollars. Inputs are size-capped and never touch
+  credentials or spend logs.
 
 ## Supported versions
 

--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -39,5 +39,11 @@ Wire format (compatible with the macOS OpenUsage API):
   read your usage), Pane sends no CORS headers — so browsers block web
   pages from reading this API. PowerShell, curl, Rainmeter, and native
   apps are unaffected; CORS only constrains browsers.
+- **No authentication.** Any program running as your Windows user can
+  read this API — that is what makes zero-config widgets and scripts
+  possible, and it is a deliberate trade-off. What such a program gets is
+  usage percentages and reset times; your credentials are never served.
+  (A local process that could steal anything meaningful could also read
+  the CLIs' credential files directly — the API adds no new exposure.)
 - If port 6736 is already taken, the API is silently unavailable for that
   session; everything else works normally.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,12 +1,9 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main window",
+  "description": "Capability for the main window. Only core IPC: the frontend talks to Rust exclusively through app commands (open_link, install_update, ...), so no plugin surface is exposed to the webview.",
   "windows": ["main"],
   "permissions": [
-    "core:default",
-    "opener:default",
-    "updater:default",
-    "process:default"
+    "core:default"
   ]
 }

--- a/src-tauri/src/httpapi.rs
+++ b/src-tauri/src/httpapi.rs
@@ -69,7 +69,6 @@ fn iso8601(epoch_ms: i64) -> String {
 fn route(method: &tiny_http::Method, url: &str) -> (u16, String) {
     let path = url.split('?').next().unwrap_or(url);
     match method {
-        tiny_http::Method::Options => (204, String::new()),
         tiny_http::Method::Get => {
             if path == "/v1/usage" {
                 let body = latest()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,12 +97,41 @@ fn get_config() -> Value {
     config_with_defaults(load_config())
 }
 
+/// Every key config.json may hold — the same set config_with_defaults seeds.
+/// set_config drops anything else so a compromised frontend can't stash
+/// arbitrary data in the config file.
+const CONFIG_KEYS: &[&str] = &[
+    "refreshMinutes",
+    "disabled",
+    "pinned",
+    "trayProviders",
+    "pacingAlways",
+    "notifyAlmostOut",
+    "notifyCuttingClose",
+    "notifyWillRunOut",
+    "spendTab",
+    "showUsed",
+    "resetExact",
+    "timeFormat",
+    "layout",
+    "appearance",
+    "density",
+    "shortcut",
+    "proxy",
+    "showTotalSpend",
+    "welcomeDismissed",
+];
+
 #[tauri::command]
 fn set_config(patch: Value) -> Result<Value, String> {
     let mut cfg = config_with_defaults(load_config());
     if let (Some(target), Some(source)) = (cfg.as_object_mut(), patch.as_object()) {
         for (k, v) in source {
-            target.insert(k.clone(), v.clone());
+            if CONFIG_KEYS.contains(&k.as_str()) {
+                target.insert(k.clone(), v.clone());
+            } else {
+                eprintln!("[pane] set_config: ignoring unknown key '{k}'");
+            }
         }
     }
     let dir = providers::config_dir();
@@ -320,9 +349,29 @@ struct StripEntry {
     tooltip: String,
 }
 
-const STRIP_PROVIDER_IDS: [&str; 10] = [
-    "claude", "codex", "cursor", "opencode", "copilot", "grok", "devin", "openrouter", "zai",
+/// Every provider id that may appear in the tray strip. Doubles as the
+/// allowlist for update_tray_strip: ids from the frontend are validated
+/// against this before being spliced into tray icon ids, and stale strip
+/// icons are removed for exactly this set.
+const STRIP_PROVIDER_IDS: [&str; 18] = [
+    "claude",
+    "codex",
+    "cursor",
+    "opencode",
+    "copilot",
+    "grok",
+    "devin",
+    "minimax",
+    "openrouter",
+    "zai",
     "antigravity",
+    "deepseek",
+    "moonshot",
+    "elevenlabs",
+    "ollama",
+    "codebuff",
+    "kilo",
+    "kiro",
 ];
 
 #[tauri::command]
@@ -338,6 +387,10 @@ fn update_tray_strip(app: tauri::AppHandle, entries: Vec<StripEntry>) -> Result<
         }
 
         for entry in &entries {
+            // Only known provider ids may reach the tray icon namespace.
+            if !STRIP_PROVIDER_IDS.contains(&entry.id.as_str()) {
+                continue;
+            }
             if entry.logo.len() != 32 * 32 * 4 {
                 continue;
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,6 +101,10 @@ fn get_config() -> Value {
 /// set_config drops anything else so a compromised frontend can't stash
 /// arbitrary data in the config file.
 const CONFIG_KEYS: &[&str] = &[
+    // Not seeded by config_with_defaults (the autostart plugin is the
+    // source of truth at runtime) but persisted here so setup() can apply
+    // the user's choice on launch.
+    "autostart",
     "refreshMinutes",
     "disabled",
     "pinned",

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -148,15 +148,26 @@ fn apply_supplement(store: &mut Store, doc: &Value) {
             }
         }
     }
+    // The supplement is fetched from a third-party URL, so cap what it can
+    // feed us: at most 64 alias rules of at most 256 chars each, compiled
+    // with a bounded size. (Rust's regex engine is linear-time by design,
+    // so ReDoS-style backtracking blowups aren't possible; the caps bound
+    // memory and compile cost.)
     if let Some(rules) = doc.get("alias_rules").and_then(Value::as_array) {
-        for rule in rules {
+        for rule in rules.iter().take(64) {
             let (Some(pattern), Some(canonical)) = (
                 rule.get("pattern").and_then(Value::as_str),
                 rule.get("canonical").and_then(Value::as_str),
             ) else {
                 continue;
             };
-            if let Ok(re) = regex::Regex::new(pattern) {
+            if pattern.len() > 256 || canonical.len() > 128 {
+                continue;
+            }
+            if let Ok(re) = regex::RegexBuilder::new(pattern)
+                .size_limit(1 << 20)
+                .build()
+            {
                 store.alias_rules.push((re, canonical.to_string()));
             }
         }

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -95,6 +95,9 @@ async fn fetch() -> Result<Snapshot, String> {
             entry["accessToken"] = Value::from(new_access);
             entry["refreshToken"] = Value::from(new_refresh);
             entry["expiresAt"] = Value::from(now_ms + expires_in * 1000);
+            // Keep a copy of the CLI's own file before touching it, so a bad
+            // write can never cost the user their login.
+            let _ = std::fs::copy(&path, path.with_extension("json.pane-bak"));
             let tmp = path.with_extension("json.tmp");
             std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
                 .and_then(|_| std::fs::rename(&tmp, &path))

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -125,6 +125,9 @@ async fn load_access() -> Result<Access, String> {
                 t["id_token"] = Value::from(i);
             }
             doc["last_refresh"] = Value::from(Utc::now().to_rfc3339());
+            // Keep a copy of the CLI's own file before touching it, so a bad
+            // write can never cost the user their login.
+            let _ = std::fs::copy(&path, path.with_extension("json.pane-bak"));
             let tmp = path.with_extension("json.tmp");
             std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
                 .and_then(|_| std::fs::rename(&tmp, &path))

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -111,6 +111,9 @@ async fn fetch() -> Result<Snapshot, String> {
                 e["refresh_token"] = Value::from(r);
             }
             e["expires_at"] = Value::from((Utc::now() + Duration::seconds(expires_in)).to_rfc3339());
+            // Keep a copy of the CLI's own file before touching it, so a bad
+            // write can never cost the user their login.
+            let _ = std::fs::copy(&path, path.with_extension("json.pane-bak"));
             let tmp = path.with_extension("json.tmp");
             std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
                 .and_then(|_| std::fs::rename(&tmp, &path))

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
     "frontendDist": "../dist"
   },
   "app": {
-    "withGlobalTauri": true,
+    "withGlobalTauri": false,
     "windows": [
       {
         "label": "main",
@@ -27,7 +27,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src ipc: http://ipc.localhost; object-src 'none'; base-uri 'none'; form-action 'none'; frame-src 'none'"
     }
   },
   "plugins": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1927,17 +1927,15 @@ async function saveApiKey(provider: string): Promise<void> {
 function populatePinnedOptions(): void {
   const select = document.querySelector<HTMLSelectElement>("#pinned")!;
   const current = config.pinned ? `${config.pinned.provider}::${config.pinned.label}` : "";
-  const options = ['<option value="">Auto (first live metric)</option>'];
+  select.replaceChildren(new Option("Auto (first live metric)", ""));
   for (const s of lastSnapshots) {
     if (s.status !== "ok") continue;
     for (const m of s.metrics) {
       if (m.kind !== "progress") continue;
       const value = `${s.id}::${m.label}`;
-      const selected = value === current ? " selected" : "";
-      options.push(`<option value="${value}"${selected}>${escapeHtml(`${s.name} — ${m.label}`)}</option>`);
+      select.add(new Option(`${s.name} — ${m.label}`, value, false, value === current));
     }
   }
-  select.innerHTML = options.join("");
 }
 
 async function initSettings(): Promise<void> {


### PR DESCRIPTION
Full remediation of a community security review (Codex CLI + Devin, 13 findings). Every finding is either fixed in code or — where a code "fix" would be security theater — documented honestly.

## Webview lockdown
- **Strict CSP replaces `csp: null`** (the review's P0): scripts only from the app bundle, no inline script, no eval, no frames, no remote origins. Any future HTML injection is inert instead of arbitrary-code-with-IPC-access.
- **Capabilities trimmed to `core:default`** — the UI calls only Pane's own Rust commands, never plugin APIs, so the opener/updater/process grants were pure attack surface. Removed. `withGlobalTauri` off (all module imports).
- **Pinned-metric dropdown built via DOM** (`new Option`) instead of string HTML — closes the one attribute-context injection path found for vendor-supplied metric labels. Audited every other interpolation: escaped or compile-time literal.

## Rust-side input validation
- `set_config` accepts only the 19 known config keys; unknown keys are dropped and logged.
- `update_tray_strip` validates provider ids against the known list before splicing them into tray icon ids. **Also fixes a real bug:** the removal list still had only the original 10 providers, so newer providers' starred tray icons could never be removed.
- Pricing supplement (third-party JSON): alias rules capped at 64 rules / 256-char patterns / bounded regex compile. Not hash-pinned — prices must keep updating, Rust's regex engine is linear-time (no ReDoS), and the data is display-only.

## Credential safety
- Claude/Codex/Grok credential files are copied to `*.pane-bak` before Pane writes a refreshed token back — a bad write can no longer cost a login.

## Honesty items (documented, deliberately not "fixed")
- install.ps1's SHA-256 check defends against corrupted/swapped downloads, **not** a compromised release — the manifest and the script itself come from the same origin. Stated plainly in SECURITY.md; the cryptographic guarantee remains the minisign-verified updater.
- The local HTTP API stays unauthenticated by design (usage numbers only, never credentials; zero-config widgets are the point). Trade-off now documented in docs/local-http-api.md. Pointless OPTIONS no-op removed.

## Verification
- `tsc --noEmit` and `cargo check` clean; signed release build succeeds.
- Built binary installed and smoke-tested: popover renders fully under the new CSP (donut, SVG icons, inline-style pace bars — exactly the paths a strict CSP could break), local API serving all enabled providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->