### PR TITLE
Release 0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.4.9 — 2026-07-11
+
+### Added
+- **Cost/MTok** — the Total Spend ring's metric now cycles Cost →
+  Cost/MTok → Tokens on click (right-click cycles backward). The center
+  shows your true blended rate — total dollars over total megatokens —
+  and each legend row shows that provider's own $/MTok.
+- Cursor's spend rows say **"estimated"** — its usage export aggregates
+  requests, so per-request exactness isn't possible.
+- Reset countdowns inside a minute read **"Resets soon"** instead of a
+  dying timer.
+
+### Fixed
+- **Long-context requests price correctly** — models with 1M-token
+  context bill the *whole* request at a higher tier once the prompt
+  crosses 200k tokens; Pane now applies those tiers. Claude's 1-hour
+  cache writes bill at twice the input rate (they were priced as
+  ordinary writes before), and Claude fast-mode requests apply the
+  published fast multiplier. Spend histories reprice automatically —
+  expect Claude's 30-day figure to correct upward.
+- **Codex percentages show as reported** — the old "fresh window
+  reads 1%, call it 0" normalization masked real early usage and is
+  gone (the Mac dropped it too). "Not started" now keys on the window
+  still being full-length, and windows under 5% used never flash a
+  red pace projection off a floored reading.
+
 ## 0.4.8 — 2026-07-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.8",
+  "version": "0.4.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.8"
+version = "0.4.9"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to 0.4.9 + changelog.

Ships the upstream-parity batch: request-wide long-context pricing with 1h cache writes and the Claude fast flag (#50), Codex as-reported percentages with calm near-empty pacing and freshness-based "Not started" (#51), and the Cost/MTok metric + Cursor estimated tag + "Resets soon" (#52).

After merge: `git tag v0.4.9 && git push origin v0.4.9` → CI builds, signs, publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->