### PR TITLE
Release 0.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,6 @@
   the Claude Code refresh token (leaving Pane's copy invalid), the card
   now says "run `claude` in a terminal once and Pane recovers
   automatically" instead of "token refresh failed: HTTP 400".
-- **⚠ Outdated tooltips explain the problem and the fix** — hovering
-  the warning now classifies what went wrong (sign-in expired, vendor
-  rate limit, vendor outage, no connection) and says exactly what to
-  do about it — including the right re-login command per provider —
-  instead of showing a bare error code.
 
 ## 0.4.10 — 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## Unreleased
+## 0.4.11 — 2026-07-16
 
 ### Fixed
+- **⚠ Outdated tooltips explain the problem and the fix** — hovering
+  the warning now classifies what went wrong (sign-in expired, vendor
+  rate limit, vendor outage, no connection) and says exactly what to
+  do about it — including the right re-login command per provider —
+  instead of showing a bare error code.
 - **Total Spend always draws its ring** — a period with no usage now
   shows a quiet zeroed track with $0.00 in the center instead of
   collapsing to a bare "No spend in this period" line.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.10"
+version = "0.4.11"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to **0.4.11** (tauri.conf.json, package.json, Cargo.toml + lock) and changelog for everything merged since 0.4.10:

- **⚠ Outdated tooltips explain cause + fix** — sign-in / rate-limit / outage / connection classification with per-provider re-login commands (#58)
- **Total Spend always draws its ring** — empty periods show a muted $0.00 track instead of bare text (#57)
- **Dead Claude sign-in says what to do** — invalid_grant now reads "run `claude` once and Pane recovers automatically" (#57)

After merge: tag `v0.4.11` and CI builds/signs/publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->