### PR TITLE
Route update checks through pane.jazii.dev with anonymous counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **Update checks go through pane.jazii.dev first** (GitHub stays as
+  the automatic fallback, and every update remains signature-verified).
+  The endpoint serves the same manifest and counts anonymous daily
+  installs — distinct-install estimate, country code, app version, and
+  nothing else; no IP addresses are stored. Full mechanics in
+  docs/privacy.md ("The update check").
+
 ## 0.4.16 — 2026-07-16
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,13 @@ vulnerability reporting).
   [docs/providers.md](docs/providers.md) documenting exactly what it
   reads and calls.
 - No telemetry, analytics, or "phone home" code — PRs adding any will be
-  declined regardless of intent. See [docs/privacy.md](docs/privacy.md).
+  declined regardless of intent. The single, deliberate exception is the
+  update check, which counts anonymous daily installs (country-level, no
+  IPs stored) — documented in full in
+  [docs/privacy.md](docs/privacy.md) ("The update check"). That
+  exception is not a precedent: usage data, quotas, and spend never
+  leave the user's PC, and PRs widening what the update check carries
+  will be declined.
 - No new dependencies without a stated reason.
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -124,8 +124,11 @@ pricing keep their measured tokens in the counts, but no dollars are
 ever guessed for them — a ⚠ on the provider's spend row says the real
 cost runs a little higher than shown.
 
-**5. Staying local.** All of the above happens on your machine. There is no
-Pane server, no account, and no telemetry — see [Privacy](#privacy--security).
+**5. Staying local.** All of the above happens on your machine. There is
+no account and no usage telemetry — your quotas, spend, and provider data
+never leave your PC. The only thing counted is the update check every few
+hours: anonymous, country-level, no IPs stored — see
+[Privacy](#privacy--security).
 
 ## Providers (18 and counting)
 
@@ -197,8 +200,9 @@ Pane reads credential files. You should not take our word for how it
 treats them — verify it:
 
 - **[docs/privacy.md](docs/privacy.md)** — the complete list of every
-  network call Pane can make. Zero telemetry: no analytics, no crash
-  reporting, no install pings, none of it exists in the codebase.
+  network call Pane can make. No analytics, no crash reporting, no
+  event tracking; the update check counts anonymous daily installs by
+  country (no IPs stored), and that document explains exactly how.
 - **[docs/providers.md](docs/providers.md)** — per provider: exactly which
   files are read on your PC and exactly which endpoints they're sent to.
 - **[SECURITY.md](SECURITY.md)** — how to report vulnerabilities

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -11,13 +11,37 @@ This is the complete list. Anything not listed here does not happen.
 |---|---|---|
 | Each provider's own API (Anthropic, OpenAI/ChatGPT, cursor.com, GitHub, x.ai, Devin, MiniMax, OpenRouter, Z.ai, Google, DeepSeek, Moonshot, ElevenLabs, Codebuff, Kilo…) | Every refresh (default 1 min), only for providers you have enabled | That provider's own token/key, exactly as its official tool would send it. Full per-provider detail: [providers.md](providers.md) |
 | `raw.githubusercontent.com` (LiteLLM), `models.dev`, `robinebers.github.io` | ~Daily | Anonymous GET for public model price tables (no identifying data) |
-| `github.com/ItsJazii/pane/releases` | On launch + every 4 h | Anonymous GET for the update manifest; the download only happens if you click the update banner |
+| `pane.jazii.dev/api/update` (falls back to `github.com/ItsJazii/pane/releases`) | On launch + every 4 h | Anonymous GET for the update manifest, carrying the app version. See "The update check" below for exactly what this counts. |
 | `127.0.0.1:11434` (your own PC) | Every refresh, if Ollama is enabled | Local-only query of your Ollama server |
 
-Notably absent: analytics, crash reporting, install pings, A/B flags,
-"anonymous usage statistics" — none of it exists in the codebase. The Mac
-app this project was inspired by ships PostHog telemetry (disclosed and
-toggleable); Pane deliberately ports everything **except** that.
+Notably absent: analytics, crash reporting, A/B flags, in-app event
+tracking — none of it exists in the codebase. The Mac app this project
+was inspired by ships PostHog telemetry (disclosed and toggleable); Pane
+deliberately ports everything **except** that.
+
+## The update check
+
+Pane has to ask *somewhere* "is there a newer version?" — that request
+existed from day one. As of 0.4.17 it goes to `pane.jazii.dev` (which
+serves the same signed manifest; GitHub remains the automatic fallback,
+and every update is still signature-verified against the key baked into
+the app). The server counts, per day: **how many distinct installs
+checked in, from which country, on which version.** That's the entire
+list. Concretely:
+
+- **No IP addresses are stored.** Uniqueness comes from a salted one-way
+  hash folded into a [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog)
+  — a counter that can say "≈37 distinct installs today" but is
+  mathematically incapable of listing them.
+- **Country** is the two-letter code the CDN edge derives; nothing
+  finer (no city, no region, no coordinates).
+- **Version** is the `?v=` parameter the updater sends.
+- Nothing else: no machine ids, no usernames, no usage data — your
+  quotas, spend, and provider data never leave your PC, same as always.
+
+The counting code is public in the site repo, and the request itself is
+identical either way — the only thing that changed is who serves the
+manifest first.
 
 ## What stays on your PC
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,7 +32,10 @@
   },
   "plugins": {
     "updater": {
-      "endpoints": ["https://github.com/ItsJazii/pane/releases/latest/download/latest.json"],
+      "endpoints": [
+        "https://pane.jazii.dev/api/update?v={{current_version}}",
+        "https://github.com/ItsJazii/pane/releases/latest/download/latest.json"
+      ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDhDRUI5RUYzRkVBMzlCQ0QKUldUTm02UCs4NTdyalB4dHhyci8wb2dzb1FUQzJpaCt1VWc5dDJCaGpoWlNMTlNlWTF3Z0F4NEEK"
     }
   },


### PR DESCRIPTION
The app-side half of the usage dashboard (the site half is live at pane.jazii.dev).

**What changes:** `tauri.conf.json` updater endpoints become `["https://pane.jazii.dev/api/update?v={{current_version}}", "<github latest.json>"]`. The first endpoint serves the exact same manifest (it proxies GitHub, and 302-redirects to GitHub if anything on the site breaks — the site can never block an update); GitHub stays as the plugin's automatic fallback; signature verification against the baked-in key is untouched.

**What gets counted, exactly:** per UTC day — distinct-install estimate (salted one-way hash into a HyperLogLog; **no IP addresses stored**, the structure cannot enumerate members), two-letter country code (CDN edge header), and app version (`?v=`). Nothing else exists to count: no machine ids, no usage data, no quotas/spend — those never leave the PC, as always.

**Honesty pass on the docs:** the old "no install pings, none of it exists in the codebase" claim would have become false, so it's rewritten rather than lawyered: docs/privacy.md gains a "The update check" section describing the mechanism in full (including what a HyperLogLog can and cannot reveal), the network-call table row is updated, and both README privacy mentions now say plainly that anonymous daily installs are counted by country.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->