### PR TITLE
Release 0.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## Unreleased
+## 0.4.10 — 2026-07-14
 
 ### Fixed
+- **Claude card recovers faster from rate-limit cooldowns** — when
+  Anthropic's usage endpoint returns 429 (a plan change can trigger a
+  ~25-minute cooldown), Pane now honors the vendor's own Retry-After
+  timing instead of knocking every 5 minutes, and the card's note says
+  how long the wait is.
 - **Codex subagent replays no longer inflate spend** — when Codex spawns
   a subagent (or forks a session), the child's rollout file replays the
   parent's entire token history with fresh timestamps. Pane counted

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.9",
+  "version": "0.4.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.9"
+version = "0.4.10"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to **0.4.10** (tauri.conf.json, package.json, Cargo.toml + lock) and changelog for everything merged since 0.4.9:

- **Codex subagent replays no longer inflate spend** — child-session rollouts replay the parent's whole token history; now gated out via the log's own markers (#55)
- **Codex fast/priority turns price at fast rates**, per session from `thread_settings_applied`, with OpenAI's 272k long-context boundary (#55)
- **Claude advisor iterations** count once under the advisor's own model; sidechain replays deduplicated; `<synthetic>` turns never priced (#55)
- **OpenCode free-model tokens count** at their real $0 price (#55)
- **Claude card honors Anthropic's Retry-After** on 429 cooldowns instead of retrying every 5 minutes (#54)

After merge: tag `v0.4.10` and CI builds/signs/publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->