### PR TITLE
Judge symlinked logs by the target file's mtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   as a Hermes slice.
 
 ### Fixed
+- **Symlinked session logs count their real age** — the spend scanner
+  follows symlinks/junctions when walking log directories, but judged a
+  linked file's recency by the link's own timestamp; logs relocated to
+  another drive could silently vanish from the 31-day window. The
+  target file's timestamp decides now.
 - **Kimi K3 cache reads were overpriced ~10×** — models.dev lists the
   same model under many resellers and Pane took the alphabetically first
   entry, which for kimi-k3 was a stub with no cache pricing; cache hits

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -195,6 +195,10 @@ fn build_spend(id: &'static str, name: &'static str, data: FileData) -> Provider
 }
 
 /// All .jsonl files under `root` modified in the last 31 days.
+/// Symlinks and junctions are followed throughout: `is_dir()` resolves
+/// links when recursing, and the recency check below reads the *target*
+/// file's mtime — a link's own (usually ancient) timestamp must not hide
+/// logs a user relocated to another drive.
 fn recent_jsonl_files(root: &Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = fs::read_dir(root) else { return };
     let cutoff = SystemTime::now() - Duration::from_secs(31 * 86_400);
@@ -203,7 +207,7 @@ fn recent_jsonl_files(root: &Path, out: &mut Vec<PathBuf>) {
         if path.is_dir() {
             recent_jsonl_files(&path, out);
         } else if path.extension().is_some_and(|e| e == "jsonl") {
-            if let Ok(meta) = entry.metadata() {
+            if let Ok(meta) = fs::metadata(&path) {
                 if meta.modified().map(|m| m >= cutoff).unwrap_or(true) {
                     out.push(path);
                 }


### PR DESCRIPTION
The spend walker already follows symlinks/junctions when recursing, but the 31-day recency filter read the link's own metadata — a fresh log behind an old link was silently excluded from spend. The target file's timestamp decides now. Upstream parity with robinebers/openusage#973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->