### PR TITLE
Add MiniMax spend: Agent CLI store + re-routed Claude Code sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **MiniMax spend** — the MiniMax card now shows Today / Yesterday /
+  30-day dollars and tokens like the other CLIs, fed by two local
+  sources: the MiniMax Agent CLI's own per-turn usage store (its
+  recorded cost is used as-is), and any Claude Code sessions run
+  against MiniMax's Anthropic-compatible endpoint — that usage used to
+  be counted (mislabeled) under the Claude card and now moves to the
+  MiniMax card where it belongs.
+
 ## 0.4.11 — 2026-07-16
 
 ### Fixed

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -93,9 +93,16 @@ Ground rules that apply to every provider:
 ## MiniMax
 
 - **Reads:** pasted key (Settings), `MINIMAX_API_KEY`, or
-  `%USERPROFILE%\.minimax\config.yaml`.
+  `%USERPROFILE%\.minimax\config.yaml`; local spend from
+  `%USERPROFILE%\.minimax\sqlite.db` (the Agent CLI's per-turn
+  token_usage table, snapshotted via SQLite's backup API — never
+  modified) and from Claude Code sessions that ran against MiniMax's
+  Anthropic-compatible endpoint (those log MiniMax models into
+  `~\.claude\projects\` and are re-routed here from the Claude card).
 - **Calls:** `api.minimax.io/v1/token_plan/remains` (+ regional fallbacks).
-- **Shows:** 5-hour Session + Weekly plan windows.
+- **Shows:** 5-hour Session + Weekly plan windows; Today / Yesterday /
+  30-day spend with per-model breakdown (the CLI's own cost_usd is
+  preferred; catalog pricing otherwise).
 
 ## OpenRouter
 

--- a/src-tauri/src/providers/minimax.rs
+++ b/src-tauri/src/providers/minimax.rs
@@ -175,6 +175,124 @@ fn parse_remains(doc: &Value) -> Option<Snapshot> {
     Some(Snapshot::ok(ID, NAME, Some("Coding Plan".into()), metrics))
 }
 
+// ---------------------------------------------------------------------------
+// Local spend: the MiniMax Agent CLI's ~/.minimax/sqlite.db keeps a
+// token_usage table with one row per turn — model, token buckets, and the
+// CLI's own cost_usd. Same snapshot/cache machinery as the Devin store:
+// the app writes to the WAL continuously, so raw file copies tear.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct UsageEvent {
+    pub ts_ms: i64,
+    pub model: String,
+    pub input: f64,
+    pub output: f64,
+    pub reasoning: f64,
+    pub cache_read: f64,
+    pub cache_write: f64,
+    pub cost_usd: f64,
+}
+
+fn agent_db_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(".minimax").join("sqlite.db"))
+}
+
+type FileStamp = (std::time::SystemTime, u64);
+
+fn file_stamp(path: &std::path::Path) -> FileStamp {
+    std::fs::metadata(path)
+        .map(|m| (m.modified().unwrap_or(std::time::UNIX_EPOCH), m.len()))
+        .unwrap_or((std::time::UNIX_EPOCH, 0))
+}
+
+/// Per-turn token usage from the MiniMax Agent CLI's local store. Cached on
+/// the (db, WAL) stamps; a busy/locked db serves the last good events.
+pub fn collect_usage_events() -> Vec<UsageEvent> {
+    use std::sync::Mutex;
+    static CACHE: Mutex<Option<(FileStamp, FileStamp, Vec<UsageEvent>)>> = Mutex::new(None);
+
+    let Some(db_path) = agent_db_path() else { return Vec::new() };
+    if !db_path.exists() {
+        return Vec::new();
+    }
+    let db_stamp = file_stamp(&db_path);
+    let wal_stamp = file_stamp(&db_path.with_extension("db-wal"));
+
+    if let Ok(cache) = CACHE.lock() {
+        if let Some((d, w, events)) = cache.as_ref() {
+            if *d == db_stamp && *w == wal_stamp {
+                return events.clone();
+            }
+        }
+    }
+
+    let tmp_base = std::env::temp_dir().join(format!("pane-minimax-{}", std::process::id()));
+    let tmp_db = tmp_base.with_extension("db");
+    let events = snapshot_db(&db_path, &tmp_db).and_then(|()| read_usage_events(&tmp_db));
+    for suffix in ["db", "db-wal", "db-shm"] {
+        let _ = std::fs::remove_file(tmp_base.with_extension(suffix));
+    }
+
+    match events {
+        Ok(events) => {
+            if let Ok(mut cache) = CACHE.lock() {
+                *cache = Some((db_stamp, wal_stamp, events.clone()));
+            }
+            events
+        }
+        Err(_) => CACHE
+            .lock()
+            .ok()
+            .and_then(|c| c.as_ref().map(|(_, _, e)| e.clone()))
+            .unwrap_or_default(),
+    }
+}
+
+/// Consistent point-in-time copy via SQLite's backup API (reads through the
+/// WAL with proper locks, retrying briefly while the writer is busy).
+fn snapshot_db(src_path: &std::path::Path, dst_path: &std::path::Path) -> Result<(), String> {
+    let _ = std::fs::remove_file(dst_path);
+    let src = rusqlite::Connection::open_with_flags(
+        src_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .map_err(|e| format!("open live db: {e}"))?;
+    let mut dst =
+        rusqlite::Connection::open(dst_path).map_err(|e| format!("open snapshot: {e}"))?;
+    let backup = rusqlite::backup::Backup::new(&src, &mut dst)
+        .map_err(|e| format!("backup init: {e}"))?;
+    backup
+        .run_to_completion(256, std::time::Duration::from_millis(10), None)
+        .map_err(|e| format!("backup run: {e}"))
+}
+
+fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
+    let conn = rusqlite::Connection::open(db).map_err(|e| format!("open db copy: {e}"))?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT ts, model, input_tokens, output_tokens, reasoning_tokens,
+                    cache_read_tokens, cache_write_tokens, cost_usd
+             FROM token_usage",
+        )
+        .map_err(|e| format!("query token_usage: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(UsageEvent {
+                ts_ms: row.get::<_, i64>(0)?,
+                model: row.get::<_, String>(1)?,
+                input: row.get::<_, f64>(2).unwrap_or(0.0),
+                output: row.get::<_, f64>(3).unwrap_or(0.0),
+                reasoning: row.get::<_, f64>(4).unwrap_or(0.0),
+                cache_read: row.get::<_, f64>(5).unwrap_or(0.0),
+                cache_write: row.get::<_, f64>(6).unwrap_or(0.0),
+                cost_usd: row.get::<_, f64>(7).unwrap_or(0.0),
+            })
+        })
+        .map_err(|e| format!("read token_usage: {e}"))?;
+    Ok(rows.flatten().collect())
+}
+
 #[cfg(test)]
 mod tests {
     /// Live probe with this machine's real key — run manually via

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -469,10 +469,42 @@ fn claude_line(st: &mut ClaudeFileState, line: &str, data: &mut FileData) {
     }
 }
 
+/// Move every event whose model starts with `prefix` out of `data` into a
+/// new FileData (unpriced tallies included). Used to re-route usage that a
+/// CLI logged on another vendor's behalf.
+fn split_models(data: &mut FileData, prefix: &str) -> FileData {
+    let mut out = FileData::default();
+    data.days.retain(|(day, model), v| {
+        if model.starts_with(prefix) {
+            out.days.insert((*day, model.clone()), *v);
+            false
+        } else {
+            true
+        }
+    });
+    let moved: Vec<String> = data
+        .unpriced
+        .keys()
+        .filter(|m| m.starts_with(prefix))
+        .cloned()
+        .collect();
+    for m in moved {
+        if let Some(c) = data.unpriced.remove(&m) {
+            out.unpriced.insert(m, c);
+        }
+    }
+    out
+}
+
 /// Claude Code writes one JSONL per session under ~/.claude/projects. Each
 /// assistant line carries usage token counts and usually a precomputed
 /// costUSD, which we prefer over our own pricing table.
-fn claude() -> ProviderSpend {
+///
+/// Claude Code can also run against MiniMax's Anthropic-compatible endpoint
+/// (ANTHROPIC_BASE_URL); those sessions log MiniMax models into the same
+/// files. That usage is split out and returned separately — it belongs on
+/// the MiniMax card, not Claude's.
+fn claude() -> (ProviderSpend, FileData) {
     let root = std::env::var("CLAUDE_CONFIG_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".claude"))
@@ -486,7 +518,44 @@ fn claude() -> ProviderSpend {
         let data = file_days(&file, &mut |line, data| claude_line(&mut state, line, data));
         merge_data(&mut all, data);
     }
-    build_spend("claude", "Claude", all)
+    let minimax = split_models(&mut all, "MiniMax");
+    (build_spend("claude", "Claude", all), minimax)
+}
+
+/// MiniMax spend: the Agent CLI's local token_usage store (its own cost_usd
+/// preferred, catalog-priced otherwise) plus whatever Claude Code logged
+/// while pointed at MiniMax's endpoint (passed in from the Claude scan).
+fn minimax(extra: FileData) -> ProviderSpend {
+    let mut data = extra;
+    for ev in providers::minimax::collect_usage_events() {
+        let Some(ts) = DateTime::from_timestamp_millis(ev.ts_ms) else { continue };
+        let tokens = ev.input + ev.output + ev.reasoning + ev.cache_read + ev.cache_write;
+        if tokens <= 0.0 && ev.cost_usd <= 0.0 {
+            continue;
+        }
+        // Rows carry provider-prefixed slugs ("minimax/MiniMax-M3") — the
+        // bare model is what the card, catalogs, and the Claude-side split
+        // all use.
+        let model = ev.model.strip_prefix("minimax/").unwrap_or(&ev.model).to_string();
+        if ev.cost_usd > 0.0 {
+            add_event(&mut data, ts, &model, ev.cost_usd, tokens);
+            continue;
+        }
+        match pricing::lookup(&model) {
+            Some(p) => {
+                let u = pricing::Usage {
+                    input: ev.input,
+                    output: ev.output + ev.reasoning,
+                    cache_read: ev.cache_read,
+                    cache_write_5m: ev.cache_write,
+                    cache_write_1h: 0.0,
+                };
+                add_event(&mut data, ts, &model, pricing::request_cost(&p, &u, true), tokens);
+            }
+            None => note_unpriced(&mut data, ts, &model, tokens),
+        }
+    }
+    build_spend("minimax", "MiniMax", data)
 }
 
 /// One `token_count` usage object, tolerating the older field spellings
@@ -1326,6 +1395,23 @@ mod tests {
     }
 
     #[test]
+    fn split_models_reroutes_minimax_usage() {
+        let mut data = FileData::default();
+        data.days.insert((1000, "claude-fable-5".into()), (5.0, 100.0));
+        data.days.insert((1000, "MiniMax-M3".into()), (0.5, 50.0));
+        data.days.insert((1001, "MiniMax-M2.7".into()), (0.2, 20.0));
+        data.unpriced.insert("MiniMax-Unknown".into(), 3);
+        data.unpriced.insert("mystery-model".into(), 1);
+
+        let mm = split_models(&mut data, "MiniMax");
+        assert_eq!(data.days.len(), 1);
+        assert_eq!(data.unpriced.len(), 1);
+        assert_eq!(mm.days.len(), 2);
+        assert_eq!(mm.days[&(1000, "MiniMax-M3".to_string())], (0.5, 50.0));
+        assert_eq!(mm.unpriced.get("MiniMax-Unknown"), Some(&3));
+    }
+
+    #[test]
     fn claude_unknown_speed_marks_foreign_log_shape() {
         let line = json!({"type": "assistant", "timestamp": "2026-07-10T10:00:00Z",
             "requestId": "req_1",
@@ -1392,7 +1478,8 @@ fn split_csv_row(line: &str) -> Vec<String> {
 
 pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
     pricing::ensure_fresh();
-    let mut list = vec![claude(), codex(), grok(), opencode(), devin()];
+    let (claude_sp, minimax_extra) = claude();
+    let mut list = vec![claude_sp, codex(), grok(), opencode(), devin(), minimax(minimax_extra)];
     if let Some(csv) = cursor_csv {
         list.push(cursor_from_csv(&csv));
     }


### PR DESCRIPTION
Adds price + token usage to the MiniMax card, from two local sources:

**1. The MiniMax Agent CLI's own store.** `~/.minimax/sqlite.db` has a `token_usage` table with one row per turn: model, input/output/reasoning/cache tokens, and the CLI's own `cost_usd`. Read through a SQLite backup-API snapshot with the same (db, WAL) stamp cache and stale-serve fallback as the Devin scanner — the app writes to the WAL continuously, and raw file copies tear. The recorded `cost_usd` is used as-is when present; rows without one price through the catalog. Provider-prefixed slugs (`minimax/MiniMax-M3`) are stripped to the bare model.

**2. Claude Code sessions pointed at MiniMax.** Running Claude Code with `ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic` logs MiniMax models into the ordinary `~/.claude/projects` files. That usage was being counted under the **Claude** card (mislabeled and priced against the wrong vendor's brand); a new `split_models()` pass moves every `MiniMax*` event (unpriced tallies included) out of the Claude scan and onto the MiniMax card.

On this machine: MiniMax card now shows **$3.36 · ~39.8M tokens (30d)** ($0.75 of it from the Agent CLI's own cost records); the Claude card drops by the re-routed amount. Donut color for minimax already existed.

OpenCode-routed MiniMax usage intentionally stays on the OpenCode card — spend is per-tool, same as every other provider.

Tests: `split_models_reroutes_minimax_usage` covers the re-route (days + unpriced, non-matching models untouched); full spend suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->