### PR TITLE
Hermes desktop spend + models.dev completeness fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Hermes desktop spend** — Pane now reads the local usage ledger of
+  Nous Research's Hermes app (`%LOCALAPPDATA%\hermes\state.db`, this PC
+  only, nothing sent anywhere). Each session is filed under the backend
+  that actually billed it: MiniMax-routed chats merge into the MiniMax
+  spend slice, OpenRouter-routed into OpenRouter, and anything else shows
+  as a Hermes slice.
+
+### Fixed
+- **Kimi K3 cache reads were overpriced ~10×** — models.dev lists the
+  same model under many resellers and Pane took the alphabetically first
+  entry, which for kimi-k3 was a stub with no cache pricing; cache hits
+  then defaulted to the full $3.00 input rate instead of $0.30. The
+  catalog entry with the most complete pricing wins now.
+
 ## 0.4.22 — 2026-07-20
 
 ### Changed

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -146,6 +146,17 @@ Ground rules that apply to every provider:
   notification); Moonshot adds Today / Yesterday / 30-day spend, model
   breakdown, and the usage trend from Kimi Code sessions.
 
+## Hermes (spend only — no card)
+
+- **Reads:** the Hermes desktop app's local ledger
+  (`%LOCALAPPDATA%\hermes\state.db`, `session_model_usage` table — model,
+  billing route, token buckets, and the app's own cost per session).
+- **Calls:** nothing. This is a purely local spend source.
+- **Shows:** each session's tokens/cost in the Total Spend donut under
+  the backend that billed it — MiniMax-routed sessions join the MiniMax
+  slice, OpenRouter-routed join OpenRouter, anything else appears as a
+  Hermes slice.
+
 ## Ollama
 
 - **Reads:** nothing.

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -198,24 +198,38 @@ fn parse_litellm(doc: &Value) -> HashMap<String, Price> {
 }
 
 fn parse_modelsdev(doc: &Value) -> HashMap<String, Price> {
-    let mut out = HashMap::new();
-    let Some(providers) = doc.as_object() else { return out };
+    // models.dev repeats ids across resellers with varying completeness —
+    // the entry documenting the most cache fields wins (ties: first seen),
+    // so a reseller stub with no cache rates can't default a $0.30 cache
+    // hit to the $3.00 input price.
+    let mut out: HashMap<String, (Price, u8)> = HashMap::new();
+    let Some(providers) = doc.as_object() else { return HashMap::new() };
     for provider in providers.values() {
         let Some(models) = provider.get("models").and_then(Value::as_object) else { continue };
         for (id, m) in models {
             let Some(cost) = m.get("cost") else { continue };
             let get = |key: &str| cost.get(key).and_then(Value::as_f64);
             let (Some(input), Some(output)) = (get("input"), get("output")) else { continue };
-            // First provider wins; models.dev repeats ids across resellers.
-            out.entry(id.clone()).or_insert(Price::flat(
+            let score =
+                get("cache_read").is_some() as u8 + get("cache_write").is_some() as u8;
+            let price = Price::flat(
                 input,
                 output,
                 get("cache_read").unwrap_or(input),
                 get("cache_write").unwrap_or(input),
-            ));
+            );
+            match out.entry(id.clone()) {
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert((price, score));
+                }
+                std::collections::hash_map::Entry::Occupied(mut e) if score > e.get().1 => {
+                    e.insert((price, score));
+                }
+                _ => {}
+            }
         }
     }
-    out
+    out.into_iter().map(|(k, (p, _))| (k, p)).collect()
 }
 
 fn apply_supplement(store: &mut Store, doc: &Value) {
@@ -521,6 +535,22 @@ mod tests {
 
     fn usage(input: f64, output: f64, cache_read: f64, w5m: f64, w1h: f64) -> Usage {
         Usage { input, output, cache_read, cache_write_5m: w5m, cache_write_1h: w1h }
+    }
+
+    #[test]
+    fn modelsdev_prefers_the_most_complete_reseller_entry() {
+        // A stub reseller listing kimi-k3 without cache rates must not
+        // shadow a complete entry (alphabetical order made "aaa" win before,
+        // silently pricing $0.30 cache hits at the $3.00 input rate).
+        let doc = serde_json::json!({
+            "aaa-stub": { "models": { "kimi-k3": { "cost": { "input": 3.0, "output": 15.0 } } } },
+            "moonshotai": { "models": { "kimi-k3": {
+                "cost": { "input": 3.0, "output": 15.0, "cache_read": 0.3, "cache_write": 3.0 }
+            } } },
+        });
+        let map = super::parse_modelsdev(&doc);
+        let p = map.get("kimi-k3").expect("kimi-k3 parsed");
+        assert_eq!((p.input, p.output, p.cache_read, p.cache_write), (3.0, 15.0, 0.3, 3.0));
     }
 
     #[test]

--- a/src-tauri/src/providers/hermes.rs
+++ b/src-tauri/src/providers/hermes.rs
@@ -1,0 +1,105 @@
+//! Hermes desktop (Nous Research) — spend source only, no provider card.
+//!
+//! Hermes keeps a local ledger at %LOCALAPPDATA%\hermes\state.db: the
+//! `session_model_usage` table has one row per (session, model, billing
+//! route) with cumulative token buckets, the app's own cost fields, and
+//! first/last-seen stamps. Hermes can route the same chat through several
+//! backends (MiniMax OAuth, OpenRouter, …), so each row carries the
+//! billing provider — the spend scanner uses it to file tokens under the
+//! provider that actually served them.
+
+use super::minimax::{file_stamp, snapshot_db, FileStamp};
+
+#[derive(Clone)]
+pub struct HermesUsage {
+    pub ts_ms: i64,
+    pub model: String,
+    pub billing_provider: String,
+    pub input: f64,
+    pub output: f64,
+    pub reasoning: f64,
+    pub cache_read: f64,
+    pub cache_write: f64,
+    /// The app's own cost when it knows one (actual preferred over
+    /// estimated); 0.0 means "price it from the catalog".
+    pub cost_usd: f64,
+}
+
+fn state_db_path() -> Option<std::path::PathBuf> {
+    dirs::data_local_dir().map(|d| d.join("hermes").join("state.db"))
+}
+
+/// Per-session-per-model usage from Hermes's local store. Cached on the
+/// (db, WAL) stamps; a busy/locked db serves the last good events.
+pub fn collect_usage_events() -> Vec<HermesUsage> {
+    use std::sync::Mutex;
+    static CACHE: Mutex<Option<(FileStamp, FileStamp, Vec<HermesUsage>)>> = Mutex::new(None);
+
+    let Some(db_path) = state_db_path() else { return Vec::new() };
+    if !db_path.exists() {
+        return Vec::new();
+    }
+    let db_stamp = file_stamp(&db_path);
+    let wal_stamp = file_stamp(&db_path.with_extension("db-wal"));
+
+    if let Ok(cache) = CACHE.lock() {
+        if let Some((d, w, events)) = cache.as_ref() {
+            if *d == db_stamp && *w == wal_stamp {
+                return events.clone();
+            }
+        }
+    }
+
+    let tmp_base = std::env::temp_dir().join(format!("pane-hermes-{}", std::process::id()));
+    let tmp_db = tmp_base.with_extension("db");
+    let events = snapshot_db(&db_path, &tmp_db).and_then(|()| read_usage_events(&tmp_db));
+    for suffix in ["db", "db-wal", "db-shm"] {
+        let _ = std::fs::remove_file(tmp_base.with_extension(suffix));
+    }
+
+    match events {
+        Ok(events) => {
+            if let Ok(mut cache) = CACHE.lock() {
+                *cache = Some((db_stamp, wal_stamp, events.clone()));
+            }
+            events
+        }
+        Err(_) => CACHE
+            .lock()
+            .ok()
+            .and_then(|c| c.as_ref().map(|(_, _, e)| e.clone()))
+            .unwrap_or_default(),
+    }
+}
+
+fn read_usage_events(db: &std::path::Path) -> Result<Vec<HermesUsage>, String> {
+    let conn = rusqlite::Connection::open(db).map_err(|e| format!("open db copy: {e}"))?;
+    // last_seen/first_seen are epoch seconds as REAL; costs may be NULL.
+    let mut stmt = conn
+        .prepare(
+            "SELECT last_seen, model, billing_provider,
+                    input_tokens, output_tokens, reasoning_tokens,
+                    cache_read_tokens, cache_write_tokens,
+                    COALESCE(actual_cost_usd, 0.0), COALESCE(estimated_cost_usd, 0.0)
+             FROM session_model_usage",
+        )
+        .map_err(|e| format!("query session_model_usage: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            let actual: f64 = row.get(8).unwrap_or(0.0);
+            let estimated: f64 = row.get(9).unwrap_or(0.0);
+            Ok(HermesUsage {
+                ts_ms: (row.get::<_, f64>(0).unwrap_or(0.0) * 1000.0) as i64,
+                model: row.get::<_, String>(1).unwrap_or_default(),
+                billing_provider: row.get::<_, String>(2).unwrap_or_default(),
+                input: row.get::<_, f64>(3).unwrap_or(0.0),
+                output: row.get::<_, f64>(4).unwrap_or(0.0),
+                reasoning: row.get::<_, f64>(5).unwrap_or(0.0),
+                cache_read: row.get::<_, f64>(6).unwrap_or(0.0),
+                cache_write: row.get::<_, f64>(7).unwrap_or(0.0),
+                cost_usd: if actual > 0.0 { actual } else { estimated },
+            })
+        })
+        .map_err(|e| format!("read session_model_usage: {e}"))?;
+    Ok(rows.flatten().collect())
+}

--- a/src-tauri/src/providers/minimax.rs
+++ b/src-tauri/src/providers/minimax.rs
@@ -198,9 +198,9 @@ fn agent_db_path() -> Option<std::path::PathBuf> {
     dirs::home_dir().map(|h| h.join(".minimax").join("sqlite.db"))
 }
 
-type FileStamp = (std::time::SystemTime, u64);
+pub(crate) type FileStamp = (std::time::SystemTime, u64);
 
-fn file_stamp(path: &std::path::Path) -> FileStamp {
+pub(crate) fn file_stamp(path: &std::path::Path) -> FileStamp {
     std::fs::metadata(path)
         .map(|m| (m.modified().unwrap_or(std::time::UNIX_EPOCH), m.len()))
         .unwrap_or((std::time::UNIX_EPOCH, 0))
@@ -251,7 +251,7 @@ pub fn collect_usage_events() -> Vec<UsageEvent> {
 
 /// Consistent point-in-time copy via SQLite's backup API (reads through the
 /// WAL with proper locks, retrying briefly while the writer is busy).
-fn snapshot_db(src_path: &std::path::Path, dst_path: &std::path::Path) -> Result<(), String> {
+pub(crate) fn snapshot_db(src_path: &std::path::Path, dst_path: &std::path::Path) -> Result<(), String> {
     let _ = std::fs::remove_file(dst_path);
     let src = rusqlite::Connection::open_with_flags(
         src_path,

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -8,6 +8,7 @@ pub mod deepseek;
 pub mod devin;
 pub mod elevenlabs;
 pub mod grok;
+pub mod hermes;
 pub mod kilo;
 pub mod minimax;
 pub mod moonshot;

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -558,6 +558,62 @@ fn minimax(extra: FileData) -> ProviderSpend {
     build_spend("minimax", "MiniMax", data)
 }
 
+/// Which spend slice a Hermes row belongs to. Hermes (Nous Research's
+/// desktop agent) routes chats through whichever backend the user connected,
+/// so its ledger rows are filed under the provider that actually billed
+/// them; routes Pane has no slice for stay under Hermes's own name.
+fn hermes_bucket(billing_provider: &str) -> (&'static str, &'static str) {
+    let lower = billing_provider.to_lowercase();
+    if lower.contains("minimax") {
+        ("minimax", "MiniMax")
+    } else if lower.contains("openrouter") {
+        ("openrouter", "OpenRouter")
+    } else {
+        ("hermes", "Hermes")
+    }
+}
+
+/// Hermes spend, grouped per target slice. Rows are cumulative per
+/// (session, model, route) — the app updates them in place while a session
+/// runs — so every refresh rebuilds from the full table instead of
+/// accumulating deltas. The whole session lands on its last-active day.
+fn hermes() -> Vec<(&'static str, &'static str, FileData)> {
+    let mut buckets: Vec<(&'static str, &'static str, FileData)> = Vec::new();
+    for ev in providers::hermes::collect_usage_events() {
+        let Some(ts) = DateTime::from_timestamp_millis(ev.ts_ms) else { continue };
+        let tokens = ev.input + ev.output + ev.reasoning + ev.cache_read + ev.cache_write;
+        if tokens <= 0.0 && ev.cost_usd <= 0.0 {
+            continue;
+        }
+        let (id, name) = hermes_bucket(&ev.billing_provider);
+        let data = match buckets.iter_mut().find(|(bid, _, _)| *bid == id) {
+            Some((_, _, data)) => data,
+            None => {
+                buckets.push((id, name, FileData::default()));
+                &mut buckets.last_mut().unwrap().2
+            }
+        };
+        if ev.cost_usd > 0.0 {
+            add_event(data, ts, &ev.model, ev.cost_usd, tokens);
+            continue;
+        }
+        match pricing::lookup(&ev.model) {
+            Some(p) => {
+                let u = pricing::Usage {
+                    input: ev.input,
+                    output: ev.output + ev.reasoning,
+                    cache_read: ev.cache_read,
+                    cache_write_5m: ev.cache_write,
+                    cache_write_1h: 0.0,
+                };
+                add_event(data, ts, &ev.model, pricing::request_cost(&p, &u, true), tokens);
+            }
+            None => note_unpriced(data, ts, &ev.model, tokens),
+        }
+    }
+    buckets
+}
+
 /// One `token_count` usage object, tolerating the older field spellings
 /// (`prompt_tokens`, `cache_read_input_tokens`, …) the Mac scanner accepts.
 #[derive(Clone, PartialEq)]
@@ -1231,6 +1287,17 @@ mod tests {
         d.days.values().map(|v| v.0).sum()
     }
 
+    // ---- Hermes: billing-route buckets -----------------------------------
+
+    #[test]
+    fn hermes_routes_land_in_the_right_slice() {
+        assert_eq!(hermes_bucket("minimax-oauth").0, "minimax");
+        assert_eq!(hermes_bucket("MiniMax").0, "minimax");
+        assert_eq!(hermes_bucket("openrouter").0, "openrouter");
+        assert_eq!(hermes_bucket("nous-api").0, "hermes");
+        assert_eq!(hermes_bucket("").0, "hermes");
+    }
+
     // ---- Codex: child-session replay gate --------------------------------
 
     #[test]
@@ -1569,7 +1636,17 @@ fn split_csv_row(line: &str) -> Vec<String> {
 
 pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
     pricing::ensure_fresh();
-    let (claude_sp, minimax_extra) = claude();
+    let (claude_sp, mut minimax_extra) = claude();
+    // Hermes rows going to an existing slice merge into it (MiniMax via the
+    // extra-data path); the rest become their own spend entries.
+    let mut hermes_rest = Vec::new();
+    for (id, name, data) in hermes() {
+        if id == "minimax" {
+            merge_data(&mut minimax_extra, data);
+        } else {
+            hermes_rest.push(build_spend(id, name, data));
+        }
+    }
     let mut list = vec![
         claude_sp,
         codex(),
@@ -1579,6 +1656,7 @@ pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
         minimax(minimax_extra),
         moonshot(),
     ];
+    list.extend(hermes_rest);
     if let Some(csv) = cursor_csv {
         list.push(cursor_from_csv(&csv));
     }

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -606,7 +606,10 @@ fn hermes() -> Vec<(&'static str, &'static str, FileData)> {
                     cache_write_5m: ev.cache_write,
                     cache_write_1h: 0.0,
                 };
-                add_event(data, ts, &ev.model, pricing::request_cost(&p, &u, true), tokens);
+                // Rows aggregate a whole session's requests, so no single
+                // request can be proven long-context — stay on base rates
+                // (same reasoning as the Cursor CSV scanner).
+                add_event(data, ts, &ev.model, pricing::request_cost(&p, &u, false), tokens);
             }
             None => note_unpriced(data, ts, &ev.model, tokens),
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -256,6 +256,7 @@ const SPEND_COLORS: Record<string, string> = {
   devin: "#38bdf8",
   cursor: "var(--spend-cursor)", // brand black, theme-flipped in CSS
   moonshot: "#e0b354", // moon gold
+  hermes: "#c2a878", // Nous tan
   __others__: "#8b8b94", // the folded small-spenders wedge
 };
 


### PR DESCRIPTION
## Hermes desktop spend

Nous Research's Hermes app keeps a per-session usage ledger in `%LOCALAPPDATA%\hermes\state.db` (`session_model_usage`: model, billing route, token buckets, the app's own cost fields). Pane now scans it with the same SQLite snapshot + (db, WAL) stamp-cache machinery as the MiniMax CLI store — purely local, no network calls, documented in docs/providers.md.

Rows are filed under the backend that actually billed them: `minimax-*` routes merge into the existing MiniMax spend slice, `openrouter` into OpenRouter, anything else renders as a "Hermes" slice.

## models.dev completeness fix

models.dev repeats model ids across resellers and Pane took the alphabetically first entry. For kimi-k3 that was a stub with no cache pricing, so cache reads defaulted to the $3.00 input rate instead of the documented $0.30 (~10x overpriced). The entry with the most cache fields wins now (ties keep first seen). Regression tests for both changes.

Verified on a local build: a real Hermes MiniMax-M3 session (175k tokens) appears in the MiniMax slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/88" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->