### PR TITLE
Persist the spend engine's parse cache across launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Changed
+- **Instant startup for the spend engine** — per-file parse summaries now
+  persist across launches (`%APPDATA%\Pane\spend_cache.json`, a few MB at
+  most), so a fresh start re-parses only logs that changed instead of
+  re-reading every session file ever written. The cache is discarded
+  whenever the pricing catalogs update, so costs are never served stale.
+
 ### Added
 - **Hermes desktop spend** — Pane now reads the local usage ledger of
   Nous Research's Hermes app (`%LOCALAPPDATA%\hermes\state.db`, this PC

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -155,6 +155,32 @@ pub fn generation() -> u64 {
     GENERATION.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// Stable fingerprint of the on-disk catalog files. The persistent spend
+/// cache stores costs priced under a specific catalog set; when any catalog
+/// file changes (a refresh rewrote it), the stamp changes and the whole
+/// persisted cache is discarded rather than served with stale prices.
+pub fn catalog_stamp() -> String {
+    SOURCES
+        .iter()
+        .map(|(source, _)| {
+            let path = dir().join(format!("{source}.json"));
+            match std::fs::metadata(&path) {
+                Ok(m) => {
+                    let ms = m
+                        .modified()
+                        .ok()
+                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                        .map(|d| d.as_millis())
+                        .unwrap_or(0);
+                    format!("{source}:{ms}:{}", m.len())
+                }
+                Err(_) => format!("{source}:absent"),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
 fn dir() -> PathBuf {
     providers::config_dir().join("pricing")
 }

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -86,6 +86,127 @@ fn cache() -> &'static Mutex<HashMap<PathBuf, FileEntry>> {
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+// ---------------------------------------------------------------------------
+// Persistent parse cache. The per-file summaries above are tiny (a few
+// day/model totals per file) but rebuilding them means re-reading every
+// session log ever written — thousands of files, growing forever. Saving
+// the summaries to disk makes a fresh launch re-parse only files that
+// changed since the last run. The cache is only trusted when it was priced
+// under the exact catalog files currently on disk (pricing::catalog_stamp);
+// any mismatch, version bump, or parse error discards it wholesale — a
+// stale-price cache is worse than a slow first scan.
+// ---------------------------------------------------------------------------
+
+const PERSIST_VERSION: u32 = 1;
+
+/// Set when any file was (re)parsed this run — nothing changed, nothing saved.
+static CACHE_DIRTY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Paths seen by file_days() this collect() run. Entries for paths nobody
+/// scanned anymore (deleted logs, disabled providers) are dropped on save,
+/// so the cache can't grow without bound.
+fn touched() -> &'static Mutex<HashSet<PathBuf>> {
+    static TOUCHED: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+    TOUCHED.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PersistEntry {
+    path: PathBuf,
+    /// mtime at full filesystem precision (NTFS is 100ns) — millisecond
+    /// rounding would break the equality check and re-parse everything.
+    mtime_secs: u64,
+    mtime_nanos: u32,
+    size: u64,
+    days: Vec<(i32, String, f64, f64)>,
+    unpriced: Vec<(String, u64)>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PersistFile {
+    version: u32,
+    pricing_stamp: String,
+    entries: Vec<PersistEntry>,
+}
+
+fn persist_path() -> PathBuf {
+    providers::config_dir().join("spend_cache.json")
+}
+
+/// Loads the persisted cache into the in-memory map, once per app run.
+/// Runs after pricing::ensure_fresh() so the stamp reflects any catalog
+/// download that just happened — in which case it mismatches and the
+/// persisted costs are correctly thrown away.
+fn load_persisted_cache() {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        let Ok(raw) = fs::read_to_string(persist_path()) else { return };
+        let Ok(doc) = serde_json::from_str::<PersistFile>(&raw) else { return };
+        if doc.version != PERSIST_VERSION || doc.pricing_stamp != pricing::catalog_stamp() {
+            return;
+        }
+        let gen = pricing::generation();
+        let Ok(mut map) = cache().lock() else { return };
+        for e in doc.entries {
+            let mtime = SystemTime::UNIX_EPOCH
+                + std::time::Duration::new(e.mtime_secs, e.mtime_nanos);
+            let mut data = FileData::default();
+            for (day, model, cost, tokens) in e.days {
+                data.days.insert((day, model), (cost, tokens));
+            }
+            data.unpriced = e.unpriced.into_iter().collect();
+            map.insert(e.path, FileEntry { mtime, size: e.size, gen, data });
+        }
+    });
+}
+
+/// Writes the cache back to disk (atomically, via temp + rename) when this
+/// run parsed anything new. Only entries that are current — touched this
+/// run and priced under the live catalog generation — are persisted.
+fn save_persisted_cache() {
+    let dirty = CACHE_DIRTY.swap(false, std::sync::atomic::Ordering::Relaxed);
+    let path = persist_path();
+    if !dirty && path.exists() {
+        return;
+    }
+    let gen = pricing::generation();
+    let Ok(touched_set) = touched().lock() else { return };
+    let Ok(map) = cache().lock() else { return };
+    let entries: Vec<PersistEntry> = map
+        .iter()
+        .filter(|(p, e)| e.gen == gen && touched_set.contains(*p))
+        .map(|(p, e)| {
+            let d = e
+                .mtime
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default();
+            PersistEntry {
+                path: p.clone(),
+                mtime_secs: d.as_secs(),
+                mtime_nanos: d.subsec_nanos(),
+                size: e.size,
+                days: e
+                    .data
+                    .days
+                    .iter()
+                    .map(|((day, model), (cost, tokens))| (*day, model.clone(), *cost, *tokens))
+                    .collect(),
+                unpriced: e.data.unpriced.iter().map(|(m, c)| (m.clone(), *c)).collect(),
+            }
+        })
+        .collect();
+    let doc = PersistFile {
+        version: PERSIST_VERSION,
+        pricing_stamp: pricing::catalog_stamp(),
+        entries,
+    };
+    let Ok(json) = serde_json::to_string(&doc) else { return };
+    let tmp = path.with_extension("json.tmp");
+    if fs::write(&tmp, json).is_ok() {
+        let _ = fs::rename(&tmp, &path);
+    }
+}
+
 fn day_of_utc(ts: DateTime<Utc>) -> i32 {
     ts.with_timezone(&Local).date_naive().num_days_from_ce()
 }
@@ -218,6 +339,9 @@ fn file_days(path: &Path, parse: &mut dyn FnMut(&str, &mut FileData)) -> FileDat
     let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
     let size = meta.len();
 
+    if let Ok(mut t) = touched().lock() {
+        t.insert(path.to_path_buf());
+    }
     let gen = pricing::generation();
     if let Ok(map) = cache().lock() {
         if let Some(entry) = map.get(path) {
@@ -237,6 +361,7 @@ fn file_days(path: &Path, parse: &mut dyn FnMut(&str, &mut FileData)) -> FileDat
     if let Ok(mut map) = cache().lock() {
         map.insert(path.to_path_buf(), FileEntry { mtime, size, gen, data: data.clone() });
     }
+    CACHE_DIRTY.store(true, std::sync::atomic::Ordering::Relaxed);
     data
 }
 
@@ -1290,6 +1415,39 @@ mod tests {
         d.days.values().map(|v| v.0).sum()
     }
 
+    // ---- Persistent cache: serialization roundtrip -----------------------
+
+    #[test]
+    fn persist_file_roundtrips_losslessly() {
+        let doc = PersistFile {
+            version: PERSIST_VERSION,
+            pricing_stamp: "litellm:1:2|modelsdev:3:4|supplement:5:6".into(),
+            entries: vec![PersistEntry {
+                path: PathBuf::from(r"C:\logs\session.jsonl"),
+                mtime_secs: 1_784_600_000,
+                mtime_nanos: 123_456_700, // NTFS 100ns precision must survive
+                size: 4096,
+                days: vec![(739_000, "claude-fable-5".into(), 1.25, 40_000.0)],
+                unpriced: vec![("mystery-model".into(), 3)],
+            }],
+        };
+        let json = serde_json::to_string(&doc).unwrap();
+        let back: PersistFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.version, doc.version);
+        assert_eq!(back.pricing_stamp, doc.pricing_stamp);
+        let (a, b) = (&back.entries[0], &doc.entries[0]);
+        assert_eq!(a.path, b.path);
+        assert_eq!((a.mtime_secs, a.mtime_nanos, a.size), (b.mtime_secs, b.mtime_nanos, b.size));
+        assert_eq!(a.days, b.days);
+        assert_eq!(a.unpriced, b.unpriced);
+    }
+
+    #[test]
+    fn corrupt_persist_file_is_rejected_not_panicked() {
+        assert!(serde_json::from_str::<PersistFile>("{not json").is_err());
+        assert!(serde_json::from_str::<PersistFile>(r#"{"version":1}"#).is_err());
+    }
+
     // ---- Hermes: billing-route buckets -----------------------------------
 
     #[test]
@@ -1639,6 +1797,10 @@ fn split_csv_row(line: &str) -> Vec<String> {
 
 pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
     pricing::ensure_fresh();
+    load_persisted_cache();
+    if let Ok(mut t) = touched().lock() {
+        t.clear();
+    }
     let (claude_sp, mut minimax_extra) = claude();
     // Hermes rows going to an existing slice merge into it (MiniMax via the
     // extra-data path); the rest become their own spend entries.
@@ -1668,5 +1830,6 @@ pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
     if list.iter().any(|sp| sp.unpriced > 0) {
         pricing::note_unpriced();
     }
+    save_persisted_cache();
     list.into_iter().filter(ProviderSpend::has_data).collect()
 }


### PR DESCRIPTION
Every launch re-parsed every session log ever written (thousands of files, growing forever) just to rebuild tiny per-day summaries. The in-memory (mtime, size, pricing-gen) cache now round-trips through `%APPDATA%\Pane\spend_cache.json` — load on first collect, atomic save when a run parsed anything new.

Safety properties:
- **Never stale prices:** validity is anchored to `pricing::catalog_stamp()` (fingerprint of the on-disk catalog files); any catalog refresh discards the persisted cache wholesale.
- **Never grows unbounded:** only entries touched this run are saved — deleted logs and disabled providers fall out naturally.
- **Never trusts corruption:** version gate + full-file discard on any parse error; rebuilds from logs.
- mtimes stored at nanosecond precision (NTFS is 100ns) — ms rounding would break equality and silently re-parse everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->