### PR TITLE
Pricing: full model-family surface — effort tiers, Ultra, consistent fast multipliers

### DIFF
--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -349,7 +349,22 @@ fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
     // composed slugs like "gpt-5.6-sol-max-fast" reach the -max fallback
     // and alias/fuzzy matching too.
     if let Some(base) = canonical.strip_suffix("-fast") {
-        let m = s.fast_multipliers.get(base).copied().unwrap_or(2.0);
+        // Multipliers are keyed by the plain model name; peel effort/mode
+        // tokens off composed bases ("gpt-5.6-sol-max" → "gpt-5.6-sol") so
+        // "sol-max-fast" gets sol's real multiplier, not the default.
+        let mut mkey = base;
+        let m = loop {
+            if let Some(m) = s.fast_multipliers.get(mkey) {
+                break *m;
+            }
+            match ["-xhigh", "-light", "-low", "-medium", "-high", "-max", "-ultra"]
+                .iter()
+                .find_map(|suf| mkey.strip_suffix(suf))
+            {
+                Some(next) => mkey = next,
+                None => break 2.0,
+            }
+        };
         if let Some(p) = resolve(s, base, depth + 1) {
             return Some(Price {
                 input: p.input * m,
@@ -410,6 +425,7 @@ mod tests {
             for suffix in [
                 "-light", "-low", "-medium", "-high", "-xhigh", "-max", "-ultra", "-fast",
                 "-max-xhigh", "-ultra-high", "-max-fast", "-fast-high",
+                "-light-fast", "-xhigh-fast", "-ultra-fast", "-max-fast-xhigh",
             ] {
                 matrix.push(format!("{base}{suffix}"));
             }

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -372,13 +372,19 @@ fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
     if let Some(p) = s.modelsdev.get(&canonical) {
         return Some(*p);
     }
-    // Cursor's Max-mode slugs ("gpt-5.6-sol-max") bill token-based at the
-    // base model's rates, and no catalog carries the -max name itself. Only
-    // when the whole chain above misses does the suffix get stripped and
-    // the base model resolved — a real -max entry in any source wins.
-    canonical
-        .strip_suffix("-max")
-        .and_then(|base| resolve(s, base, depth + 1))
+    // Slug tails no catalog carries under their own name, billed at the
+    // base model's per-token rates: reasoning-effort tiers (they change how
+    // many tokens burn, not the unit price) and Cursor's Max/Ultra modes
+    // (token-based at model rates). Only when the whole chain above misses
+    // does one trailing token get peeled and the rest rerun — compositions
+    // unwind right to left ("…-max-xhigh" → "…-max" → base), the depth cap
+    // bounds it, and a real entry for any tail in any source always wins.
+    for suffix in ["-xhigh", "-light", "-low", "-medium", "-high", "-max", "-ultra"] {
+        if let Some(base) = canonical.strip_suffix(suffix) {
+            return resolve(s, base, depth + 1);
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -389,14 +395,26 @@ mod tests {
     #[ignore]
     fn live_probe() {
         super::ensure_fresh();
-        for model in [
-            "claude-opus-4-8",
-            "gpt-5.1-codex-max-xhigh",
-            "composer-2.5",
-            "claude-4.5-haiku-thinking",
-            "gpt-5",
-            "some-unknown-model-xyz",
-        ] {
+        let mut matrix: Vec<String> = vec![
+            "claude-opus-4-8".into(),
+            "gpt-5.1-codex-max-xhigh".into(),
+            "composer-2.5".into(),
+            "claude-4.5-haiku-thinking".into(),
+            "gpt-5".into(),
+            "some-unknown-model-xyz".into(),
+        ];
+        // The full GPT-5.6 family surface Cursor/Devin can emit: every
+        // effort tier, Max/Ultra modes, fast tier, and their compositions.
+        for base in ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"] {
+            matrix.push(base.to_string());
+            for suffix in [
+                "-light", "-low", "-medium", "-high", "-xhigh", "-max", "-ultra", "-fast",
+                "-max-xhigh", "-ultra-high", "-max-fast", "-fast-high",
+            ] {
+                matrix.push(format!("{base}{suffix}"));
+            }
+        }
+        for model in &matrix {
             match super::lookup(model) {
                 Some(p) => eprintln!(
                     "{model}: in=${:.2} out=${:.2} cr=${:.3} cw=${:.2} (per 1M)",

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -577,7 +577,7 @@ fn devin() -> ProviderSpend {
 /// reordered.
 fn devin_model(raw: &str) -> String {
     let mut base = raw;
-    for suffix in ["-low", "-medium", "-high", "-xhigh"] {
+    for suffix in ["-xhigh", "-light", "-low", "-medium", "-high"] {
         if let Some(b) = raw.strip_suffix(suffix) {
             base = b;
             break;


### PR DESCRIPTION
## What

Two commits (the first was pushed to #46 moments after it merged, so it rides here):

1. **Effort tiers and Ultra mode price like Max** — the end-of-chain fallback peels one trailing token at a time from `-xhigh/-light/-low/-medium/-high/-max/-ultra` and reruns the chain (depth-capped). Effort tiers change how many tokens burn, not the unit price; Ultra bills token-based at model rates like Max; explicit catalog entries always win first. Devin's display normalizer learns `-light`.
2. **Composed fast slugs get the real multiplier** — multipliers are keyed by plain model names, so `gpt-5.6-sol-max-fast` looked up a multiplier for `gpt-5.6-sol-max`, missed, and fell to the ×2 default while `gpt-5.6-sol-fast` correctly got the supplement's ×2.5. The multiplier lookup now peels effort/mode tokens until it matches.

## Verified

The pricing live probe now walks a **51-slug matrix**: Luna/Terra/Sol × {light, low, medium, high, xhigh, max, ultra, fast, max-xhigh, ultra-high, max-fast, fast-high, light-fast, xhigh-fast, ultra-fast, max-fast-xhigh}. All 51 resolve; every non-fast variant at its base rates, every fast variant at the family's ×2.5 — e.g. the whole Sol block: $5/$30 base, $12.50/$75 fast, no exceptions. The `-fast` handling is generic, so the same guarantees hold for any provider's slugs (grok-4.5-fast-high etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->