### PR TITLE
Price Kimi K3 via a built-in vendor-rate fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Kimi K3 prices everywhere** — K3 usage through Devin, Cursor, the
+  Kimi Code CLI, or the API now bills at Moonshot's published rates
+  ($3 in / $15 out / $0.30 cache hit per MTok) via a built-in fallback,
+  in every slug spelling the tools use. The live catalogs win
+  automatically once they learn the model.
+
 ## 0.4.15 — 2026-07-16
 
 ### Added

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -478,6 +478,12 @@ fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
     if let Some(p) = s.modelsdev.get(&canonical) {
         return Some(*p);
     }
+    // Vendor-documented rates for models the live catalogs haven't learned
+    // yet — consulted after every online source so a real catalog entry
+    // always wins the moment one ships. Keep this list tiny and sourced.
+    if let Some(p) = builtin_price(&canonical) {
+        return Some(p);
+    }
     // Slug tails no catalog carries under their own name, billed at the
     // base model's per-token rates: reasoning-effort tiers (they change how
     // many tokens burn, not the unit price) and Cursor's Max/Ultra modes
@@ -493,12 +499,45 @@ fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
     None
 }
 
+/// Kimi K3 — platform.kimi.ai/docs/pricing/chat-k3 (USD/MTok): input $3,
+/// cache hit $0.30, output $15; no published cache-write rate, so writes
+/// bill at the input rate. The `-code` spelling follows the K2.7 pattern
+/// (the supplement priced k2.7 and k2.7-code identically); "moonshot/" and
+/// "moonshot-ai/" prefixed spellings match how the CLIs log it.
+fn builtin_price(canonical: &str) -> Option<Price> {
+    let bare = canonical
+        .strip_prefix("moonshot/")
+        .or_else(|| canonical.strip_prefix("moonshot-ai/"))
+        .unwrap_or(canonical);
+    match bare {
+        "kimi-k3" | "kimi-k3-code" => Some(Price::flat(3.0, 15.0, 0.3, 3.0)),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{request_cost, Price, Usage};
 
     fn usage(input: f64, output: f64, cache_read: f64, w5m: f64, w1h: f64) -> Usage {
         Usage { input, output, cache_read, cache_write_5m: w5m, cache_write_1h: w1h }
+    }
+
+    #[test]
+    fn kimi_k3_builtin_prices_every_spelling() {
+        // Vendor-documented rates (platform.kimi.ai): $3 in, $15 out, $0.30
+        // cache hit — resolvable however each tool spells the slug.
+        for slug in [
+            "kimi-k3",                    // Cursor / Devin bare
+            "kimi-k3-code",               // Kimi Code CLI variant
+            "moonshot/kimi-k3",           // catalog-style prefix
+            "moonshot-ai/kimi-k3-code",   // Kimi CLI's own prefix
+            "kimi-k3-high",               // effort tier → peels to base
+            "kimi-k3-max",                // mode → peels to base
+        ] {
+            let p = super::lookup(slug).unwrap_or_else(|| panic!("{slug} did not price"));
+            assert_eq!((p.input, p.output, p.cache_read), (3.0, 15.0, 0.3), "{slug}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Kimi K3 just shipped and no catalog (supplement, LiteLLM, models.dev) knows it yet — K3 usage would land in the unpriced ⚠ bucket everywhere. Vendor-documented rates from [platform.kimi.ai/docs/pricing/chat-k3](https://platform.kimi.ai/docs/pricing/chat-k3): **$3.00 input / $15.00 output / $0.30 cache hit** per MTok, 1M context, no long-context tiers, no published cache-write rate (writes bill at input rate).

New `builtin_price()` step in the resolve chain, **after** every online source — so the moment the supplement or LiteLLM learns K3, their entry wins and the builtin becomes dead code to delete. Kept deliberately tiny and sourced.

Coverage by tool (verified by the new `kimi_k3_builtin_prices_every_spelling` test):
- **Cursor / Devin**: bare `kimi-k3`, plus effort/mode compositions (`-high`, `-max`, …) through the existing peel rules; Devin's `devin_model()` strips its suffixes first
- **Kimi Code CLI (API)**: `moonshot-ai/kimi-k3-code` / `kimi-k3-code` (the `-code` spelling priced identically, following the K2.7 supplement's own pattern)
- **OpenCode**: uses its db's recorded costs, so K3 was already covered there by construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->