### PR TITLE
Attribute Devin usage to each message's generation_model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
   "Almost Out" notification the quota providers get.
 
 ### Fixed
+- **Devin usage counts under the model that actually ran** — Devin
+  rewrites a session's model label whenever you switch models, which
+  retroactively relabeled (and mispriced) everything the session ran
+  before. Each message's own recorded model now wins, so switching to
+  Fable (or anything else) mid-session shows up correctly, priced at
+  the right rates. Fable's Max mode slug also normalizes now.
 - **Grok no longer shows the same meter twice** — the billing payload
   repeats one percentage under several keys; the card now keeps one
   row per label, and layouts saved while the duplicate existed repair

--- a/src-tauri/src/providers/devin.rs
+++ b/src-tauri/src/providers/devin.rs
@@ -296,9 +296,19 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
             .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
             .map(|dt| dt.timestamp_millis())
             .unwrap_or(node_created_s * 1000);
+        // The message's own generation_model is the truth: the session-level
+        // model is rewritten in place on every switch, which retroactively
+        // relabels (and misprices) everything the session ran before. Older
+        // records without the field fall back to the session model.
+        let event_model = md
+            .get("generation_model")
+            .and_then(Value::as_str)
+            .filter(|m| !m.trim().is_empty())
+            .unwrap_or(&model)
+            .to_string();
         out.push(UsageEvent {
             ts_ms,
-            model: model.clone(),
+            model: event_model,
             input: num("input_tokens"),
             output: num("output_tokens"),
             cache_read: num("cache_read_tokens"),

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -1028,7 +1028,8 @@ fn devin() -> ProviderSpend {
 /// reordered.
 fn devin_model(raw: &str) -> String {
     let mut base = raw;
-    for suffix in ["-xhigh", "-light", "-low", "-medium", "-high"] {
+    // Effort tiers and Max/Ultra modes bill at the base model's rates.
+    for suffix in ["-xhigh", "-light", "-low", "-medium", "-high", "-max", "-ultra"] {
         if let Some(b) = raw.strip_suffix(suffix) {
             base = b;
             break;
@@ -1455,6 +1456,16 @@ mod tests {
         let data = claude_run(&[carried]);
         assert_eq!(cost_sum(&data), 0.5);
         assert!(data.days.keys().all(|(_, m)| m == "unattributed"));
+    }
+
+    #[test]
+    fn devin_model_normalizes_fable_and_modes() {
+        assert_eq!(devin_model("claude-5-fable-medium"), "claude-fable-5");
+        assert_eq!(devin_model("claude-5-fable-max"), "claude-fable-5");
+        assert_eq!(devin_model("claude-5-fable-high"), "claude-fable-5");
+        assert_eq!(devin_model("gpt-5-6-sol-max"), "gpt-5.6-sol");
+        assert_eq!(devin_model("claude-opus-4-8-medium"), "claude-opus-4-8");
+        assert_eq!(devin_model("gpt-4-0125-preview"), "gpt-4-0125-preview");
     }
 
     #[test]


### PR DESCRIPTION
User report: "I used Fable on Devin and it didn't show data."

Diagnosis: the scanner attributes usage by **session-level** model (`sessions.model`), and Devin rewrites that field in place on every model switch — so a Fable run inside a session later labeled `gpt-5-6-luna-max` displayed (and priced) as Luna. On the reporting machine the per-message field tells the real story: **129.8M tokens on claude-5-fable-medium + 30.4M on fable-high** were hiding under GPT-5.6 session labels, and today's Fable run was priced at Luna's $1/$6 instead of Fable's $10/$50.

Fix:
- `read_usage_events` prefers each message's `metadata.generation_model` (2,759 messages carry it on this machine; 1,162 differ from their session label), falling back to the session model for older records without the field.
- `devin_model()` strips `-max`/`-ultra` too, so `claude-5-fable-max` → `claude-fable-5` (effort tiers and modes bill at base rates, matching the pricing chain's own peel rules). Composed GPT slugs normalize the same way (`gpt-5-6-sol-max` → `gpt-5.6-sol`); cost is identical since Max billed at base already.
- Devin's internal `summarizer` model now lands in the unpriced bucket (tokens counted, no dollars guessed) instead of billing under whatever the session label happened to be.

Live probe before/after: 30-day $57.39 → $50.64 with identical token totals — the mislabeling cut both ways (cheap Luna work priced as Sol slightly outweighed under-priced Fable), so the correction is honest in both directions. New test: `devin_model_normalizes_fable_and_modes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->