### PR TITLE
Release 0.4.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.25 — 2026-07-28
 
 ### Fixed
 - **The telemetry toggle shows its real state** — the "Share anonymous

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "openusage",
-  "version": "0.4.24",
+  "name": "pane",
+  "version": "0.4.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "openusage",
-      "version": "0.4.24",
+      "name": "pane",
+      "version": "0.4.25",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.24",
+  "version": "0.4.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.24"
+version = "0.4.25"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -346,12 +346,12 @@ mod tests {
 
     #[test]
     fn raw_error_text_never_appears_in_events() {
-        let secret = "token refresh failed for C:\\Users\\jazii\\.grok\\auth.json";
+        let secret = "token refresh failed for C:\\Users\\alice\\.grok\\auth.json";
         let mut state = State { uuid: "u".into(), ..Default::default() };
         accumulate(&mut state, "2026-07-26", &[outcome("grok", "error", false, Some(secret))]);
         let events = accumulate(&mut state, "2026-07-27", &[]);
         let raw = serde_json::to_string(&events).unwrap();
-        assert!(!raw.contains("jazii"), "raw error text leaked into telemetry");
+        assert!(!raw.contains("alice"), "raw error text leaked into telemetry");
         assert!(raw.contains("errors_auth"), "categorized as auth (expired/credentials)");
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bumps version to 0.4.25 and dates the changelog.

Ships #95 (telemetry toggle displays its true state) and #96 (OpenCode real Go windows — UTC Monday week, anchored monthly cycle — with reset countdowns on all three meters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->