### PR TITLE
Fix Grok card showing Outdated after every weekly reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Grok no longer shows "Outdated" right after its weekly reset** —
+  xAI's billing API omits the usage-percent field entirely while usage
+  is 0%, which Pane misread as a broken response and kept showing last
+  week's 100%-used bar with an ⚠ Outdated tag. A fresh window with no
+  usage now correctly renders as a 0% bar with the new reset countdown.
+
 ## 0.4.20 — 2026-07-18
 
 ### Fixed

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -141,10 +141,7 @@ async fn fetch() -> Result<Snapshot, String> {
     let billing: Value = billing_resp.json().await.map_err(|e| format!("billing parse: {e}"))?;
 
     let mut metrics = Vec::new();
-    if let Some(used) = billing
-        .pointer("/config/creditUsagePercent")
-        .and_then(Value::as_f64)
-    {
+    if let Some(used) = credit_usage_percent(&billing) {
         let (resets_at, period_ms) = current_period_window(&billing);
         metrics.push(Metric::progress("Usage", used, None).with_reset(resets_at, period_ms));
     }
@@ -185,6 +182,17 @@ async fn fetch() -> Result<Snapshot, String> {
     }
 
     Ok(Snapshot::ok(ID, NAME, plan, metrics))
+}
+
+/// Usage percent for the current billing window. proto3-as-JSON omits
+/// zero-valued fields, so a fresh window reports 0% used by *omitting*
+/// creditUsagePercent entirely — with a currentPeriod present, that absence
+/// is an explicit "nothing used yet", not an unknown response shape.
+fn credit_usage_percent(billing: &Value) -> Option<f64> {
+    billing
+        .pointer("/config/creditUsagePercent")
+        .and_then(Value::as_f64)
+        .or_else(|| billing.pointer("/config/currentPeriod").map(|_| 0.0))
 }
 
 /// The aggregate quota resets at the end of the provider-reported current
@@ -241,5 +249,56 @@ fn collect_billing_metrics(node: &Value, parent_key: &str, metrics: &mut Vec<Met
             }
         }
         _ => {}
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact shape xAI returns right after a weekly rollover (captured
+    /// live 2026-07-19): zero usage means creditUsagePercent is omitted.
+    fn rollover_billing() -> Value {
+        serde_json::json!({
+            "config": {
+                "currentPeriod": {
+                    "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                    "start": "2026-07-19T11:17:21.044357+00:00",
+                    "end": "2026-07-26T11:17:21.044357+00:00"
+                },
+                "onDemandCap": { "val": 0 },
+                "onDemandUsed": { "val": 0 },
+                "isUnifiedBillingUser": true,
+                "prepaidBalance": { "val": 0 },
+                "billingPeriodStart": "2026-07-19T11:17:21.044357+00:00",
+                "billingPeriodEnd": "2026-07-26T11:17:21.044357+00:00"
+            }
+        })
+    }
+
+    #[test]
+    fn omitted_percent_with_period_is_zero_usage() {
+        assert_eq!(credit_usage_percent(&rollover_billing()), Some(0.0));
+    }
+
+    #[test]
+    fn explicit_percent_wins() {
+        let mut billing = rollover_billing();
+        billing["config"]["creditUsagePercent"] = Value::from(37.5);
+        assert_eq!(credit_usage_percent(&billing), Some(37.5));
+    }
+
+    #[test]
+    fn no_config_stays_unknown_shape() {
+        assert_eq!(credit_usage_percent(&serde_json::json!({})), None);
+        assert_eq!(credit_usage_percent(&serde_json::json!({ "config": {} })), None);
+    }
+
+    #[test]
+    fn rollover_still_reports_reset_window() {
+        let (resets_at, period_ms) = current_period_window(&rollover_billing());
+        assert!(resets_at.is_some());
+        assert_eq!(period_ms, Some(7 * 24 * 3_600_000));
     }
 }


### PR DESCRIPTION
## What

The Grok card sat on "⚠ Outdated" (showing last week's 100%-used bar) from every weekly reset until the first Grok request of the new week.

## Why

xAI's billing endpoint serializes proto3 to JSON, which **omits zero-valued fields**: right after a rollover the response carries a valid `config.currentPeriod` but no `config.creditUsagePercent` at all (0% → field dropped). Pane found no percent anywhere, declared "unexpected billing response shape", and served the stale snapshot.

The same quirk was already handled for `onDemandCap` a few lines down — the usage percent never got the same treatment.

## Fix

`credit_usage_percent()`: an omitted percent alongside a valid `currentPeriod` now reads as an explicit **0% used**; a response with no config at all still errors as an unknown shape. Regression tests use the rollover JSON captured live from a real account today (2026-07-19).

Verified on a local build: card went from stale "100% / Outdated" to a fresh 0% bar with the correct Jul 26 reset countdown on the first refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/84" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->