### PR TITLE
Share expanded cards whole; collapsed cards stay compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Changed
+- **Share cards copy what you see** — the ⧉ copy of an expanded card now
+  includes everything visible: the usage trend, spend rows, and pace
+  hints. Collapsed cards keep the clean compact composition. Buttons,
+  links, and carets stay out of the image either way.
+
 ### Fixed
 - **Daily statistics count on the day they belong to** — the once-a-day
   telemetry gate used the machine's local date while every consumer

--- a/src/main.ts
+++ b/src/main.ts
@@ -1276,11 +1276,14 @@ async function shareCard(id: string): Promise<void> {
     // (cards sit flat on the background there, panels carry the chrome).
     clone.classList.add("snap-card");
     if (id !== "__total__") {
-      const chrome = ".share-btn, .card-caret, .quick-links, .action-row, .tick, .drag-grip";
+      const chrome = ".share-btn, .card-caret, .quick-links, .action-row, .drag-grip";
       const expanded = clone.querySelector(".on-demand") !== null;
+      // The pace tick is visible data (the even-pace marker), so it stays
+      // in the what-you-see expanded copy and goes with the other pace
+      // elements in the compact one.
       clone
         .querySelectorAll(
-          expanded ? chrome : `${chrome}, .metric.trend, [data-spend], .pace-note`
+          expanded ? chrome : `${chrome}, .metric.trend, [data-spend], .pace-note, .tick`
         )
         .forEach((n) => n.remove());
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1267,15 +1267,20 @@ async function shareCard(id: string): Promise<void> {
     clone.style.width = `${W}px`;
     clone.style.boxSizing = "border-box";
 
-    // Shares are the card minus its interactive chrome (trend chart,
-    // spend rows, pace hints, links, carets, grips); .snap-card restores
-    // the card surface the popover no longer draws (cards sit flat on
-    // the background there, panels carry the chrome).
+    // Shares match what's on screen. A collapsed card copies as the
+    // compact composition (meters + resets, no trend/spend/pace). An
+    // expanded card — its On Demand section is open — copies whole:
+    // trend chart, spend rows, and pace hints included. Interactive
+    // chrome (buttons, links, carets, grips) never belongs in an image.
+    // .snap-card restores the card surface the popover no longer draws
+    // (cards sit flat on the background there, panels carry the chrome).
     clone.classList.add("snap-card");
     if (id !== "__total__") {
+      const chrome = ".share-btn, .card-caret, .quick-links, .action-row, .tick, .drag-grip";
+      const expanded = clone.querySelector(".on-demand") !== null;
       clone
         .querySelectorAll(
-          ".share-btn, .card-caret, .quick-links, .metric.trend, [data-spend], .action-row, .pace-note, .tick, .drag-grip"
+          expanded ? chrome : `${chrome}, .metric.trend, [data-spend], .pace-note`
         )
         .forEach((n) => n.remove());
     }


### PR DESCRIPTION
The ⧉ copy always stripped the trend chart, spend rows, and pace hints regardless of card state. Now the composition matches the screen: a card with its On Demand section open copies with everything visible (trend, Today/Yesterday/30-Days rows, pace hints); a collapsed card keeps the compact meters-and-resets treatment it has today. Interactive chrome (buttons, links, carets, grips) is stripped in both cases. Total Spend card unchanged.

Verified on a local build by jazii: expanded copy matches the on-screen card, collapsed copy matches the previous behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->