### PR TITLE
Devin spend: price dashed GPT slugs, snapshot the db safely

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1", features = ["macros", "process", "time"] }
 chrono = "0.4"
 base64 = "0.22"
 dirs = "6"
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.32", features = ["bundled", "backup"] }
 toml = "0.8"
 regex = "1"
 webview2-com = "0.38"

--- a/src-tauri/src/providers/devin.rs
+++ b/src-tauri/src/providers/devin.rs
@@ -203,29 +203,51 @@ pub fn collect_usage_events() -> Vec<UsageEvent> {
         }
     }
 
-    // Copy db + sidecars first — the CLI may hold the live files locked.
+    // Snapshot through SQLite's backup API rather than copying files: the
+    // Devin app writes new rows to the WAL continuously, and a raw copy of
+    // db + WAL taken at slightly different instants makes SQLite silently
+    // discard the WAL — recent sessions would just vanish from the totals.
     let tmp_base = std::env::temp_dir().join(format!("pane-devin-{}", std::process::id()));
     let tmp_db = tmp_base.with_extension("db");
-    if std::fs::copy(&db_path, &tmp_db).is_err() {
-        return Vec::new();
-    }
-    for suffix in ["db-wal", "db-shm"] {
-        let side = db_path.with_extension(suffix);
-        if side.exists() {
-            let _ = std::fs::copy(&side, tmp_base.with_extension(suffix));
-        }
-    }
-
-    let events = read_usage_events(&tmp_db).unwrap_or_default();
+    let events = snapshot_db(&db_path, &tmp_db).and_then(|()| read_usage_events(&tmp_db));
 
     for suffix in ["db", "db-wal", "db-shm"] {
         let _ = std::fs::remove_file(tmp_base.with_extension(suffix));
     }
 
-    if let Ok(mut cache) = CACHE.lock() {
-        *cache = Some((db_stamp, wal_stamp, events.clone()));
+    match events {
+        Ok(events) => {
+            if let Ok(mut cache) = CACHE.lock() {
+                *cache = Some((db_stamp, wal_stamp, events.clone()));
+            }
+            events
+        }
+        // Busy/locked db: keep showing the last good events instead of a
+        // sudden empty Devin row; the next refresh retries.
+        Err(_) => CACHE
+            .lock()
+            .ok()
+            .and_then(|c| c.as_ref().map(|(_, _, e)| e.clone()))
+            .unwrap_or_default(),
     }
-    events
+}
+
+/// Consistent point-in-time copy of the live db (reads through the WAL
+/// with proper locks, retrying briefly while the writer is busy).
+fn snapshot_db(src_path: &std::path::Path, dst_path: &std::path::Path) -> Result<(), String> {
+    let _ = std::fs::remove_file(dst_path);
+    let src = rusqlite::Connection::open_with_flags(
+        src_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .map_err(|e| format!("open live db: {e}"))?;
+    let mut dst =
+        rusqlite::Connection::open(dst_path).map_err(|e| format!("open snapshot: {e}"))?;
+    let backup = rusqlite::backup::Backup::new(&src, &mut dst)
+        .map_err(|e| format!("backup init: {e}"))?;
+    backup
+        .run_to_completion(256, std::time::Duration::from_millis(10), None)
+        .map_err(|e| format!("backup run: {e}"))
 }
 
 fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -588,12 +588,13 @@ fn devin_model(raw: &str) -> String {
     }
     if let Some(rest) = base.strip_prefix("gpt-") {
         let parts: Vec<&str> = rest.splitn(3, '-').collect();
-        if parts.len() >= 2
-            && !parts[0].is_empty()
-            && !parts[1].is_empty()
-            && parts[0].chars().all(|c| c.is_ascii_digit())
-            && parts[1].chars().all(|c| c.is_ascii_digit())
-        {
+        // Version components are 1–2 digits ("5-6" is 5.6); OpenAI's
+        // date-stamped snapshots ("4-0125-preview") use 4-digit segments
+        // and must pass through untouched.
+        let is_ver = |s: &str| {
+            !s.is_empty() && s.len() <= 2 && s.chars().all(|c| c.is_ascii_digit())
+        };
+        if parts.len() >= 2 && is_ver(parts[0]) && is_ver(parts[1]) {
             let tail = parts.get(2).map(|t| format!("-{t}")).unwrap_or_default();
             return format!("gpt-{}.{}{}", parts[0], parts[1], tail);
         }

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -547,25 +547,27 @@ fn devin() -> ProviderSpend {
             continue;
         }
         let model = devin_model(&ev.model);
-        match pricing::lookup(model) {
+        match pricing::lookup(&model) {
             Some(p) => {
                 let cost = (ev.input * p.input
                     + ev.cache_read * p.cache_read
                     + ev.cache_write * p.cache_write
                     + ev.output * p.output)
                     / 1e6;
-                add_event(&mut data, ts, model, cost, tokens);
+                add_event(&mut data, ts, &model, cost, tokens);
             }
-            None => note_unpriced(&mut data, model),
+            None => note_unpriced(&mut data, &model),
         }
     }
     build_spend("devin", "Devin", data)
 }
 
 /// Windsurf-style slugs append a reasoning effort ("claude-opus-4-8-medium")
-/// that no catalog knows; price and display the base model. A couple of
-/// slugs also spell the model differently than the catalogs do.
-fn devin_model(raw: &str) -> &str {
+/// that no catalog knows; price and display the base model. Some slugs also
+/// spell the model differently than the catalogs: version dots become
+/// dashes ("gpt-5-6-sol-max" is GPT-5.6 Sol Max) and Fable's parts are
+/// reordered.
+fn devin_model(raw: &str) -> String {
     let mut base = raw;
     for suffix in ["-low", "-medium", "-high", "-xhigh"] {
         if let Some(b) = raw.strip_suffix(suffix) {
@@ -573,10 +575,22 @@ fn devin_model(raw: &str) -> &str {
             break;
         }
     }
-    match base {
-        "claude-5-fable" => "claude-fable-5", // LiteLLM's slug order
-        b => b,
+    if base == "claude-5-fable" {
+        return "claude-fable-5".into(); // LiteLLM's slug order
     }
+    if let Some(rest) = base.strip_prefix("gpt-") {
+        let parts: Vec<&str> = rest.splitn(3, '-').collect();
+        if parts.len() >= 2
+            && !parts[0].is_empty()
+            && !parts[1].is_empty()
+            && parts[0].chars().all(|c| c.is_ascii_digit())
+            && parts[1].chars().all(|c| c.is_ascii_digit())
+        {
+            let tail = parts.get(2).map(|t| format!("-{t}")).unwrap_or_default();
+            return format!("gpt-{}.{}{}", parts[0], parts[1], tail);
+        }
+    }
+    base.to_string()
 }
 
 /// Cursor spend from the dashboard's usage-events CSV export (fetched by the

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -45,8 +45,11 @@ pub struct ProviderSpend {
     pub last30: Window,
     /// Tokens per day, oldest first — trend[29] is today.
     pub trend: Vec<f64>,
-    /// Events excluded because no catalog prices their model — counting
-    /// them at a guessed rate would fabricate dollars (Mac #853 semantics).
+    /// Events whose model no catalog prices. Their measured tokens still
+    /// count in token totals/trend, but no dollars are guessed for them
+    /// (a deliberate softening of the Mac's exclude-everything semantics:
+    /// tokens are facts, only prices are unknown), so dollar figures
+    /// under-report and the ⚠ says so.
     pub unpriced: u64,
     pub unpriced_models: Vec<String>,
 }
@@ -96,8 +99,13 @@ fn add_event(data: &mut FileData, ts: DateTime<Utc>, model: &str, cost: f64, tok
     entry.1 += tokens;
 }
 
-fn note_unpriced(data: &mut FileData, model: &str) {
+/// Tally an event no catalog can price: its tokens still count (they're
+/// measured, not guessed) at zero cost, so only the dollars under-report.
+fn note_unpriced(data: &mut FileData, ts: DateTime<Utc>, model: &str, tokens: f64) {
     *data.unpriced.entry(model.to_string()).or_insert(0) += 1;
+    if tokens > 0.0 {
+        add_event(data, ts, model, 0.0, tokens);
+    }
 }
 
 fn merge_data(target: &mut FileData, source: FileData) {
@@ -349,7 +357,7 @@ fn claude() -> ProviderSpend {
                         }
                         None => {
                             if tokens > 0.0 {
-                                note_unpriced(data, &model);
+                                note_unpriced(data, ts, &model, tokens);
                             }
                             return;
                         }
@@ -430,7 +438,7 @@ fn codex() -> ProviderSpend {
                 Some(r) => r,
                 None if lower.contains("gpt") || lower.contains("codex") => codex_price(&model),
                 None => {
-                    note_unpriced(data, &model);
+                    note_unpriced(data, ts, &model, tokens);
                     return;
                 }
             };
@@ -510,7 +518,7 @@ fn grok() -> ProviderSpend {
                     (i, o, i)
                 }
                 None => {
-                    note_unpriced(data, &model);
+                    note_unpriced(data, ts, &model, tokens);
                     return;
                 }
             };
@@ -556,7 +564,7 @@ fn devin() -> ProviderSpend {
                     / 1e6;
                 add_event(&mut data, ts, &model, cost, tokens);
             }
-            None => note_unpriced(&mut data, &model),
+            None => note_unpriced(&mut data, ts, &model, tokens),
         }
     }
     build_spend("devin", "Devin", data)
@@ -660,7 +668,7 @@ pub fn cursor_from_csv(csv: &str) -> ProviderSpend {
                         / 1e6;
                     add_event(&mut data, ts, &model, cost, tokens);
                 }
-                None => note_unpriced(&mut data, &model),
+                None => note_unpriced(&mut data, ts, &model, tokens),
             }
         }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -838,7 +838,7 @@ function legendHtml(entries: DonutEntry[]): string {
       (e) => `
         <div class="legend-row" data-pid="${e.s.id}">
           <span class="dot" style="background:${spendColor(e.s.id)}"></span>
-          <span class="legend-name">${escapeHtml(e.s.name)} ${unpricedWarn(e.s)}</span>
+          <span class="legend-name">${escapeHtml(e.s.name)}</span>
           <span class="legend-val">${fmtSpendVal(e.w)}</span>
         </div>`,
     )

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,9 @@ function unpricedWarn(sp: ProviderSpend | undefined): string {
   if (!sp || sp.unpriced <= 0) return "";
   const models = sp.unpriced_models.join(", ") || "unknown models";
   return `<span class="stale" title="${escapeHtml(
-    `${sp.unpriced} events have no known price (${models}) — tokens are counted, dollars under-report.`,
+    `${sp.unpriced} requests ran on models with no public pricing (${models}). ` +
+      `Their tokens are included, but they can't be turned into dollars — ` +
+      `so the real cost is a little higher than shown.`,
   )}">⚠</span>`;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,13 +87,13 @@ interface ProviderSpend {
   unpriced_models: string[];
 }
 
-/// ⚠ shown when events were excluded because no catalog prices the model —
-/// totals would otherwise silently under-report.
+/// ⚠ shown when some events have no known model price — their tokens are
+/// counted, but no dollars are guessed, so dollar totals under-report.
 function unpricedWarn(sp: ProviderSpend | undefined): string {
   if (!sp || sp.unpriced <= 0) return "";
   const models = sp.unpriced_models.join(", ") || "unknown models";
   return `<span class="stale" title="${escapeHtml(
-    `${sp.unpriced} events excluded — no price known for: ${models}. Totals may under-report.`,
+    `${sp.unpriced} events have no known price (${models}) — tokens are counted, dollars under-report.`,
   )}">⚠</span>`;
 }
 


### PR DESCRIPTION
## Symptoms (reported live)

Devin's spend showed ~700–800K tokens for today, then dropped to zero minutes later; the 30-day ⚠ listed `gpt-5-6-sol-max` among unpriced models; the warning copy read like a ledger; the ⚠ cluttered the Total Spend legend.

## What's in here

1. **Dashed version slugs price now.** The Devin CLI/desktop writes Windsurf-style slugs (`gpt-5-6-sol-max` = GPT-5.6 Sol Max) while catalogs spell `gpt-5.6-sol`. `devin_model()` converts 1–2 digit dash version segments to dots — 4-digit date-stamped snapshots (`gpt-4-0125-preview`) pass through untouched (review catch). Because the model is stored per session and updated in place, one unpriced slug used to retroactively exclude the whole session — that was the "vanish".
2. **Safe snapshots.** Raw-copying `sessions.db` + WAL at different instants makes SQLite silently discard the WAL (newest rows disappear). The reader now snapshots via SQLite's **backup API** (rusqlite gains the `backup` feature), retrying while the writer is busy; a failed read serves the last good events instead of an empty row. Cache keys on main db + WAL stamps (review catch from yesterday).
3. **Unpriced events keep their tokens.** Previously excluded from *everything* (Mac semantics) — but tokens are measured facts; only prices are unknown. All five scanners now record unpriced events at zero cost: token totals, trend, and breakdowns stay complete, dollar totals still never guess.
4. **Warning UX.** The ⚠ tooltip explains itself in plain words ("ran on models with no public pricing… real cost is a little higher than shown") and lives only on the provider's spend row — the Total Spend legend stays clean.
5. providers.md documents the sessions.db read (repo-rules catch).

## Verified

Live probe with the Devin desktop app actively writing (70 MB db, hot WAL):

```
devin: today=$48.79 30d=$87.99 tokens30=101457449 unpriced=25 ["adaptive", "swe-1-6-fast"]
```

The remaining 25 are genuinely rate-less (Windsurf's `adaptive` router + `swe-1-6-fast`) and age out of the window within days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)