### PR TITLE
Zero-state spend ring + actionable Claude dead-login message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Total Spend always draws its ring** — a period with no usage now
+  shows a quiet zeroed track with $0.00 in the center instead of
+  collapsing to a bare "No spend in this period" line.
+- **Dead Claude sign-in says what to do** — when another app rotates
+  the Claude Code refresh token (leaving Pane's copy invalid), the card
+  now says "run `claude` in a terminal once and Pane recovers
+  automatically" instead of "token refresh failed: HTTP 400".
+
 ## 0.4.10 — 2026-07-14
 
 ### Fixed

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -72,7 +72,19 @@ async fn fetch() -> Result<Snapshot, String> {
             .await
             .map_err(|e| format!("token refresh: {e}"))?;
         if !resp.status().is_success() {
-            return Err(format!("token refresh failed: HTTP {}", resp.status()));
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            // A rejected refresh token isn't transient: another app (Claude
+            // Code itself, or a second machine) rotated it and this copy is
+            // dead. Only a fresh CLI sign-in mints a working pair — say so
+            // instead of leaving a bare HTTP code on the card.
+            if body.contains("invalid_grant") {
+                return Err(
+                    "Claude sign-in was rotated by another app — run `claude` in a terminal once and Pane recovers automatically"
+                        .into(),
+                );
+            }
+            return Err(format!("token refresh failed: HTTP {status}"));
         }
         let tok: Value = resp.json().await.map_err(|e| format!("token refresh parse: {e}"))?;
         let new_access = tok

--- a/src/main.ts
+++ b/src/main.ts
@@ -988,6 +988,8 @@ function renderTotalSpend(): string {
 
   const center = spendCenter(entries);
   const exact = `${center.exact} — computed locally from session logs. Click to show ${METRIC_NAMES[nextSpendMetric(false)]}.`;
+  // An empty window still draws the ring — a zeroed track with $0.00 in the
+  // center — so the card doesn't collapse to bare text between periods.
   const body = entries.length
     ? `
       <div class="donut-wrap" title="${escapeHtml(exact)}">
@@ -998,7 +1000,15 @@ function renderTotalSpend(): string {
         </svg>
         <div class="legend">${legend}</div>
       </div>`
-    : `<p class="placeholder" style="margin-top:8px">No spend in this period.</p>`;
+    : `
+      <div class="donut-wrap donut-empty" title="No spend recorded in this period.">
+        <svg width="96" height="96" viewBox="0 0 96 96">
+          <path class="seg donut-zero" data-full="1" fill-rule="evenodd" d="${sectorPath(0, TAU)}"/>
+          <text class="donut-total" x="48" y="50" text-anchor="middle" font-size="14" font-weight="600">${center.primary}</text>
+          <text class="donut-sub" x="48" y="62" text-anchor="middle" font-size="8">${center.sub}</text>
+        </svg>
+        <div class="legend"><p class="placeholder" style="margin:0">No spend in this period.</p></div>
+      </div>`;
 
   const contributors = lastSpend.map((s) => s.name).join(", ");
   return `

--- a/src/styles.css
+++ b/src/styles.css
@@ -1422,6 +1422,15 @@ body.drawer-open #drawer {
   cursor: pointer;
 }
 
+/* Empty-window ring: a quiet track instead of a vanished card. */
+.total-spend path.seg.donut-zero {
+  fill: var(--muted);
+  cursor: default;
+}
+.donut-wrap.donut-empty .donut-total {
+  opacity: 0.55;
+}
+
 /* First-run welcome card. */
 .welcome-card {
   border-color: #3f3f46;


### PR DESCRIPTION
Two small fixes from a user report:

**Total Spend keeps its graph when a period is empty.** Selecting Today (or any window) with no usage used to collapse the card to a bare "No spend in this period." line. It now draws the same donut ring as a muted track with $0.00 in the center (metric-aware — shows 0 tokens in token mode), so the card keeps its shape between periods. Tab-switch morphing is unaffected: the zero ring carries `data-full`, which already routes through the full re-render path.

**Claude card explains a dead sign-in.** Anthropic refresh tokens rotate on use; when another consumer (Claude Code itself, a second machine) rotates the pair, the copy in `.credentials.json` gets `invalid_grant` forever — that's not transient, and retrying can't fix it. The card previously showed "token refresh failed: HTTP 400 — showing the last good data"; it now says: *"Claude sign-in was rotated by another app — run `claude` in a terminal once and Pane recovers automatically."* Diagnosed live: Pane last refreshed successfully at Jul 15 12:48, Claude Code rotated at 20:48, and the endpoint returns invalid_grant for the stored token while answering Pane's HTTP stack normally (not a Cloudflare/fingerprint issue — verified separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->