### PR TITLE
Release 0.4.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.13 — 2026-07-16
 
 ### Fixed
 - **Cursor spend updates within minutes, not an hour** — the dashboard

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.12",
+  "version": "0.4.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.12"
+version = "0.4.13"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to **0.4.13** (tauri.conf.json, package.json, Cargo.toml + lock) and changelog:

- **Cursor spend updates within minutes, not an hour** (#62) — 5-minute CSV cache instead of hourly, and failed fetches serve the last good export instead of blanking the Cursor rows.

After merge: tag `v0.4.13` and CI builds/signs/publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->