### PR TITLE
Give the Outdated tag a grace window

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -566,6 +566,11 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
             snap: providers::Snapshot,
         }
         const MAX_STALE_MS: i64 = 24 * 60 * 60 * 1000;
+        // One failed cycle isn't "Outdated": vendors hiccup routinely, and
+        // at short refresh intervals the tag was flashing on every blip.
+        // Data younger than the grace window serves silently; the tag (and
+        // the error on hover) appears once staleness is real.
+        const STALE_GRACE_MS: i64 = 3 * 60 * 1000;
 
         static LAST_OK: OnceLock<Mutex<HashMap<String, CachedSnap>>> = OnceLock::new();
         let cache_file = providers::config_dir().join("last_snapshots.json");
@@ -588,11 +593,14 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
                     dirty = true;
                 } else if s.status == "error" {
                     if let Some(previous) = map.get(&s.id) {
-                        if now_ms - previous.at <= MAX_STALE_MS {
+                        let age = now_ms - previous.at;
+                        if age <= MAX_STALE_MS {
                             let warning = s.error.clone();
                             *s = previous.snap.clone();
-                            s.stale = true;
-                            s.warning = warning;
+                            if age > STALE_GRACE_MS {
+                                s.stale = true;
+                                s.warning = warning;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Why

Reported live: cards flash "Outdated" often (Claude most of all) at a 1-minute refresh interval. The stale-cache fallback tagged data as outdated on the *first* failed cycle — but vendors hiccup routinely, and one blip means the data is exactly one minute old, which no one would call outdated.

## What

Last-good data younger than **3 minutes** now serves silently when a refresh fails; the amber tag (with the real error on hover) appears only once staleness crosses that line. The 24-hour maximum for serving cached data is unchanged, and genuinely persistent failures (outages, rate-limit benches) still surface exactly as before — just not one-minute blips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->