### PR TITLE
Docs: refresh README + ROADMAP, retake hero screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Silent install (for scripts): `Pane_x.y.z_x64-setup.exe /S`
 
 ### winget *(pending review)*
 
-Pane 0.4.0 is [submitted to the winget community repo](https://github.com/microsoft/winget-pkgs/pull/399096).
+Pane is [submitted to the winget community repo](https://github.com/microsoft/winget-pkgs/pull/399096).
 Once Microsoft's review merges it, this works:
 
 ```
@@ -114,9 +114,11 @@ reset window ("Almost out", "Will run out").
 **4. Counting the money.** Your CLIs already log every request locally.
 Pane scans those logs (Claude, Codex, Grok, OpenCode, Cursor CSV), prices
 each request with live per-model rates (LiteLLM / models.dev, refreshed
-daily), and draws the Today / Yesterday / 30-day donut with a per-model
-breakdown. On a flat-rate plan this shows what your usage *would* cost at
-API prices — the best ad for your subscription you'll ever see. Events for
+daily — hourly while unknown models are around, so brand-new models price
+within the hour), and draws the Today / Yesterday / 30-day donut with a
+per-model breakdown. Click the ring to flip between dollars and tokens.
+On a flat-rate plan this shows what your usage *would* cost at API
+prices — the best ad for your subscription you'll ever see. Events for
 models without a known price are excluded and flagged, never guessed.
 
 **5. Staying local.** All of the above happens on your machine. There is no
@@ -158,7 +160,9 @@ whatever the community asks for loudest.
 - **Pace projections** — colored bars and "will run out" warnings based on
   your burn rate within each reset window, plus optional Windows toasts.
 - **Local spend** — Today / Yesterday / 30 Days donut with per-model
-  breakdown and a 30-day trend, priced with live model rates.
+  breakdown and a 30-day trend, priced with live model rates. Hover a
+  slice and it pops out with its legend row; click the ring to flip
+  dollars ⇄ tokens.
 - **Codex reset credits** — see each banked credit's exact expiry and
   redeem it with one click.
 - **Signed auto-updates** — Pane checks for updates every time you open
@@ -167,13 +171,15 @@ whatever the community asks for loudest.
   verifies the signature, and restarts.
 - **Live tray numbers** — star up to two metrics per provider and they
   render as logo + percentage pairs directly in the tray.
-- **Customize** (☰) — reorder providers and metrics by drag, hide rows,
-  tuck rarely-needed ones behind an "On Demand" caret. Ctrl+Z undoes.
+- **Customize** — drag any card by its grip right in the popover to
+  reorder, or open the Customize screen (☰) to reorder metrics, hide
+  rows, and tuck rarely-needed ones behind an "On Demand" caret. Ctrl+Z
+  undoes.
 - **Liquid glass UI** — real SDF lens refraction on the auto-hiding
   sidebar and glass bars, magnetic minimap trail, circular day/night wipe.
-- **Share cards** — hover a card, click ⧉, and paste anywhere: a
-  pixel-true snapshot of the card exactly as it looks on screen, framed
-  with the Pane logo.
+- **Share cards** — hover a card, click ⧉, and paste anywhere: a clean
+  composition of the card (interactive chrome stripped, just the
+  numbers), framed with the Pane icon and tagline.
 - **Quick links** — Status / Dashboard shortcuts on every card.
 - **[Local HTTP API](docs/local-http-api.md)** — `GET
   http://127.0.0.1:6736/v1/usage` for scripts, Rainmeter widgets, stream

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,11 +1,16 @@
 # Roadmap — full Mac parity (and beyond)
 
-**Status (v0.4.0, 2026-07-07): every wave below is shipped.** Pane has
-full feature parity with the macOS original (re-audited at its HEAD
-4d75562) plus 18 providers, signed auto-updates, and Codex reset-credit
-redemption. What comes next is demand-driven — open an issue for the
-provider or feature you're missing. Candidates on deck: Windsurf and
-JetBrains AI providers, a Re-detect Tools button, tray "Bars" icon
+**Status (v0.4.6+, 2026-07-10): every wave below is shipped, and the
+post-launch releases keep going.** Pane has full feature parity with the
+macOS original plus 18 providers, signed auto-updates published by CI,
+Codex reset-credit redemption, update-check-on-open with a one-click
+footer button, live model pricing that re-prices within the hour when
+new models appear, modern Cursor plan support, and a Mac-parity design
+pass (inset card composition, wedge spend donut with dollars ⇄ tokens,
+in-popover drag reorder, curated share cards). What comes next is
+demand-driven — open an issue for the provider or feature you're
+missing. Candidates on deck: Windsurf and JetBrains AI providers,
+long-context pricing tiers, a Re-detect Tools button, tray "Bars" icon
 style, code signing.
 
 ---
@@ -55,7 +60,7 @@ wave ends with a shipped, installed build.
 - [x] Stars (≤2 per provider) drive the tray strip, replacing the plain
       trayProviders picker; strip follows customize order.
 - [x] Per-provider Reset and Reset All (with confirm).
-- [ ] Stretch: Ctrl+Z undo for customization steps. (deferred)
+- [x] Stretch: Ctrl+Z undo for customization steps.
 
 ## Wave 6 — Platform features
 - [x] Provider quick links (Status / Console / Dashboard buttons per card).
@@ -77,11 +82,11 @@ wave ends with a shipped, installed build.
 
 ## Wave 8 — Ship v0.2.0
 - [x] Version bump, changelog, rebuild installers, silent reinstall.
-- [ ] (Parked until user says go: GitHub release, auto-updater, winget.)
+- [x] GitHub release, auto-updater, winget submission (in review).
 
-All waves shipped 2026-07-07 as v0.2.0. Remaining backlog: Ctrl+Z undo in
-Customize, GitHub/winget publishing, OpenCode official balance API when it
-ships, Cursor server-side spend.
+All waves shipped 2026-07-07 as v0.2.0; public launch followed as v0.4.0.
+Remaining backlog: OpenCode official balance API when it ships,
+long-context pricing tiers.
 
 ## Deliberately not ported
 - Anonymous telemetry — ours stays zero-telemetry.


### PR DESCRIPTION
## What

Catches the docs up to everything shipped since launch:

**README**
- Spend section: mentions the hourly pricing-catalog recheck for unknown models (0.4.6) and the new dollars ⇄ tokens ring toggle.
- Features: donut hover pop + metric toggle, in-popover drag reorder by grip, share cards described as the curated composition they now are (was "pixel-true snapshot").
- winget note no longer hardcodes 0.4.0 — the pending community PR tracks the latest release.

**ROADMAP**
- Status header updated from "(v0.4.0, 2026-07-07)" to reflect the post-launch releases: CI-published signed updates, footer update button, hourly pricing, modern Cursor plans, and the Mac design-parity pass.
- Ctrl+Z undo and GitHub/winget publishing checked off (both shipped); backlog trimmed to what's genuinely left.

**Screenshots** *(follow-up commit on this branch)*
- `docs/screenshot.png` / `screenshot-light.png` retaken with the current design — inset card composition, wedge donut, new spend colors.

providers.md, privacy.md, and SECURITY.md were audited and are still accurate (Grok's local-log spend source was already documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->