### PR TITLE
Pricing: resolve -fast bases through the full chain

### DIFF
--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -344,10 +344,13 @@ fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
     if let Some(p) = s.litellm.get(&canonical) {
         return Some(*p);
     }
-    // Fast tier: base price × the supplement's multiplier (default 2).
+    // Fast tier: base price × the supplement's multiplier (default 2). The
+    // base runs through the whole chain — not a bare map lookup — so
+    // composed slugs like "gpt-5.6-sol-max-fast" reach the -max fallback
+    // and alias/fuzzy matching too.
     if let Some(base) = canonical.strip_suffix("-fast") {
-        if let Some(p) = s.litellm.get(base).or_else(|| s.supplement.get(base)) {
-            let m = s.fast_multipliers.get(base).copied().unwrap_or(2.0);
+        let m = s.fast_multipliers.get(base).copied().unwrap_or(2.0);
+        if let Some(p) = resolve(s, base, depth + 1) {
             return Some(Price {
                 input: p.input * m,
                 output: p.output * m,


### PR DESCRIPTION
## Why

Reported live: Cursor usage on `gpt-5.6-sol-max-fast` sat in the unpriced ⚠ bucket. The fast-tier branch strips `-fast` but then does a **bare map lookup** on the base — so `gpt-5.6-sol-max` missed (no catalog carries `-max` names) and the chain ended before the `-max` fallback could run.

## What

The `-fast` base now recurses through `resolve()` — aliases, exact maps, fuzzy LiteLLM, models.dev, and the `-max` strip all apply — with the fast multiplier applied on top and the existing depth cap guarding recursion. Side effect: `-fast` slugs whose base is only known via alias/fuzzy/models.dev price now too (previously only exact-map bases worked).

## Verified

Live probe: `cursor: today=$19.17 30d=$31.72 unpriced=0` (was `today=$0.02`, 7 events / 12.4M tokens unpriced) — the Max-fast requests were real dollars hiding in the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->