### PR TITLE
Release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.4.2 — 2026-07-08
+
+**⚠ Installs of 0.4.1 and earlier: this release is signed with a new
+key, so the in-app updater will decline it. Reinstall once via
+`irm https://pane.jazii.dev/install.ps1 | iex` — updates then resume
+normally.**
 
 ### Changed (security)
 - **Breaking for browser-page consumers:** the local HTTP API no longer

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.1"
+version = "0.4.2"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump + changelog date for v0.4.2. When this merges, tagging `v0.4.2` triggers the CI release pipeline (first CI-built, new-key-signed release).

Highlights: full security-hardening pass (13 community-review findings), CORS lockdown, CI-built releases, key rotation, pixel-true share cards, transparency docs.

**Note:** existing 0.4.x installs will decline this release's signature (new key) — the changelog leads with the one-time `irm` reinstall instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->