### PR TITLE
Label OpenCode Go meters "this PC only"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **OpenCode Go meters say "this PC only"** — Go quotas are counted
+  account-wide on OpenCode's servers, and there is no API to read
+  them; the local meters can't see other devices or other participants
+  on a shared subscription, and now say so instead of "local estimate".
+
 ## 0.4.18 — 2026-07-17
 
 ### Fixed

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -62,8 +62,13 @@ Ground rules that apply to every provider:
 - **Reads:** `%USERPROFILE%\.local\share\opencode\opencode.db` (copied
   before reading) — message costs your own OpenCode history already
   contains.
-- **Calls:** nothing — OpenCode has no public usage API yet; usage is
-  computed locally against documented plan limits.
+- **Calls:** nothing — OpenCode has no public usage API (the gateway
+  exposes only inference routes); usage is computed locally against
+  documented plan limits. **The meters say "this PC only" because they
+  are:** Go quotas are counted account-wide on OpenCode's servers, so
+  usage from your other devices or from other participants on a shared
+  subscription can't appear here. The Console quick-link shows the
+  account-wide truth.
 
 ## GitHub Copilot
 

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -91,17 +91,17 @@ fn fetch() -> Result<Snapshot, String> {
         Metric::progress(
             "Session",
             session / SESSION_LIMIT * 100.0,
-            Some(format!("${session:.2} of ${SESSION_LIMIT:.0} · local estimate")),
+            Some(format!("${session:.2} of ${SESSION_LIMIT:.0} · this PC only")),
         ),
         Metric::progress(
             "Weekly",
             weekly / WEEKLY_LIMIT * 100.0,
-            Some(format!("${weekly:.2} of ${WEEKLY_LIMIT:.0} · local estimate")),
+            Some(format!("${weekly:.2} of ${WEEKLY_LIMIT:.0} · this PC only")),
         ),
         Metric::progress(
             "Monthly",
             monthly / MONTHLY_LIMIT * 100.0,
-            Some(format!("${monthly:.2} of ${MONTHLY_LIMIT:.0} · local estimate")),
+            Some(format!("${monthly:.2} of ${MONTHLY_LIMIT:.0} · this PC only")),
         ),
     ];
     Ok(Snapshot::ok(ID, NAME, Some("Go".into()), metrics))


### PR DESCRIPTION
User report: the OpenCode console showed sliding 100% / weekly 45% while Pane showed 10% / 6%.

Root cause is a blind spot, not a bug: Pane's Go meters sum this machine's `opencode.db` — and the machine's log matched Pane exactly ($1.15 in the sliding window, all glm-5.2). The quota-burning usage (Hermes) happened on another device or another participant of the shared Go subscription, which OpenCode counts account-wide server-side. Verified against the opencode source (anomalyco/opencode): the console reads its own server DB via session-authed server functions, and the Go gateway exposes only `chat/completions` / `messages` / `models` — **no usage endpoint an API key could query**, so the account truth is unreachable today.

Change: the meters' detail now reads `$X of $Y · this PC only` (was "local estimate"), and docs/providers.md explains exactly why other devices/participants can't appear. If OpenCode ever ships a usage API, these meters switch to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->