### PR TITLE
Gate daily telemetry by UTC day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Daily statistics count on the day they belong to** — the once-a-day
+  telemetry gate used the machine's local date while every consumer
+  buckets by UTC day, so an install east of UTC whose app runs at local
+  midnight always landed in the previous UTC day (Pakistan showed "0
+  today" while actively using Pane). The gate is UTC now, matching the
+  dashboard.
+
 ## 0.4.25 — 2026-07-28
 
 ### Fixed

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -3,7 +3,7 @@
 //! opt-out). No SDK: events are plain documented POSTs to PostHog's batch
 //! API, so everything that can ever leave the machine is in this one file.
 //!
-//! Exactly two event shapes, at most one of each per provider per local day:
+//! Exactly two event shapes, at most one of each per provider per UTC day:
 //!   - `app_daily_active` — "this install was alive today" + a config
 //!     snapshot (which providers are enabled, which metrics are starred —
 //!     stable IDs only, never free text).
@@ -272,7 +272,12 @@ pub async fn record(enabled: bool, snap: ConfigSnapshot, outcomes: Vec<Outcome>)
         return;
     }
 
-    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+    // UTC day, not local: event timestamps are UTC and every consumer
+    // (dashboard HogQL, the Redis pipeline) buckets by UTC day. Local-day
+    // gating made a UTC+5 install whose app runs at local midnight fire
+    // its "today" ping at 19:00 UTC — landing in the *previous* UTC day,
+    // so its country read 0 all day on the dashboard.
+    let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
     let mut state = load_state();
 
     let mut batch = accumulate(&mut state, &today, &outcomes);


### PR DESCRIPTION
The once-a-day telemetry gate used the **local** date while event timestamps are UTC and every consumer (dashboard HogQL, Redis pipeline) buckets by **UTC day**. Result: a UTC+5 install whose app runs at local midnight fires its "today" ping at 19:00 UTC — landing in the *previous* UTC day. jazii (PKT) showed "Pakistan: 0 today" while actively using Pane; verified against the live event stream (their daily consistently stamps 19:0x UTC of the prior day).

One-line semantic fix: the gate is UTC now. Transition is benign — worst case one duplicated or skipped daily on the day an install updates, invisible to per-day uniques.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->