### PR TITLE
Honor Retry-After on Claude 429s

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -479,11 +479,28 @@ where
     if snap.status == "error" {
         let err = snap.error.clone().unwrap_or_default();
         let rate_limited = err.contains("429");
+        // A vendor-stated Retry-After wins over our fixed backoff — bench
+        // for exactly that long (capped at an hour) instead of knocking on
+        // a door the server said stays shut.
+        let retry_after_ms = err
+            .split("retry_after_s=")
+            .nth(1)
+            .and_then(|rest| {
+                rest.chars()
+                    .take_while(|c| c.is_ascii_digit())
+                    .collect::<String>()
+                    .parse::<i64>()
+                    .ok()
+            })
+            .map(|s| (s * 1000).min(3_600_000));
+        let bench_ms = retry_after_ms.unwrap_or(if rate_limited { 300_000 } else { 60_000 });
         map.insert(
             id.to_string(),
             FailState {
-                until_ms: now + if rate_limited { 300_000 } else { 60_000 },
-                note: if rate_limited {
+                until_ms: now + bench_ms,
+                note: if let Some(ms) = retry_after_ms {
+                    format!("rate limited — the vendor asked to wait ~{}m", (ms / 60_000).max(1))
+                } else if rate_limited {
                     format!("rate limited — cooling down for a few minutes ({err})")
                 } else {
                     err

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -113,6 +113,21 @@ async fn fetch() -> Result<Snapshot, String> {
         .await
         .map_err(|e| format!("usage request: {e}"))?;
     if !resp.status().is_success() {
+        // Anthropic's 429s state how long the cooldown runs (a plan change
+        // can trigger a ~25-minute one); carry it so the fetch guard can
+        // bench for exactly that long instead of knocking every 5 minutes.
+        if resp.status().as_u16() == 429 {
+            if let Some(secs) = resp
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok())
+            {
+                return Err(format!(
+                    "usage endpoint: HTTP 429 (retry_after_s={secs})"
+                ));
+            }
+        }
         return Err(format!("usage endpoint: HTTP {}", resp.status()));
     }
     let usage: Value = resp.json().await.map_err(|e| format!("usage parse: {e}"))?;


### PR DESCRIPTION
## Why (observed live)

Cancelling and resubscribing a Claude plan put the account's usage endpoint into a **~25-minute cooldown** — `HTTP 429` with a `retry-after` header counting down (1487s → 1416s across probes). Pane benched a fixed 5 minutes per 429 and kept knocking on a door the server had said stays shut, and the card's Outdated hover gave no hint of how long.

## What

- The Claude provider carries `retry-after` through its error string (`retry_after_s=N`) on 429s.
- The fetch guard parses it and benches for exactly the vendor-stated window (capped at 1 hour), instead of the fixed 300s. Other providers and headerless 429s keep the existing behavior.
- The Outdated hover now reads "rate limited — the vendor asked to wait ~24m".

The card self-heals when the window lapses and then reflects the new plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->