### PR TITLE
Dedupe metric labels in saved layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 ### Fixed
 - **Grok no longer shows the same meter twice** — the billing payload
   repeats one percentage under several keys; the card now keeps one
-  row per label.
+  row per label, and layouts saved while the duplicate existed repair
+  themselves on the next refresh.
 
 ## 0.4.14 — 2026-07-16
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -395,6 +395,7 @@ function defaultProviderLayout(s: Snapshot | undefined, spend: ProviderSpend | u
   const order: string[] = [];
   const onDemand: string[] = [];
   for (const m of s?.metrics ?? []) {
+    if (order.includes(m.label)) continue; // one row per label
     order.push(m.label);
     if (m.kind !== "progress") onDemand.push(m.label); // balances etc. tuck away
   }
@@ -473,6 +474,15 @@ function ensureLayout(): void {
           changed = true;
         }
       }
+    }
+    // Repair layouts saved while a provider emitted duplicate labels (old
+    // Grok billing bug): the label landed in metricOrder twice and the
+    // card rendered the same row twice.
+    const seenKeys = new Set<string>();
+    const dedupedOrder = L.metricOrder.filter((k) => !seenKeys.has(k) && (seenKeys.add(k), true));
+    if (dedupedOrder.length !== L.metricOrder.length) {
+      L.metricOrder = dedupedOrder;
+      changed = true;
     }
     // Repair saved layouts where EVERY visible row sits behind the caret
     // (balance-only cards defaulted that way before this rule existed):


### PR DESCRIPTION
Follow-up to #68: the Grok card still showed two "Usage" bars after the provider-side dedup, because the duplicate had been **persisted in the saved layout** back when the billing payload produced two metrics — `metricOrder: ["Usage", "Usage", …]` — and the card renders one row per layout entry.

- `defaultProviderLayout()` now records one entry per label.
- `ensureLayout()` repairs already-saved layouts by deduping `metricOrder` in place (keep-first, order preserved), so existing installs self-heal on the next refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->