### PR TITLE
Scale Others fold thresholds with the spend period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   in every slug spelling the tools use. The live catalogs win
   automatically once they learn the model.
 
+### Changed
+- **"Others" thresholds scale with the period** — Today and Yesterday
+  fold providers under $1 into the grey Others wedge; 30 Days folds
+  under $5 (was a flat $10 everywhere, which swallowed most of a quiet
+  day's ring). The hover breakdown states the active bar.
+
 ## 0.4.15 — 2026-07-16
 
 ### Added

--- a/src/main.ts
+++ b/src/main.ts
@@ -826,12 +826,18 @@ type DonutEntry = {
   /// Present on the synthetic "Others" entry: the folded-in providers,
   /// largest first, for the hover breakdown.
   parts?: { name: string; w: SpendWindow }[];
+  /// The dollar bar the parts fell under (period-specific).
+  foldLimit?: number;
 };
 
 const OTHERS_ID = "__others__";
 /// Providers under this many dollars (in the visible window) fold into
-/// one "Others" wedge; hovering it lists who spent what.
-const OTHERS_FOLD_USD = 10;
+/// one "Others" wedge; hovering it lists who spent what. The bar scales
+/// with the period — $1 barely registers in a day but $10 would swallow
+/// most of a quiet day's ring, while a month works the other way.
+function othersFoldUsd(tab: SpendTab): number {
+  return tab === "last30" ? 5 : 1;
+}
 
 function donutEntries(tab: SpendTab): DonutEntry[] {
   const all: DonutEntry[] = lastSpend
@@ -852,7 +858,8 @@ function donutEntries(tab: SpendTab): DonutEntry[] {
   // Small spenders fold into a single "Others" wedge — but only when
   // there are at least two of them (a group of one is just a rename) and
   // at least one named provider remains (an all-Others ring says nothing).
-  const small = all.filter((e) => e.w.cost < OTHERS_FOLD_USD);
+  const limit = othersFoldUsd(tab);
+  const small = all.filter((e) => e.w.cost < limit);
   if (small.length < 2 || small.length === all.length) return all;
 
   const others: DonutEntry = {
@@ -866,8 +873,9 @@ function donutEntries(tab: SpendTab): DonutEntry[] {
       models: [],
     },
     parts: small.map((e) => ({ name: e.s.name, w: e.w })),
+    foldLimit: limit,
   };
-  return [...all.filter((e) => e.w.cost >= OTHERS_FOLD_USD), others].sort(
+  return [...all.filter((e) => e.w.cost >= limit), others].sort(
     (a, b) => spendVal(b.w) - spendVal(a.w),
   );
 }
@@ -997,7 +1005,7 @@ function donutPop(g: { a0: number; a1: number }): { tx: string; ty: string } {
 function othersBreakdown(e: DonutEntry): string {
   if (!e.parts) return "";
   return (
-    `Under $${OTHERS_FOLD_USD} each:\n` +
+    `Under $${e.foldLimit ?? 1} each:\n` +
     e.parts.map((p) => `${p.name}  ${fmtSpendVal(p.w)}`).join("\n")
   );
 }


### PR DESCRIPTION
User request: fold under $1 on Today, under $5 on the 30-day view.

The flat $10 bar made sense for a month but swallowed nearly everything on a normal day. `othersFoldUsd(tab)` now returns $1 for Today/Yesterday and $5 for 30 Days; the synthetic Others entry carries its period's bar (`foldLimit`) so the hover tooltip says "Under $1 each:" / "Under $5 each:" to match. Same guard rails as before: no fold with fewer than two small spenders, never an all-Others ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->