### PR TITLE
Credit meters for balance cards + Grok duplicate-row fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
   scanned from the Kimi Code CLI's local session logs (one usage record
   per turn). Models the price catalogs don't know yet count their
   tokens with the usual ⚠ until pricing lands.
+- **Credit meters for pay-as-you-go cards** — Moonshot and DeepSeek get
+  a "Credits used" percent bar metered against the highest balance Pane
+  has seen (a top-up raises it automatically), so balance cards read
+  like every other card — and the low-credit case now fires the same
+  "Almost Out" notification the quota providers get.
+
+### Fixed
+- **Grok no longer shows the same meter twice** — the billing payload
+  repeats one percentage under several keys; the card now keeps one
+  row per label.
 
 ## 0.4.14 — 2026-07-16
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -135,9 +135,11 @@ Ground rules that apply to every provider:
 - **Calls:** `api.deepseek.com/user/balance`;
   `api.moonshot.ai|cn/v1/users/me/balance`;
   `api.elevenlabs.io/v1/user/subscription`.
-- **Shows:** balances / character quota with reset pacing; Moonshot
-  adds Today / Yesterday / 30-day spend, model breakdown, and the
-  usage trend from Kimi Code sessions.
+- **Shows:** balances / character quota with reset pacing; Moonshot and
+  DeepSeek add a "Credits used" percent bar metered against the highest
+  balance Pane has seen locally (top-ups raise it; feeds the Almost Out
+  notification); Moonshot adds Today / Yesterday / 30-day spend, model
+  breakdown, and the usage trend from Kimi Code sessions.
 
 ## Ollama
 

--- a/src-tauri/src/providers/deepseek.rs
+++ b/src-tauri/src/providers/deepseek.rs
@@ -36,7 +36,13 @@ async fn fetch() -> Result<Snapshot, String> {
 
     // balance_infos rows carry stringified decimals per currency (CNY/USD).
     let mut metrics = Vec::new();
-    for row in doc.get("balance_infos").and_then(Value::as_array).unwrap_or(&vec![]) {
+    for (i, row) in doc
+        .get("balance_infos")
+        .and_then(Value::as_array)
+        .unwrap_or(&vec![])
+        .iter()
+        .enumerate()
+    {
         let currency = row.get("currency").and_then(Value::as_str).unwrap_or("?");
         let total = row
             .get("total_balance")
@@ -44,6 +50,13 @@ async fn fetch() -> Result<Snapshot, String> {
             .and_then(|s| s.parse::<f64>().ok())
             .unwrap_or(0.0);
         let sign = if currency == "CNY" { "¥" } else { "$" };
+        // Usage line + low-credit notifications for the primary currency,
+        // metered against the highest balance seen (top-ups raise it).
+        if i == 0 {
+            if let Some(meter) = super::credit_meter(ID, sign, total) {
+                metrics.push(meter);
+            }
+        }
         metrics.push(Metric::text(&format!("Balance ({currency})"), format!("{sign}{total:.2}")));
     }
     if metrics.is_empty() {

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -199,7 +199,11 @@ fn collect_billing_metrics(node: &Value, parent_key: &str, metrics: &mut Vec<Met
                         } else {
                             "Usage"
                         };
-                        metrics.push(Metric::progress(label, n, None));
+                        // The undocumented payload repeats the same percent
+                        // under several keys/nestings — one row per label.
+                        if !metrics.iter().any(|m| m.label == label) {
+                            metrics.push(Metric::progress(label, n, None));
+                        }
                     } else if lower.contains("credit") || lower.contains("balance") {
                         metrics.push(Metric::text(key, format!("{n:.2}")));
                     }

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -236,6 +236,11 @@ pub fn credit_meter(provider: &str, sign: &str, balance: f64) -> Option<Metric> 
     if !balance.is_finite() || balance < 0.0 {
         return None;
     }
+    // Providers refresh concurrently and this is a read-modify-write on a
+    // shared file — serialize it, or one card's just-raised high-water
+    // mark can be overwritten by another's stale copy.
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = LOCK.lock();
     let path = config_dir().join("credit_baselines.json");
     let mut doc: serde_json::Value = std::fs::read_to_string(&path)
         .ok()

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -226,6 +226,42 @@ pub fn credential_string(target: &str) -> Option<String> {
     Some(text)
 }
 
+/// Percent-used meter for pay-as-you-go balances. These APIs report only
+/// what's left — never "of how much" — so Pane remembers the highest
+/// balance it has ever seen per provider (a top-up raises it automatically)
+/// and meters usage against that high-water mark. Persisted so restarts
+/// keep the story. As a progress row it also feeds the notification rules
+/// ("Almost Out" fires under 10% remaining) like every other meter.
+pub fn credit_meter(provider: &str, sign: &str, balance: f64) -> Option<Metric> {
+    if !balance.is_finite() || balance < 0.0 {
+        return None;
+    }
+    let path = config_dir().join("credit_baselines.json");
+    let mut doc: serde_json::Value = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .filter(serde_json::Value::is_object)
+        .unwrap_or_else(|| serde_json::json!({}));
+    let high = doc.get(provider).and_then(serde_json::Value::as_f64).unwrap_or(0.0);
+    if balance > high {
+        doc[provider] = serde_json::Value::from(balance);
+        let _ = std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&doc).unwrap_or_default(),
+        );
+    }
+    let high = high.max(balance);
+    if high <= 0.0 {
+        return None;
+    }
+    let used = ((1.0 - balance / high) * 100.0).clamp(0.0, 100.0);
+    Some(Metric::progress(
+        "Credits used",
+        used,
+        Some(format!("{sign}{balance:.2} of {sign}{high:.2} left")),
+    ))
+}
+
 /// API key lookup: our saved config file first, then environment variables.
 pub fn stored_api_key(provider: &str, env_vars: &[&str]) -> Option<String> {
     let path = config_dir().join(format!("{provider}.json"));

--- a/src-tauri/src/providers/moonshot.rs
+++ b/src-tauri/src/providers/moonshot.rs
@@ -54,7 +54,13 @@ async fn fetch() -> Result<Snapshot, String> {
             continue;
         };
         let sign = if url.contains(".cn") { "¥" } else { "$" };
-        let mut metrics = vec![Metric::text("Balance", format!("{sign}{available:.2}"))];
+        let mut metrics = Vec::new();
+        // A percent bar against the highest balance ever seen — gives the
+        // card a usage line and feeds the low-credit notifications.
+        if let Some(meter) = super::credit_meter(ID, sign, available) {
+            metrics.push(meter);
+        }
+        metrics.push(Metric::text("Balance", format!("{sign}{available:.2}")));
         if let Some(v) = voucher {
             if v > 0.0 {
                 metrics.push(Metric::text("Vouchers", format!("{sign}{v:.2}")));


### PR DESCRIPTION
User request: balance cards should have % usage lines and "you will run out" notifications like the quota providers.

**Credit meters.** Pay-as-you-go APIs report only what's left, never "of how much" — so `providers::credit_meter()` meters against the **highest balance Pane has ever seen** for that provider, persisted in `credit_baselines.json` in the config dir. A top-up raises the high-water mark automatically; the detail line reads `$199.81 of $200.00 left`. Wired into **Moonshot** (available balance) and **DeepSeek** (primary currency row). Because it's an ordinary progress metric, the existing alert engine picks it up with zero changes — **"Almost Out" fires when under 10% of the high-water remains**, exactly like quota meters (the pace-based "Will Run Out" projection needs a reset period, which balances don't have — that one stays quota-only by nature).

**Grok duplicate rows** (also visible in the user's screenshot): the undocumented billing payload repeats the same percentage under several keys/nestings, and the walker pushed one meter per occurrence — two identical "Usage 54%" bars. Now one row per label, keep-first.

Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->