### PR TITLE
Release 0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.4.7 — 2026-07-10
+
+### Added
+- **Devin spend** — the Devin CLI's local session store now feeds the
+  Total Spend donut, spend rows, per-model breakdown, and usage trend,
+  priced with the live catalog like the other CLIs. Cloud Devin
+  sessions bill in ACUs and keep no local logs, so only CLI usage
+  appears.
+- **Dollars ⇄ tokens** — click the Total Spend ring (or right-click)
+  to flip the donut, legend, and center total between money and raw
+  token counts; the choice persists.
+- **Reorder without leaving the popover** — every card grows a drag
+  grip in its header; drop it where you want and the order saves to
+  the same layout Customize edits.
+
+### Changed
+- **The popover looks like the Mac's now** — provider cards are a
+  clean header over an inset panel, the usage trend sits in a labeled
+  row, and the Total Spend ring is rebuilt from true wedge segments:
+  radial-cut ends with soft corners, hairline gaps, and tiny spenders
+  that stay thin slivers instead of swelling into dots. Hovering a
+  wedge (or its legend row) slides it outward and dims the rest.
+- **Spend colors** — Codex blue, Grok green, Devin sky blue, and
+  Cursor its brand black (flipped to white in dark mode so it stays
+  visible).
+- **Share cards** — the copied image is a curated composition: buttons,
+  links, and spend chrome stripped, the canvas hugs the content, and
+  the footer carries the app icon with the full tagline.
+
+### Fixed
+- **Grok spend works again** — the Grok CLI changed its log format and
+  the old scanner silently matched nothing; the new one reads token
+  counts from the CLI's turn events and attributes models per process,
+  like the Mac app.
+- **Cursor Max-mode models price correctly** — "-max" slugs bill
+  token-based at the base model's rates, so they now resolve through
+  the full pricing chain instead of landing in the unpriced bucket.
+- **Kilo fresh accounts** — a just-created account shows a friendly
+  "no credits yet" card instead of an error.
+
 ## 0.4.6 — 2026-07-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 ### Added
 - **Devin spend** — the Devin CLI's local session store now feeds the
   Total Spend donut, spend rows, per-model breakdown, and usage trend,
-  priced with the live catalog like the other CLIs. Cloud Devin
+  priced with the live catalog like the other CLIs. Windsurf-style
+  model names ("gpt-5-6-sol-max") are normalized so they price, and
+  the store is read through SQLite's backup API so numbers stay
+  correct while the Devin app is actively writing. Cloud Devin
   sessions bill in ACUs and keep no local logs, so only CLI usage
   appears.
 - **Dollars ⇄ tokens** — click the Total Spend ring (or right-click)
@@ -26,8 +29,13 @@
   Cursor its brand black (flipped to white in dark mode so it stays
   visible).
 - **Share cards** — the copied image is a curated composition: buttons,
-  links, and spend chrome stripped, the canvas hugs the content, and
-  the footer carries the app icon with the full tagline.
+  links, and spend chrome stripped, the canvas hugs the content, the
+  header aligns with the panel's text column, and the footer carries
+  the app icon with the full tagline.
+- **Unpriced usage keeps its tokens** — requests on models with no
+  public pricing now count their measured tokens in token totals and
+  the trend; dollars still refuse to guess, and the ⚠ (on the
+  provider's spend row only) explains it in plain words.
 
 ### Fixed
 - **Grok spend works again** — the Grok CLI changed its log format and

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.6"
+version = "0.4.7"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to 0.4.7 + changelog.

Ships everything merged since 0.4.6: Devin CLI spend (#40), the dollars ⇄ tokens donut toggle, in-popover drag reordering, the Mac-parity popover composition with the wedge Total Spend ring (#37), spend brand colors, curated share cards, the Grok spend scanner fix (#36), Cursor Max-mode pricing with the recursion cap (#35), and Kilo's fresh-account zero-state (#34).

After merge: `git tag v0.4.7 && git push origin v0.4.7` → CI builds, signs, and publishes with latest.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->