### PR TITLE
Release 0.4.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.15 — 2026-07-16
 
 ### Added
 - **Moonshot/Kimi spend** — the Moonshot card gains Today / Yesterday /

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.14",
+  "version": "0.4.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.14"
+version = "0.4.15"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to **0.4.15** (tauri.conf.json, package.json, Cargo.toml + lock) and changelog for what's merged since 0.4.14:

- **Moonshot/Kimi spend** (#67) — trend, spend rows, and model breakdown from Kimi Code CLI session logs
- **Credit meters for pay-as-you-go cards** (#68) — "Credits used" % bar vs the high-water balance, feeding the Almost Out notification
- **Devin usage counts under the model that actually ran** (#70) — per-message generation_model beats the rewritten session label; Fable-on-Devin now shows correctly
- **Grok duplicate meter fixed** (#68 + #69) — provider-side dedup plus saved-layout self-repair

All verified on a local build on the maintainer's machine.

After merge: tag `v0.4.15` and CI builds/signs/publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->