### PR TITLE
Release 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.4 — 2026-07-08
+
+### Performance
+- Background refreshes no longer rebuild the popover interface while
+  it's hidden in the tray (~99% of the time) — rendering now happens
+  once, at the moment you open Pane. Same for the 30-second countdown
+  ticks. Less idle CPU, all day.
+- New **Settings → General → "Liquid glass effects"** toggle (on by
+  default). Turn it off on slower PCs: the glass refraction and blurs
+  become clean flat surfaces, and the expensive lens machinery never
+  even initializes — from the very first frame of a cold start.
+
 ## 0.4.3 — 2026-07-08
 
 ### New

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.3"
+version = "0.4.4"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump + changelog for v0.4.4: hidden-render skipping and the Liquid glass effects toggle (the performance pass, PR #28, three Devin findings folded in).

Merge → I tag `v0.4.4` → CI builds, signs, publishes. Existing 0.4.2/0.4.3 installs get offered the update via the footer's blue pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->