### PR TITLE
Cursor spend tiles: date-ranged export + hourly pricing retry for new models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Cursor spend tiles work again** — Cursor's usage-events export now
+  requires an explicit date range and token strategy; Pane sends both
+  (last 31 days), so Today / Yesterday / 30 Days dollars populate.
+- **New models price within the hour, not within the day** — when spend
+  events reference models the price catalog doesn't know yet (new Cursor
+  slugs ship often), Pane now rechecks the catalog hourly instead of
+  daily, and a catalog update re-prices already-scanned logs instead of
+  waiting for them to change on disk.
+
 ## 0.4.5 — 2026-07-09
 
 ### Fixed

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -60,6 +60,22 @@ fn store() -> &'static Mutex<Store> {
     S.get_or_init(Default::default)
 }
 
+/// Set when the spend engine met models no catalog prices — sources are
+/// then retried hourly instead of daily, so a newly shipped model (e.g. a
+/// fresh Cursor slug) prices as soon as the supplement learns it.
+static UNPRICED_HINT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+/// Bumped whenever a source ingests a new document; spend's per-file cache
+/// keys on it so already-parsed logs re-price under the new catalog.
+static GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+pub fn note_unpriced() {
+    UNPRICED_HINT.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn generation() -> u64 {
+    GENERATION.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 fn dir() -> PathBuf {
     providers::config_dir().join("pricing")
 }
@@ -223,11 +239,16 @@ pub fn ensure_fresh() {
 
     let mut state = load_state();
     let now = now_ms();
+    let refresh_ms = if UNPRICED_HINT.load(std::sync::atomic::Ordering::Relaxed) {
+        3_600_000 // unpriced models seen: look for catalog updates hourly
+    } else {
+        REFRESH_MS
+    };
     for (source, url) in SOURCES {
         let entry = state.get(source).cloned().unwrap_or_else(|| json!({}));
         let fetched_at = entry.get("fetchedAt").and_then(Value::as_i64).unwrap_or(0);
         let failed_at = entry.get("failedAt").and_then(Value::as_i64).unwrap_or(0);
-        let due = now - fetched_at > REFRESH_MS && now - failed_at > RETRY_MS;
+        let due = now - fetched_at > refresh_ms && now - failed_at > RETRY_MS;
         if !due {
             continue;
         }
@@ -266,6 +287,8 @@ pub fn ensure_fresh() {
                     let _ = std::fs::write(dir().join(format!("{source}.json")), &body);
                     ingest(&mut store().lock().unwrap(), source, &doc);
                     state[source] = json!({ "etag": new_etag, "fetchedAt": now, "failedAt": 0 });
+                    GENERATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    UNPRICED_HINT.store(false, std::sync::atomic::Ordering::Relaxed);
                     eprintln!("[pane] pricing: refreshed {source}");
                 }
                 Err(e) => {

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -123,9 +123,17 @@ pub async fn fetch_usage_csv() -> Option<String> {
     let user_id = sub.split('|').next_back().unwrap_or(&sub).to_string();
     let cookie = format!("WorkosCursorSessionToken={user_id}%3A%3A{token}");
 
+    // The export answers 200-with-empty unless it's given an explicit
+    // range; strategy=tokens yields the per-model token columns the spend
+    // parser prices (same query Cursor's dashboard sends).
+    let end = chrono::Utc::now().timestamp_millis();
+    let start = end - 31 * 24 * 3_600_000;
     let resp = http()
-        .get("https://cursor.com/api/dashboard/export-usage-events-csv")
+        .get(format!(
+            "https://cursor.com/api/dashboard/export-usage-events-csv?startDate={start}&endDate={end}&strategy=tokens"
+        ))
         .header("Cookie", &cookie)
+        .header("Accept", "text/csv")
         .send()
         .await
         .ok()?;

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -72,6 +72,9 @@ struct FileData {
 struct FileEntry {
     mtime: SystemTime,
     size: u64,
+    /// Pricing-catalog generation the file was priced under — a catalog
+    /// refresh re-prices even files that haven't changed on disk.
+    gen: u64,
     data: FileData,
 }
 
@@ -207,9 +210,10 @@ fn file_days(path: &Path, parse: &mut dyn FnMut(&str, &mut FileData)) -> FileDat
     let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
     let size = meta.len();
 
+    let gen = pricing::generation();
     if let Ok(map) = cache().lock() {
         if let Some(entry) = map.get(path) {
-            if entry.mtime == mtime && entry.size == size {
+            if entry.mtime == mtime && entry.size == size && entry.gen == gen {
                 return entry.data.clone();
             }
         }
@@ -223,7 +227,7 @@ fn file_days(path: &Path, parse: &mut dyn FnMut(&str, &mut FileData)) -> FileDat
     }
 
     if let Ok(mut map) = cache().lock() {
-        map.insert(path.to_path_buf(), FileEntry { mtime, size, data: data.clone() });
+        map.insert(path.to_path_buf(), FileEntry { mtime, size, gen, data: data.clone() });
     }
     data
 }
@@ -604,9 +608,18 @@ mod tests {
         eprintln!("cursor csv: {} bytes", csv.as_deref().map(str::len).unwrap_or(0));
         if let Some(c) = &csv {
             eprintln!("csv header: {}", c.lines().next().unwrap_or(""));
-            if let Some(row) = c.lines().nth(1) {
-                let date = super::split_csv_row(row).into_iter().next().unwrap_or_default();
-                eprintln!("csv first-row date cell: {date:?}");
+            for row in c.lines().skip(1).take(3) {
+                let cells = super::split_csv_row(row);
+                eprintln!(
+                    "row: date={:?} parsed={} model={:?} in={:?} out={:?} total={:?} cost={:?}",
+                    cells.first(),
+                    cells.first().map(|d| super::parse_csv_date(d).is_some()).unwrap_or(false),
+                    cells.get(4),
+                    cells.get(6),
+                    cells.get(9),
+                    cells.get(10),
+                    cells.get(11),
+                );
             }
         }
         for sp in super::collect(csv) {
@@ -644,6 +657,11 @@ pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
     let mut list = vec![claude(), codex(), grok(), opencode()];
     if let Some(csv) = cursor_csv {
         list.push(cursor_from_csv(&csv));
+    }
+    // Models nothing prices yet (new slugs ship often): flag the catalog
+    // to look for updates hourly instead of daily.
+    if list.iter().any(|sp| sp.unpriced > 0) {
+        pricing::note_unpriced();
     }
     list.into_iter().filter(ProviderSpend::has_data).collect()
 }


### PR DESCRIPTION
Follow-up to #30: the usage bars worked but the Today/Yesterday/30-Days spend tiles said "No data" with an unpriced warning. Two independent causes, both fixed:

1. **The export needs a range now.** Cursor's usage-events CSV answers 200-with-empty without explicit `startDate`/`endDate`; Pane now requests the last 31 days with `strategy=tokens` — the same query the Cursor dashboard sends.

2. **Brand-new model slugs were unpriceable for up to 24 h.** The rows bill as `Cost: Included`, so Pane prices tokens via the catalog — but the account's models (`grok-4.5-fast-high`, `grok-4.5-high`) were added to the shared pricing supplement *yesterday evening*, after our daily fetch. Now: unpriced events flip catalog rechecks to hourly, and each ingested catalog bumps a generation that invalidates the spend engine's per-file cache, so already-scanned logs re-price immediately (previously a cached file kept stale pricing until its mtime changed).

Also: the live probe test now prints per-row forensics (date parse, columns, cost cell), which is how this was diagnosed.

## Verification
Live on the affected account: was 18/18 events unpriced, $0.00 everywhere → now today $2.40 / 30d $9.91 / 0 unpriced, agreeing with Cursor's own $9.65 included-usage figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->