### PR TITLE
Fix telemetry toggle displaying off while default-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **The telemetry toggle shows its real state** — the "Share anonymous
+  usage statistics" switch rendered as off for installs that had never
+  touched it, while the default-on sender kept reporting. The default is
+  now stated in the config itself, so the switch reads ON unless you
+  actually turned it off (opting out worked correctly all along; only
+  the display was wrong).
+
 ## 0.4.24 — 2026-07-27
 
 ### Added

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -92,6 +92,11 @@ fn config_with_defaults(mut cfg: Value) -> Value {
     obj.entry("proxy").or_insert(json!({ "enabled": false, "url": "" }));
     obj.entry("showTotalSpend").or_insert(json!(true));
     obj.entry("welcomeDismissed").or_insert(json!(false));
+    // Telemetry defaults ON and must SAY so: without this default the
+    // Settings toggle read `undefined` (rendered off) while the sender's
+    // own default kept transmitting — a switch that displays off while
+    // data flows is the one state a privacy control must never be in.
+    obj.entry("telemetry").or_insert(json!(true));
     cfg
 }
 


### PR DESCRIPTION
The "Share anonymous usage statistics" switch read the absent config key as unchecked for every install that never touched it, while the Rust sender defaulted the same absent key to on — so the toggle displayed **off** during active (default-on) reporting. Display-only bug: opting out did work and hard-stop semantics were correct; but a privacy control must never show off while data flows.

Fix: `config_with_defaults` materializes `telemetry: true` like every other setting, so the UI always renders the effective state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->