### PR TITLE
Release 0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.4.8 — 2026-07-11
+
+### Fixed
+- **The whole model-family surface prices now** — reasoning-effort
+  tiers (light/low/medium/high/xhigh), Max **and Ultra** modes, the
+  fast tier, and any composition of them ("gpt-5.6-sol-max-fast",
+  "…-ultra-high", "…-max-fast-xhigh") resolve to the base model's
+  rates, with fast keeping its real per-family multiplier in every
+  composition. Previously composed slugs fell into the unpriced ⚠
+  bucket — on the test machine that was ~$19 of one day's Cursor
+  Max-fast usage hiding from the totals. Verified by a 51-slug
+  regression matrix across GPT-5.6 Luna/Terra/Sol; the handling is
+  generic, so other families (Grok fast tiers etc.) get the same
+  guarantees.
+- **"Outdated" stopped crying wolf** — a single failed refresh no
+  longer tags every card; data under three minutes old serves
+  silently, and the amber tag (with the real error on hover) appears
+  only when staleness is real. Persistent failures surface exactly as
+  before.
+
 ## 0.4.7 — 2026-07-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.7",
+  "version": "0.4.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.7"
+version = "0.4.8"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to 0.4.8 + changelog.

Ships tonight's fixes: the full model-family pricing surface (#46, #48 — effort tiers, Max/Ultra modes, chained fast resolution with consistent per-family multipliers, verified by the 51-slug matrix) and the Outdated grace window (#47).

After merge: `git tag v0.4.8 && git push origin v0.4.8` → CI builds, signs, publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->