### PR TITLE
Release 0.4.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased
+## 0.4.19 — 2026-07-18
+
+### Added
+- **Grok usage bar shows its reset countdown** — the aggregate credit
+  meter now carries the billing period's real end time and duration,
+  so it paces and counts down like the other cards. Contributed by
+  @JaminYe — Pane's first outside contribution. 🎉
 
 ### Changed
 - **OpenCode Go meters say "this PC only"** — Go quotas are counted

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.18"
+version = "0.4.19"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to **0.4.19** (tauri.conf.json, package.json, Cargo.toml + lock) and changelog:

- **Grok usage bar shows its reset countdown** (#80) — billing-period end time + duration on the aggregate meter; Pane's first outside contribution, thanks @JaminYe 🎉
- **OpenCode Go meters say "this PC only"** (#79) — honest labeling of the local-estimate blind spot

After merge: tag `v0.4.19` and CI builds/signs/publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->