### PR TITLE
Add Moonshot/Kimi spend from Kimi Code CLI session logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Moonshot/Kimi spend** — the Moonshot card gains Today / Yesterday /
+  30-day dollars and tokens, a per-model breakdown, and the usage trend,
+  scanned from the Kimi Code CLI's local session logs (one usage record
+  per turn). Models the price catalogs don't know yet count their
+  tokens with the usual ⚠ until pricing lands.
+
 ## 0.4.14 — 2026-07-16
 
 ### Changed

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -128,11 +128,16 @@ Ground rules that apply to every provider:
 ## DeepSeek / Moonshot / ElevenLabs / Venice-class key providers
 
 - **Reads:** pasted key or env var only (`DEEPSEEK_API_KEY`,
-  `MOONSHOT_API_KEY`/`KIMI_API_KEY`, `ELEVENLABS_API_KEY`).
+  `MOONSHOT_API_KEY`/`KIMI_API_KEY`, `ELEVENLABS_API_KEY`). Moonshot
+  additionally reads local spend from the Kimi Code CLI's session logs
+  (`%USERPROFILE%\.kimi-code\sessions\**\wire.jsonl` — one usage.record
+  per turn with model and token buckets).
 - **Calls:** `api.deepseek.com/user/balance`;
   `api.moonshot.ai|cn/v1/users/me/balance`;
   `api.elevenlabs.io/v1/user/subscription`.
-- **Shows:** balances / character quota with reset pacing.
+- **Shows:** balances / character quota with reset pacing; Moonshot
+  adds Today / Yesterday / 30-day spend, model breakdown, and the
+  usage trend from Kimi Code sessions.
 
 ## Ollama
 

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -1053,6 +1053,69 @@ fn devin_model(raw: &str) -> String {
     base.to_string()
 }
 
+/// One Kimi Code CLI wire.jsonl line → spend event. usage.record rows are
+/// self-contained: model, token buckets, epoch-ms time. Only the "turn"
+/// scope counts — other scopes would double-report the same tokens.
+fn moonshot_line(line: &str, data: &mut FileData) {
+    if !line.contains("\"usage.record\"") {
+        return;
+    }
+    let Ok(v) = serde_json::from_str::<Value>(line) else { return };
+    if v.get("type").and_then(Value::as_str) != Some("usage.record") {
+        return;
+    }
+    if v.get("usageScope").and_then(Value::as_str) != Some("turn") {
+        return;
+    }
+    let Some(ts) = parse_ts(v.get("time")) else { return };
+    let model_raw = v.get("model").and_then(Value::as_str).unwrap_or("unknown");
+    let model = model_raw
+        .strip_prefix("moonshot-ai/")
+        .unwrap_or(model_raw)
+        .to_string();
+    let u = v.get("usage").cloned().unwrap_or(Value::Null);
+    let num = |k: &str| u.get(k).and_then(Value::as_f64).unwrap_or(0.0);
+    let (input, output) = (num("inputOther"), num("output"));
+    let (cache_read, cache_write) = (num("inputCacheRead"), num("inputCacheCreation"));
+    let tokens = input + output + cache_read + cache_write;
+    if tokens <= 0.0 {
+        return;
+    }
+    // Catalogs key Kimi models as "moonshot/<slug>"; try the bare slug
+    // first (alias/fuzzy chain), then the prefixed spelling.
+    let price = pricing::lookup(&model).or_else(|| pricing::lookup(&format!("moonshot/{model}")));
+    match price {
+        Some(p) => {
+            let usage = pricing::Usage {
+                input,
+                output,
+                cache_read,
+                cache_write_5m: cache_write,
+                cache_write_1h: 0.0,
+            };
+            add_event(data, ts, &model, pricing::request_cost(&p, &usage, true), tokens);
+        }
+        None => note_unpriced(data, ts, &model, tokens),
+    }
+}
+
+/// Moonshot spend: Kimi Code CLI sessions under ~/.kimi-code/sessions —
+/// each agent's wire.jsonl logs one usage.record per turn.
+fn moonshot() -> ProviderSpend {
+    let root = dirs::home_dir()
+        .unwrap_or_default()
+        .join(".kimi-code")
+        .join("sessions");
+    let mut files = Vec::new();
+    recent_jsonl_files(&root, &mut files);
+    let mut all = FileData::default();
+    for file in files {
+        let data = file_days(&file, &mut |line, data| moonshot_line(line, data));
+        merge_data(&mut all, data);
+    }
+    build_spend("moonshot", "Moonshot", all)
+}
+
 /// Cursor spend from the dashboard's usage-events CSV export (fetched by the
 /// async caller — this stays a pure parser). Column layout is discovered
 /// from the header row; rows with an explicit cost win, token-only rows are
@@ -1395,6 +1458,23 @@ mod tests {
     }
 
     #[test]
+    fn moonshot_counts_turn_records_only() {
+        let mut data = FileData::default();
+        let turn = json!({"type": "usage.record", "model": "moonshot-ai/kimi-test-model",
+            "usage": {"inputOther": 400.0, "output": 200.0, "inputCacheRead": 300.0,
+                      "inputCacheCreation": 100.0},
+            "usageScope": "turn", "time": 1784208630652i64})
+        .to_string();
+        let session_scope = turn.replace("\"turn\"", "\"session\"");
+        moonshot_line(&turn, &mut data);
+        moonshot_line(&session_scope, &mut data);
+        // One event; unknown model → tokens counted, dollars honest zero.
+        assert_eq!(data.days.values().map(|v| v.1).sum::<f64>(), 1_000.0);
+        assert_eq!(data.unpriced.get("kimi-test-model"), Some(&1));
+        assert!(data.days.keys().all(|(_, m)| m == "kimi-test-model"));
+    }
+
+    #[test]
     fn split_models_reroutes_minimax_usage() {
         let mut data = FileData::default();
         data.days.insert((1000, "claude-fable-5".into()), (5.0, 100.0));
@@ -1479,7 +1559,15 @@ fn split_csv_row(line: &str) -> Vec<String> {
 pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
     pricing::ensure_fresh();
     let (claude_sp, minimax_extra) = claude();
-    let mut list = vec![claude_sp, codex(), grok(), opencode(), devin(), minimax(minimax_extra)];
+    let mut list = vec![
+        claude_sp,
+        codex(),
+        grok(),
+        opencode(),
+        devin(),
+        minimax(minimax_extra),
+        moonshot(),
+    ];
     if let Some(csv) = cursor_csv {
         list.push(cursor_from_csv(&csv));
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -258,6 +258,7 @@ const SPEND_COLORS: Record<string, string> = {
   opencode: "#b7b1b1",
   devin: "#38bdf8",
   cursor: "var(--spend-cursor)", // brand black, theme-flipped in CSS
+  moonshot: "#e0b354", // moon gold
   __others__: "#8b8b94", // the folded small-spenders wedge
 };
 


### PR DESCRIPTION
User request: the Moonshot card should have usage lines and trends like Claude's.

The live meters can't exist (pay-as-you-go has no quota windows — just a balance), but spend absolutely can: the **Kimi Code CLI** logs one self-contained `usage.record` per turn into `~/.kimi-code/sessions/**/wire.jsonl`:

```json
{"type":"usage.record","model":"moonshot-ai/kimi-k2.7-code","usage":{"inputOther":12454,"output":219,"inputCacheRead":9472,"inputCacheCreation":0},"usageScope":"turn","time":1784208630652}
```

New `moonshot()` scanner in spend.rs: recent wire.jsonl files through the standard per-file cache; only `usageScope == "turn"` counts (other scopes would double-report); `moonshot-ai/` prefix strips for display and pricing; catalog lookup tries the bare slug then the `moonshot/` spelling (LiteLLM keys Kimi models that way). Cache reads/writes price through the standard request-cost path.

On this machine: **$0.18 · 701K tokens** across kimi-k2.7-code and kimi-k2.5 — both resolve against the live catalog, nothing unpriced. Moon-gold donut color for the wedge; the card's trend + spend rows appear automatically via the existing layout machinery.

Test: `moonshot_counts_turn_records_only` (turn-scope filter, prefix strip, unknown-model unpriced path). Full spend suite passes; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->