### PR TITLE
GPT-5.6 Terra/Luna: OpenAI's new prices, stale-catalog correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+- **GPT-5.6 Terra and Luna price at OpenAI's new rates** — OpenAI cut
+  both models' prices (Luna is 5× cheaper) and the public price catalogs
+  still carry launch pricing, so spend was overstated. Pane corrects the
+  stale catalog values (a self-retiring override: the moment the
+  catalogs publish updated numbers, live data wins again) and updates
+  the long-context rate table to the new tiers.
+
 ### Changed
 - **Confirmations look like Pane now** — using a Codex reset credit or
   resetting all layouts used to pop the browser's bare "localhost says"

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -155,12 +155,22 @@ pub fn generation() -> u64 {
     GENERATION.load(std::sync::atomic::Ordering::Relaxed)
 }
 
-/// Stable fingerprint of the on-disk catalog files. The persistent spend
+/// Bump whenever the baked-in pricing behavior changes (stale-catalog
+/// corrections, builtin fallbacks, long-context tables): the persisted
+/// spend cache holds pre-priced totals, and only the catalog *files* are
+/// fingerprinted below — an app update that reprices the same files would
+/// otherwise leave history at the old dollars until upstream happens to
+/// rewrite a catalog.
+const CORRECTIONS_REV: u32 = 1;
+
+/// Stable fingerprint of the effective pricing inputs: the on-disk catalog
+/// files plus this binary's corrections revision. The persistent spend
 /// cache stores costs priced under a specific catalog set; when any catalog
-/// file changes (a refresh rewrote it), the stamp changes and the whole
-/// persisted cache is discarded rather than served with stale prices.
+/// file changes (a refresh rewrote it) — or an update ships changed baked
+/// pricing — the stamp changes and the whole persisted cache is discarded
+/// rather than served with stale prices.
 pub fn catalog_stamp() -> String {
-    SOURCES
+    let files = SOURCES
         .iter()
         .map(|(source, _)| {
             let path = dir().join(format!("{source}.json"));
@@ -178,7 +188,8 @@ pub fn catalog_stamp() -> String {
             }
         })
         .collect::<Vec<_>>()
-        .join("|")
+        .join("|");
+    format!("{files}|corrections:{CORRECTIONS_REV}")
 }
 
 fn dir() -> PathBuf {

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -281,6 +281,7 @@ fn apply_supplement(store: &mut Store, doc: &Value) {
             );
         }
     }
+    correct_stale_supplement(&mut store.supplement);
     if let Some(mults) = doc.get("fast_multipliers").and_then(Value::as_object) {
         for (model, v) in mults {
             if let Some(m) = v.as_f64() {
@@ -288,6 +289,26 @@ fn apply_supplement(store: &mut Store, doc: &Value) {
             }
         }
     }
+    // 2026-07-31: OpenAI cut gpt-5.6-terra/-luna prices and both public
+    // catalogs (and the supplement, which outranks them here) still carry
+    // launch pricing. Correct ONLY the exact known-stale values — a
+    // self-retiring override: the moment the supplement publishes any new
+    // number for these models, its data wins again untouched. Remove this
+    // whole function once upstream catches up.
+    fn correct_stale_supplement(supplement: &mut HashMap<String, Price>) {
+        let corrections: [(&str, f64, Price); 2] = [
+            ("gpt-5.6-terra", 2.5, Price::flat(2.0, 12.0, 0.2, 2.5)),
+            ("gpt-5.6-luna", 1.0, Price::flat(0.2, 1.2, 0.02, 0.25)),
+        ];
+        for (model, stale_input, corrected) in corrections {
+            if let Some(p) = supplement.get_mut(model) {
+                if (p.input - stale_input).abs() < 1e-9 {
+                    *p = corrected;
+                }
+            }
+        }
+    }
+
     // The supplement is fetched from a third-party URL, so cap what it can
     // feed us: at most 64 alias rules of at most 256 chars each, compiled
     // with a bounded size. (Rust's regex engine is linear-time by design,
@@ -577,6 +598,30 @@ mod tests {
         let map = super::parse_modelsdev(&doc);
         let p = map.get("kimi-k3").expect("kimi-k3 parsed");
         assert_eq!((p.input, p.output, p.cache_read, p.cache_write), (3.0, 15.0, 0.3, 3.0));
+    }
+
+    #[test]
+    fn stale_gpt56_supplement_prices_are_corrected_until_upstream_updates() {
+        let stale = serde_json::json!({ "pricing": {
+            "gpt-5.6-terra": { "input_per_million": 2.5, "output_per_million": 15.0,
+                               "cache_read_per_million": 0.25, "cache_write_per_million": 3.125 },
+            "gpt-5.6-luna":  { "input_per_million": 1.0, "output_per_million": 6.0,
+                               "cache_read_per_million": 0.1, "cache_write_per_million": 1.25 },
+        }});
+        let mut store = super::Store::default();
+        super::apply_supplement(&mut store, &stale);
+        let terra = store.supplement.get("gpt-5.6-terra").unwrap();
+        assert_eq!((terra.input, terra.output, terra.cache_read), (2.0, 12.0, 0.2));
+        let luna = store.supplement.get("gpt-5.6-luna").unwrap();
+        assert_eq!((luna.input, luna.output, luna.cache_read), (0.2, 1.2, 0.02));
+
+        // Self-retiring: any NEW upstream number passes through untouched.
+        let updated = serde_json::json!({ "pricing": {
+            "gpt-5.6-terra": { "input_per_million": 1.75, "output_per_million": 11.0 },
+        }});
+        super::apply_supplement(&mut store, &updated);
+        let terra = store.supplement.get("gpt-5.6-terra").unwrap();
+        assert_eq!((terra.input, terra.output), (1.75, 11.0));
     }
 
     #[test]

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -859,10 +859,13 @@ fn codex_priority_multiplier(dated: &str, rate_model: &str) -> f64 {
 /// tokens, not the 200k Anthropic uses.
 fn codex_long_context(dated: &str) -> Option<(f64, f64, f64)> {
     match dated {
-        "gpt-5.4" | "gpt-5.6-terra" => Some((5.0, 22.5, 0.5)),
+        "gpt-5.4" => Some((5.0, 22.5, 0.5)),
         "gpt-5.4-pro" | "gpt-5.5-pro" => Some((60.0, 270.0, 60.0)),
         "gpt-5.5" | "gpt-5.6-sol" => Some((10.0, 45.0, 1.0)),
-        "gpt-5.6-luna" => Some((2.0, 9.0, 0.2)),
+        // 2026-07-31 price cut: terra/luna long-context dropped with the
+        // base rates (terra used to share gpt-5.4's row).
+        "gpt-5.6-terra" => Some((4.0, 18.0, 0.4)),
+        "gpt-5.6-luna" => Some((0.4, 1.8, 0.04)),
         _ => None,
     }
 }


### PR DESCRIPTION
OpenAI cut GPT-5.6 Terra to $2/$12 per MTok (long-context $4/$18, cache read $0.40) and Luna to $0.20/$1.20 (long-context $0.40/$1.80, cache read $0.04) — Luna is 5× cheaper. Sol is unchanged. Verified against the live OpenAI pricing page.

Both LiteLLM and the remote pricing supplement still carry launch pricing, and the supplement outranks every catalog in our resolution order — so Pane would overstate spend until upstream updates, however long that takes.

Two changes:
- **Long-context table** (ours alone): terra splits off gpt-5.4''s row with the new $4/$18/$0.40 tier; luna moves to $0.40/$1.80/$0.04.
- **Self-retiring stale-catalog correction** in `apply_supplement`: patches ONLY the exact known-stale values (terra input 2.5, luna input 1.0). Any new number published upstream passes through untouched, so this override removes itself from the data path the moment Robin''s supplement updates — and the function carries a remove-me comment for when that lands.

Regression test covers both the correction and the pass-through. 43/43 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->