### PR TITLE
Performance: skip hidden renders + Liquid glass effects toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,9 @@
             <label class="toggle"><input id="density" type="checkbox" /> Compact layout</label>
           </div>
           <div class="setting-row">
+            <label class="toggle" title="Turn off on slower PCs — replaces the glass refraction with a simple solid look"><input id="glass" type="checkbox" /> Liquid glass effects</label>
+          </div>
+          <div class="setting-row">
             <label class="toggle"><input id="show-total-spend" type="checkbox" /> Show Total Spend card</label>
           </div>
           <div class="setting-row">

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -85,6 +85,7 @@ fn config_with_defaults(mut cfg: Value) -> Value {
     obj.entry("layout").or_insert(Value::Null);
     obj.entry("appearance").or_insert(json!("dark"));
     obj.entry("density").or_insert(json!("compact"));
+    obj.entry("glassEffects").or_insert(json!(true));
     obj.entry("shortcut").or_insert(json!(""));
     obj.entry("proxy").or_insert(json!({ "enabled": false, "url": "" }));
     obj.entry("showTotalSpend").or_insert(json!(true));
@@ -120,6 +121,7 @@ const CONFIG_KEYS: &[&str] = &[
     "layout",
     "appearance",
     "density",
+    "glassEffects",
     "shortcut",
     "proxy",
     "showTotalSpend",

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,6 +127,7 @@ interface Config {
   layout: Layout | null;
   appearance: "system" | "light" | "dark";
   density: "regular" | "compact";
+  glassEffects: boolean;
   shortcut: string;
   proxy: { enabled: boolean; url: string };
   showTotalSpend: boolean;
@@ -246,6 +247,7 @@ let config: Config = {
   layout: null,
   appearance: "system",
   density: "regular",
+  glassEffects: true,
   shortcut: "",
   proxy: { enabled: false, url: "" },
   showTotalSpend: true,
@@ -1067,6 +1069,14 @@ function applyLens(el: HTMLElement | null, filterId: string, imgId: string): voi
   (el.style as unknown as Record<string, string>).webkitBackdropFilter = f;
 }
 
+/// "Liquid glass effects" off swaps the SDF refraction + backdrop blurs
+/// for flat surfaces (body.no-glass CSS overrides win over the inline
+/// styles applyLens sets). The expensive displacement filters then never
+/// run — the fix for laptops where the popover animates below 60 fps.
+function applyGlass(): void {
+  document.body.classList.toggle("no-glass", config.glassEffects === false);
+}
+
 function initLiquidLens(): void {
   const surfaces: [string, string, HTMLElement | null][] = [
     ["lens-side", "lens-map-side", document.querySelector(".sidebar")],
@@ -1524,6 +1534,21 @@ function showModelTip(row: HTMLElement): void {
 // Refresh + tray strip
 // ---------------------------------------------------------------------------
 
+/// Background refreshes must not pay DOM costs nobody can see: while the
+/// popover is hidden (99% of the time), rendering is deferred to the next
+/// open instead of rebuilding a filter-heavy DOM every refresh interval.
+let pendingRender = false;
+
+function renderIfVisible(): void {
+  if (document.hidden) {
+    pendingRender = true;
+    return;
+  }
+  pendingRender = false;
+  renderAll();
+  populatePinnedOptions();
+}
+
 async function refresh(force = false): Promise<void> {
   if (refreshing) return;
   if (!force && Date.now() - lastFetch < STALE_MS) return;
@@ -1593,9 +1618,8 @@ async function refresh(force = false): Promise<void> {
     if (!lastLayoutSnapshot && config.layout) {
       lastLayoutSnapshot = JSON.stringify(config.layout);
     }
-    renderAll();
-    if (firstData && !customizeOpen) playReveal();
-    populatePinnedOptions();
+    renderIfVisible();
+    if (firstData && !customizeOpen && !document.hidden) playReveal();
     void updateTrayStrip();
     const time = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
     status.textContent = `Updated ${time}`;
@@ -1605,7 +1629,7 @@ async function refresh(force = false): Promise<void> {
   const spend = await spendPromise;
   spendLoaded = true;
   if (spend) lastSpend = spend;
-  if (!customizeOpen && lastSnapshots.length) renderAll();
+  if (!customizeOpen && lastSnapshots.length) renderIfVisible();
   refreshing = false;
 }
 
@@ -2016,6 +2040,13 @@ async function initSettings(): Promise<void> {
     void patchConfig({ density: density.checked ? "compact" : "regular" }).then(applyAppearance);
   });
 
+  const glass = document.querySelector<HTMLInputElement>("#glass")!;
+  glass.checked = config.glassEffects !== false;
+  glass.addEventListener("change", () => {
+    void patchConfig({ glassEffects: glass.checked }).then(applyGlass);
+  });
+  applyGlass();
+
   const shortcut = document.querySelector<HTMLInputElement>("#shortcut")!;
   shortcut.value = config.shortcut;
   shortcut.addEventListener("change", async () => {
@@ -2247,6 +2278,12 @@ window.addEventListener("DOMContentLoaded", () => {
     // feel like the app is stuck mid-page.
     setDrawer(false);
     setSettings(false);
+    // Replay any renders skipped while hidden, before the reveal plays.
+    if (pendingRender) {
+      pendingRender = false;
+      renderAll();
+      populatePinnedOptions();
+    }
     providersEl.scrollTop = 0;
     updateTrailActive();
     if (lastSnapshots.length && !customizeOpen) playReveal();

--- a/src/main.ts
+++ b/src/main.ts
@@ -2107,7 +2107,9 @@ window.addEventListener("DOMContentLoaded", () => {
   document.querySelector("#theme-btn")!.addEventListener("click", toggleTheme);
   setupTrailFisheye();
   setupTooltips();
-  window.setTimeout(initLiquidLens, 150);
+  // No lens init here: applyGlass() (via initSettings, after the saved
+  // config arrives) owns it — a fixed timer raced the config load and
+  // built the maps even for users who turned glass off.
   window.addEventListener("keydown", (e) => {
     konamiListen(e);
     if (e.ctrlKey && e.key.toLowerCase() === "z" && customizeOpen) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1075,9 +1075,16 @@ function applyLens(el: HTMLElement | null, filterId: string, imgId: string): voi
 /// run — the fix for laptops where the popover animates below 60 fps.
 function applyGlass(): void {
   document.body.classList.toggle("no-glass", config.glassEffects === false);
+  // Lens init is skipped entirely while glass is off — build the maps the
+  // first time the user turns it on.
+  if (config.glassEffects !== false && !lensReady) initLiquidLens();
 }
 
+let lensReady = false;
+
 function initLiquidLens(): void {
+  if (config.glassEffects === false || lensReady) return;
+  lensReady = true;
   const surfaces: [string, string, HTMLElement | null][] = [
     ["lens-side", "lens-map-side", document.querySelector(".sidebar")],
     ["lens-footer", "lens-map-footer", document.querySelector(".main-col footer")],
@@ -2294,7 +2301,9 @@ window.addEventListener("DOMContentLoaded", () => {
     void refresh(true);
   });
 
+  // Countdown texts ("Resets in 3h 41m") tick every 30 s — but only for
+  // eyes that can see them; hidden ticks fold into the deferred render.
   setInterval(() => {
-    if (lastSnapshots.length && !customizeOpen) renderAll();
+    if (lastSnapshots.length && !customizeOpen) renderIfVisible();
   }, 30_000);
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -1647,3 +1647,23 @@ body.party .trail-tick.active {
   opacity: 0.7;
   cursor: wait;
 }
+
+/* ---------------------------------------------------------------------------
+   Reduced effects ("Liquid glass effects" off): flat, opaque surfaces and no
+   displacement/blur filters. !important beats the inline backdrop-filter
+   applyLens() sets, so toggling needs no JS style cleanup. The win is real
+   on iGPU laptops — the SDF lens runs 9 displacement passes per paint.
+--------------------------------------------------------------------------- */
+body.no-glass .sidebar,
+body.no-glass .main-col footer,
+body.no-glass .glass-bar,
+body.no-glass .cust-dock {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+body.no-glass .sidebar,
+body.no-glass .main-col footer,
+body.no-glass .glass-bar,
+body.no-glass .cust-dock {
+  background: var(--background) !important;
+}


### PR DESCRIPTION
The "no lag at all" pass, from a measured audit (the spend engine was already well-cached; these were the two real costs):

## Skip invisible work
Every refresh (default: every minute) rebuilt the entire popover DOM via `innerHTML` — even while the popover was hidden in the tray, which is ~99% of the app's life. Background refreshes now update data + tray strip only; the DOM render is deferred to the next popover open via a dirty flag, replayed before the reveal plays. No visible change, permanent idle-CPU savings.

## Let weak hardware opt out of expensive beauty
The liquid-glass lens runs 9 displacement passes + blurs per paint — the likely cause of the laptop lag from fresh-install QA. New **Settings → General → "Liquid glass effects"** toggle (default **on**, nothing changes unless chosen): off swaps the SDF refraction and backdrop blurs for flat opaque surfaces via `body.no-glass` CSS overrides. `!important` beats the inline styles `applyLens()` sets, so toggling needs no JS style cleanup. New `glassEffects` config key (defaults + allowlist).

## Verification
Built, installed, and tested live: toggle flips the chrome flat/glass instantly, popover renders correctly on open after background refreshes, all providers flowing (user-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->