### PR TITLE
Replace native confirm() with an in-app dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **Confirmations look like Pane now** — using a Codex reset credit or
+  resetting all layouts used to pop the browser's bare "localhost says"
+  dialog; both now use an in-app card-styled dialog matching the app
+  (with a red button where the action is destructive). The reset-credit
+  message also notes that refreshed windows can take a couple of
+  minutes to appear.
+
 ## 0.4.27 — 2026-07-30
 
 ### Added

--- a/src/main.ts
+++ b/src/main.ts
@@ -1232,6 +1232,11 @@ async function checkForUpdate(): Promise<void> {
 /// Resolves true on confirm; Esc, the ✕, backdrop clicks, and Cancel all
 /// resolve false. The keydown listener runs in the capture phase and stops
 /// propagation so the app's global Esc (close panels) stays out of it.
+/// Cancels the open appConfirm dialog, if any. The popover hides on focus
+/// loss with the dialog still in the DOM — reopening must not resurface a
+/// stale question, so the reopen routine dismisses it like Esc would.
+let dismissConfirm: (() => void) | null = null;
+
 function appConfirm(opts: {
   title: string;
   message: string;
@@ -1251,10 +1256,12 @@ function appConfirm(opts: {
         </div>
       </div>`;
     const done = (ok: boolean) => {
+      dismissConfirm = null;
       document.removeEventListener("keydown", onKey, true);
       overlay.remove();
       resolve(ok);
     };
+    dismissConfirm = () => done(false);
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();
@@ -2758,10 +2765,11 @@ window.addEventListener("DOMContentLoaded", () => {
   void listen("popover-shown", () => {
     void checkForUpdate();
     // Always reopen on the main page, at the top — leftover Customize/
-    // Settings panels or a stale scroll position from the previous visit
-    // feel like the app is stuck mid-page.
+    // Settings panels, a stale confirm dialog, or a stale scroll position
+    // from the previous visit feel like the app is stuck mid-page.
     setDrawer(false);
     setSettings(false);
+    dismissConfirm?.();
     // Replay any renders skipped while hidden, before the reveal plays.
     if (pendingRender) {
       pendingRender = false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1227,6 +1227,52 @@ async function checkForUpdate(): Promise<void> {
 /// rasterize it at 2x. Whatever the card renders — donut, tabs, trend
 /// bars, future rows — the copied image matches automatically, instead
 /// of a hand-drawn approximation that drifts from the real UI.
+/// In-app replacement for window.confirm: the native dialog renders as a
+/// bare "localhost says" browser popup, which has no place in a glass UI.
+/// Resolves true on confirm; Esc, the ✕, backdrop clicks, and Cancel all
+/// resolve false. The keydown listener runs in the capture phase and stops
+/// propagation so the app's global Esc (close panels) stays out of it.
+function appConfirm(opts: {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  danger?: boolean;
+}): Promise<boolean> {
+  return new Promise((resolve) => {
+    const overlay = document.createElement("div");
+    overlay.id = "confirm-overlay";
+    overlay.innerHTML = `
+      <div id="confirm-box" role="dialog" aria-modal="true">
+        <h3>${escapeHtml(opts.title)}</h3>
+        <p>${escapeHtml(opts.message)}</p>
+        <div id="confirm-actions">
+          <button id="confirm-cancel" type="button">Cancel</button>
+          <button id="confirm-ok" type="button" class="${opts.danger ? "danger" : ""}">${escapeHtml(opts.confirmLabel)}</button>
+        </div>
+      </div>`;
+    const done = (ok: boolean) => {
+      document.removeEventListener("keydown", onKey, true);
+      overlay.remove();
+      resolve(ok);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        done(false);
+      }
+    };
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) done(false);
+    });
+    overlay.querySelector("#confirm-cancel")!.addEventListener("click", () => done(false));
+    overlay.querySelector("#confirm-ok")!.addEventListener("click", () => done(true));
+    document.addEventListener("keydown", onKey, true);
+    document.body.appendChild(overlay);
+    overlay.querySelector<HTMLButtonElement>("#confirm-ok")!.focus();
+  });
+}
+
 async function shareCard(id: string): Promise<void> {
   const status = document.querySelector("#status")!;
   try {
@@ -2101,11 +2147,14 @@ function handleCustomizeClick(target: HTMLElement): boolean {
   }
   const resetAll = target.closest("[data-reset-all]");
   if (resetAll) {
-    if (
-      window.confirm(
-        "Reset all layout customization? Order, stars, and hidden rows go back to defaults, and installed AI tools are re-detected. (Your usage limits are not affected.)",
-      )
-    ) {
+    void appConfirm({
+      title: "Reset all layouts?",
+      message:
+        "Order, stars, and hidden rows go back to defaults, and installed AI tools are re-detected. Your usage limits are not affected.",
+      confirmLabel: "Reset all",
+      danger: true,
+    }).then((ok) => {
+      if (!ok) return;
       // Clearing layout + disabled re-arms the first-launch detection path:
       // the next refresh probes every provider and re-disables only the
       // ones with no credentials on this PC.
@@ -2115,7 +2164,7 @@ function handleCustomizeClick(target: HTMLElement): boolean {
         setDrawer(false);
         void refresh(true).then(() => void updateTrayStrip());
       });
-    }
+    });
     return true;
   }
   const reset = target.closest<HTMLElement>("[data-reset]");
@@ -2618,11 +2667,13 @@ window.addEventListener("DOMContentLoaded", () => {
     const redeem = target.closest<HTMLElement>("[data-redeem]");
     if (redeem) {
       const creditId = redeem.dataset.redeem!;
-      if (
-        window.confirm(
-          "Use one Codex reset credit now?\n\nThis resets your Codex rate-limit windows immediately and cannot be undone.",
-        )
-      ) {
+      void appConfirm({
+        title: "Use a reset credit?",
+        message:
+          "This resets your Codex rate-limit windows immediately and cannot be undone. The refreshed windows can take a couple of minutes to appear.",
+        confirmLabel: "Use credit",
+      }).then((ok) => {
+        if (!ok) return;
         const status = document.querySelector("#status")!;
         status.textContent = "Redeeming reset credit…";
         void invoke<string>("codex_redeem_credit", { creditId })
@@ -2633,7 +2684,7 @@ window.addEventListener("DOMContentLoaded", () => {
           .catch((err) => {
             status.textContent = `Redeem failed: ${err}`;
           });
-      }
+      });
       return;
     }
     const tab = target.closest("[data-tab]");

--- a/src/styles.css
+++ b/src/styles.css
@@ -1776,3 +1776,108 @@ body.no-glass .cust-dock {
 .donut-sub {
   fill: var(--muted-foreground);
 }
+
+/* ---------------------------------------------------------------------------
+   In-app confirm dialog (replaces the native "localhost says" popup)
+--------------------------------------------------------------------------- */
+
+#confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 0.45);
+  backdrop-filter: blur(6px) saturate(1.2);
+  -webkit-backdrop-filter: blur(6px) saturate(1.2);
+  animation: confirm-fade 0.16s ease;
+}
+
+#confirm-box {
+  width: min(88%, 300px);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 18px 18px 14px;
+  box-shadow:
+    0 24px 60px rgb(0 0 0 / 0.45),
+    inset 0 1px 0 rgb(255 255 255 / 0.06);
+  animation: confirm-pop 0.18s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+
+#confirm-box h3 {
+  font-size: 14px;
+  font-weight: 650;
+  margin: 0 0 6px;
+}
+
+#confirm-box p {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--muted-foreground);
+  margin: 0 0 14px;
+}
+
+#confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+#confirm-actions button {
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 5px 14px;
+  cursor: pointer;
+  transition: opacity 0.15s ease, transform 0.1s ease;
+}
+
+#confirm-actions button:active {
+  transform: scale(0.95);
+}
+
+#confirm-cancel {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--secondary-foreground);
+}
+
+#confirm-cancel:hover {
+  background: var(--accent);
+}
+
+#confirm-ok {
+  background: var(--primary);
+  border: 1px solid transparent;
+  color: var(--primary-foreground);
+}
+
+#confirm-ok:hover {
+  opacity: 0.85;
+}
+
+#confirm-ok.danger {
+  background: var(--destructive);
+  color: #fff;
+}
+
+@keyframes confirm-fade {
+  from { opacity: 0; }
+}
+
+@keyframes confirm-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.94) translateY(6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #confirm-overlay,
+  #confirm-box {
+    animation: none;
+  }
+}


### PR DESCRIPTION
window.confirm renders as a bare "localhost says" browser popup — jarring and off-brand inside a glass UI. This adds `appConfirm()`: a card-styled modal on a blurred overlay using the app''s design tokens (pill buttons, danger variant, pop-in animation with a reduced-motion guard).

Behavior: Esc, backdrop click, and Cancel all resolve false; the Esc listener runs in the capture phase with stopPropagation so the app''s global close-panels handler never fires underneath. Focus lands on the confirm button.

Both call sites converted:
- **Codex reset-credit redemption** — message now also notes the refreshed windows can take a couple of minutes to appear (real user confusion)
- **Reset all layouts** — danger-styled red confirm

Verified on a local build by jazii (Customize → Reset all: "works like charm").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->