### PR TITLE
Keep balance-only cards' rows visible instead of an empty panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
   a group of one is just a rename — and if everyone is under $10 the
   ring stays fully named rather than turning into one grey blob.)
 
+### Fixed
+- **Balance-only cards show their rows** — providers with no usage
+  meters (Moonshot, DeepSeek, and other pay-as-you-go cards) tucked
+  every row behind the "show more" caret, leaving an empty panel with
+  a floating arrow. Their Balance/Voucher rows now stay visible, and
+  already-saved layouts repair themselves on the next refresh.
+
 ## 0.4.13 — 2026-07-16
 
 ### Fixed

--- a/src/main.ts
+++ b/src/main.ts
@@ -397,6 +397,10 @@ function defaultProviderLayout(s: Snapshot | undefined, spend: ProviderSpend | u
     order.push(m.label);
     if (m.kind !== "progress") onDemand.push(m.label); // balances etc. tuck away
   }
+  // Balance-only providers (Moonshot, DeepSeek…) have no progress rows at
+  // all — tucking everything would leave an empty card with a floating
+  // caret, so their text rows stay visible.
+  if (order.length > 0 && onDemand.length === order.length) onDemand.length = 0;
   if (spend) {
     order.push(TREND_KEY); // trend stays always-visible, like the Mac
     for (const [label] of SPEND_KEYS) {
@@ -467,6 +471,20 @@ function ensureLayout(): void {
           L.onDemand.push(label);
           changed = true;
         }
+      }
+    }
+    // Repair saved layouts where EVERY visible row sits behind the caret
+    // (balance-only cards defaulted that way before this rule existed):
+    // an all-tucked card renders as an empty panel with a floating ⌄, so
+    // its own metric rows are promoted back to always-visible.
+    const alwaysVisible = L.metricOrder.filter(
+      (k) => !L.onDemand.includes(k) && !L.hidden.includes(k),
+    );
+    if (alwaysVisible.length === 0) {
+      const own = new Set(s.metrics.map((m) => m.label));
+      if (s.metrics.length > 0 && L.onDemand.some((k) => own.has(k))) {
+        L.onDemand = L.onDemand.filter((k) => !own.has(k));
+        changed = true;
       }
     }
   }


### PR DESCRIPTION
User report (Moonshot card after adding a Kimi API key): an empty panel with a floating ⌃ caret, all rows hidden behind "show more."

Cause: non-progress rows default to the on-demand (caret) section — sensible for cards where balances ride along under real usage meters, but balance-only providers (Moonshot, DeepSeek, any pay-as-you-go card) have **only** text rows, so everything got tucked and the always-visible body rendered empty.

Two-part fix in the layout code:
- `defaultProviderLayout()`: when a card has no progress rows at all, its text rows stay always-visible.
- `ensureLayout()`: repairs already-saved layouts — if every visible row of a card sits behind the caret, the card's own metric rows are promoted back (spend rows stay tucked). This also un-breaks a card the user manually tucks into the same state via Customize, which rendered just as broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->