### PR TITLE
Share cards: pad the header on the snapshot surface

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1728,9 +1728,10 @@ body.no-glass .cust-dock {
   padding: 16px 18px 16px;
 }
 /* The live popover keeps headers tight against transparent cards; on the
-   solid snapshot surface the name and mark need air from the corners. */
+   solid snapshot surface the header lines up with the panel's inner text
+   column (card 18px + head 16px = card 18px + panel 16px). */
 .snap-card .provider-head {
-  padding: 0 4px;
+  padding: 0 16px;
   margin-bottom: 12px;
 }
 .snap-card .card-panel {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1725,7 +1725,13 @@ body.no-glass .cust-dock {
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 16px;
-  padding: 10px 12px 12px;
+  padding: 16px 18px 16px;
+}
+/* The live popover keeps headers tight against transparent cards; on the
+   solid snapshot surface the name and mark need air from the corners. */
+.snap-card .provider-head {
+  padding: 0 4px;
+  margin-bottom: 12px;
 }
 .snap-card .card-panel {
   background: rgba(0, 0, 0, 0.22);


### PR DESCRIPTION
Share-card polish from live pastes:

1. **Padding** — the snapshot restores a solid rounded surface, but the live layout's near-zero header padding left the provider name and mark sitting on the corners. The snapshot card now pads 16/18px with a 12px gap before the panel.
2. **Alignment** — the header now shares its left/right edges with the panel's inner text column ("Claude" starts exactly above "Session", the mark flush with the right text edge) instead of hanging at the card's own padding.

Snapshot-only (`.snap-card` rules); the live popover is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)