### PR TITLE
Stamp the real version into the update endpoint in Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Update checks report the real app version** — Tauri's
+  `{{current_version}}` URL template arrives percent-encoded and never
+  substitutes in query strings, so 0.4.17 installs literally sent
+  "currentversion". The endpoint URL is now built in Rust with the
+  actual version stamped in.
+
 ## 0.4.17 — 2026-07-17
 
 ### Changed

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -762,12 +762,36 @@ async fn codex_redeem_credit(credit_id: String) -> Result<String, String> {
     providers::codex::redeem_credit(&credit_id).await
 }
 
+/// Updater with the app version stamped into the endpoint by us. Tauri's
+/// `{{current_version}}` template arrives percent-encoded and never gets
+/// substituted in query strings, so 0.4.17 installs literally reported
+/// "?v={{current_version}}" — the version is now formatted in Rust.
+/// GitHub stays as the automatic fallback; the pubkey comes from config.
+fn build_updater(
+    app: &tauri::AppHandle,
+) -> Result<tauri_plugin_updater::Updater, String> {
+    use tauri_plugin_updater::UpdaterExt;
+    let version = app.package_info().version.to_string();
+    let endpoints = vec![
+        format!("https://pane.jazii.dev/api/update?v={version}")
+            .parse()
+            .map_err(|e| format!("endpoint parse: {e}"))?,
+        "https://github.com/ItsJazii/pane/releases/latest/download/latest.json"
+            .parse()
+            .map_err(|e| format!("endpoint parse: {e}"))?,
+    ];
+    app.updater_builder()
+        .endpoints(endpoints)
+        .map_err(|e| e.to_string())?
+        .build()
+        .map_err(|e| e.to_string())
+}
+
 /// Downloads and installs a pending update, then restarts the app. Only
 /// called from the frontend banner after check_for_update announced one.
 #[tauri::command]
 async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
-    use tauri_plugin_updater::UpdaterExt;
-    let updater = app.updater().map_err(|e| e.to_string())?;
+    let updater = build_updater(&app)?;
     match updater.check().await.map_err(|e| e.to_string())? {
         Some(update) => {
             update
@@ -788,8 +812,7 @@ async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
 /// shows an Update button when this returns a newer version.
 #[tauri::command]
 async fn check_update(app: tauri::AppHandle) -> Result<Option<String>, String> {
-    use tauri_plugin_updater::UpdaterExt;
-    let updater = app.updater().map_err(|e| e.to_string())?;
+    let updater = build_updater(&app)?;
     updater
         .check()
         .await
@@ -803,9 +826,8 @@ async fn check_update(app: tauri::AppHandle) -> Result<Option<String>, String> {
 fn spawn_update_checker(app: &tauri::AppHandle) {
     let handle = app.clone();
     tauri::async_runtime::spawn(async move {
-        use tauri_plugin_updater::UpdaterExt;
         loop {
-            if let Ok(updater) = handle.updater() {
+            if let Ok(updater) = build_updater(&handle) {
                 match updater.check().await {
                     Ok(Some(update)) => {
                         let _ = handle.emit("update-available", update.version.clone());


### PR DESCRIPTION
The dashboard's version column showed `currentversion` for every real 0.4.17 install: Tauri parses the endpoint into a `Url` (percent-encoding `{{ }}` to `%7B%7B %7D%7D`) before the `{{current_version}}` string replacement runs, so query-string templates never substitute and the literal template ships.

Fix: new `build_updater()` constructs the updater via `updater_builder().endpoints(...)` with the endpoint formatted in Rust from `app.package_info().version` — no template involved. All three call sites (banner install, popover check, 4-hour background checker) route through it. GitHub stays the automatic fallback; the signature pubkey still comes from config; the config endpoints remain as inert defaults.

Site-side (already deployed): the endpoint permanently maps `currentversion` → `0.4.17`, which is exact — 0.4.17 is the only release that ever shipped the broken template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->