### PR TITLE
Release 0.4.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.26 — 2026-07-29
 
 ### Changed
 - **Share cards copy what you see** — the ⧉ copy of an expanded card now

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.25",
+      "version": "0.4.26",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.25",
+  "version": "0.4.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.25"
+version = "0.4.26"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bumps version to 0.4.26 (lockfiles included) and dates the changelog.

Ships #98 (daily statistics gate by UTC day — fixes east-of-UTC installs landing in the previous day) and #99 (share cards copy what you see — expanded cards copy whole, collapsed stay compact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->