### PR TITLE
Release 0.4.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.4.27 — 2026-07-30
+
+### Added
+- **Grok card shows your subscription plan** — the header now reads
+  "X Premium", "SuperGrok", and friends, resolved from xAI's settings
+  display name with a tier-code fallback (free tiers stay unbadged; a
+  plan lookup failure can never hide usage data). Contributed by
+  @JaminYe — their second Pane contribution. 🎉
+
 ## 0.4.26 — 2026-07-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ reset window ("Almost out", "Will run out").
 
 **4. Counting the money.** Your CLIs already log every request locally.
 Pane scans those logs (Claude, Codex, Grok, OpenCode, Devin CLI, Cursor
-CSV), prices each request with live per-model rates (LiteLLM /
+CSV, MiniMax CLI, Kimi Code, the Hermes desktop app), prices each
+request with live per-model rates (LiteLLM /
 models.dev, refreshed daily — hourly while unknown models are around, so
 brand-new models price within the hour), and draws the Today /
 Yesterday / 30-day donut with a per-model breakdown. Click the ring to
@@ -141,7 +142,7 @@ success/failure counts — never amounts or error text) — see
 | Cursor | Cursor's local state database + cursor.com API |
 | OpenCode (Go plan) | Local `opencode.db` spend vs documented plan limits* |
 | GitHub Copilot | Copilot editor login or GitHub CLI (Credential Manager) + GitHub API |
-| Grok (Grok CLI) | `%USERPROFILE%\.grok\auth.json` + Grok billing API |
+| Grok (Grok CLI) | `%USERPROFILE%\.grok\auth.json` + Grok billing/subscription APIs |
 | Devin (Devin CLI) | `%APPDATA%\devin\credentials.toml` + GetUserStatus RPC; local CLI session store for spend |
 | MiniMax | API key (Settings, env var, or CLI config) + token-plan API |
 | OpenRouter | API key (Settings) or key stored by OpenCode |
@@ -184,9 +185,10 @@ whatever the community asks for loudest.
   undoes.
 - **Liquid glass UI** — real SDF lens refraction on the auto-hiding
   sidebar and glass bars, magnetic minimap trail, circular day/night wipe.
-- **Share cards** — hover a card, click ⧉, and paste anywhere: a clean
-  composition of the card (interactive chrome stripped, just the
-  numbers), framed with the Pane icon and tagline.
+- **Share cards** — hover a card, click ⧉, and paste anywhere: a
+  collapsed card copies as a clean compact composition, an expanded one
+  copies whole (trend, spend, pace hints — buttons and links stripped),
+  framed with the Pane icon and tagline.
 - **Quick links** — Status / Dashboard shortcuts on every card.
 - **[Local HTTP API](docs/local-http-api.md)** — `GET
   http://127.0.0.1:6736/v1/usage` for scripts, Rainmeter widgets, stream

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -64,11 +64,14 @@ Ground rules that apply to every provider:
   contains.
 - **Calls:** nothing — OpenCode has no public usage API (the gateway
   exposes only inference routes); usage is computed locally against
-  documented plan limits. **The meters say "this PC only" because they
-  are:** Go quotas are counted account-wide on OpenCode's servers, so
-  usage from your other devices or from other participants on a shared
-  subscription can't appear here. The Console quick-link shows the
-  account-wide truth.
+  documented plan limits using OpenCode's real windows: a rolling
+  5-hour session (resets as the oldest in-window spend ages out), a UTC
+  Monday-start week, and a monthly cycle anchored to your first-ever Go
+  usage. **The meters say "this PC only" because they are:** Go quotas
+  are counted account-wide on OpenCode's servers, so usage from your
+  other devices or from other participants on a shared subscription
+  can't appear here. The Console quick-link shows the account-wide
+  truth.
 
 ## GitHub Copilot
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.26",
+  "version": "0.4.27",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.26"
+version = "0.4.27"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bumps version to 0.4.27 (lockfiles included) and dates the changelog.

Ships #101 — the Grok card''s subscription plan badge ("X Premium", "SuperGrok", …), contributed by @JaminYe. Also freshens docs: README spend-source list (MiniMax CLI, Kimi Code, Hermes were missing), the share-cards feature description, Grok''s API row, and providers.md''s OpenCode window semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->