### PR TITLE
Release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.4.3 — 2026-07-08
+
+### New
+- **Pane's new logo** 🎯 — the ring, everywhere: installer, app and
+  taskbar icons, tray, popover sidebar, and share-card footers.
+- **Update checks on every open** — the footer version stamp re-checks
+  each time you open Pane and becomes a blue **⬆ Update** button when a
+  new release is out; one click installs and restarts. (Replaces the
+  floating update banner.)
+- Party mode is now a triple-click on the sidebar logo away. 🎉
+
+### Fixed
+- Tray strip pairs now render logo-then-numbers, left to right, like
+  the macOS original (Windows inserts new tray icons leftward).
+- The update flow can no longer freeze at "Installing…" if a release
+  disappears mid-install — it fails visibly with a retry button.
+
 ## 0.4.2 — 2026-07-08
 
 **⚠ Installs of 0.4.1 and earlier: this release is signed with a new

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.2"
+version = "0.4.3"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump + changelog for v0.4.3: new ring logo everywhere, update check on every popover open with the footer Update button, triple-click party mode, tray pair ordering, update-flow freeze fix.

Merge → I tag `v0.4.3` → CI builds, signs, and publishes. Existing 0.4.2 installs (with the footer feature) will offer the update via the blue pill; public 0.4.2 installs get it via the 4-hourly background banner check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->