### PR TITLE
Add AihubMix provider: limit meter, spend slice, usage trend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+- **AihubMix provider (#18)** — the OpenAI-compatible multi-model
+  gateway gets a full card: usage metered against your account's
+  spending limit (key auto-detected from OpenCode, or pasted in
+  Settings), plus Today / Yesterday / 30-day spend, per-model breakdown,
+  and the Usage Trend from requests routed through OpenCode. AihubMix
+  dollars get their own donut slice, separate from the OpenCode plan.
+
 ### Fixed
 - **GPT-5.6 Terra and Luna price at OpenAI's new rates** — OpenAI cut
   both models' prices (Luna is 5× cheaper) and the public price catalogs

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ statistic (random ID, version, which providers are enabled, provider
 success/failure counts — never amounts or error text) — see
 [Privacy](#privacy--security) for the full contract and the off switch.
 
-## Providers (17 and counting)
+## Providers (18 and counting)
 
 | Provider | How Pane connects |
 |---|---|
@@ -154,6 +154,7 @@ success/failure counts — never amounts or error text) — see
 | Ollama | Local server on :11434 — installed + loaded models, no key |
 | Codebuff | `codebuff login` credentials file or API key → credits + weekly limit |
 | Kilo | Kilo CLI login file or API key → credit blocks + Kilo Pass |
+| AihubMix | API key (Settings or auto-detected from OpenCode) → usage vs spending limit |
 
 *OpenCode has no public usage API yet
 ([anomalyco/opencode#10448](https://github.com/anomalyco/opencode/issues/10448));

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -184,6 +184,17 @@ Ground rules that apply to every provider:
 - **Calls:** `app.kilo.ai/api/trpc/user.getCreditBlocks,kiloPass.getState`.
 - **Shows:** credit blocks, Kilo Pass window, tier.
 
+## AihubMix
+
+- **Reads:** pasted key (Settings), `AIHUBMIX_API_KEY`, or the `aihubmix`
+  key OpenCode stores in its own `auth.json` (AihubMix is typically used
+  through OpenCode as an OpenAI-compatible gateway).
+- **Calls:** `aihubmix.com/v1/dashboard/billing/subscription` (spending
+  limit) and `/usage` (month-to-date usage).
+- **Shows:** usage metered against your account's spending limit, plan.
+  Requests routed through OpenCode also appear in the Total Spend donut
+  from OpenCode's local log, same as any other OpenCode model.
+
 ---
 
 Provider request formats were researched from two MIT-licensed macOS

--- a/index.html
+++ b/index.html
@@ -255,6 +255,11 @@
             <input id="key-kilo" type="password" placeholder="API key (auto-detected from CLI)" />
             <button data-save="kilo">Save</button>
           </div>
+          <div class="key-row">
+            <label for="key-aihubmix">AihubMix</label>
+            <input id="key-aihubmix" type="password" placeholder="sk-… (auto-detected from OpenCode)" />
+            <button data-save="aihubmix">Save</button>
+          </div>
         </div></div>
       </div>
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -368,7 +368,7 @@ struct StripEntry {
 /// allowlist for update_tray_strip: ids from the frontend are validated
 /// against this before being spliced into tray icon ids, and stale strip
 /// icons are removed for exactly this set.
-const STRIP_PROVIDER_IDS: [&str; 17] = [
+const STRIP_PROVIDER_IDS: [&str; 18] = [
     "claude",
     "codex",
     "cursor",
@@ -386,6 +386,7 @@ const STRIP_PROVIDER_IDS: [&str; 17] = [
     "ollama",
     "codebuff",
     "kilo",
+    "aihubmix",
 ];
 
 #[tauri::command]
@@ -559,6 +560,7 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
         ("ollama", Box::pin(guarded("ollama", "Ollama", providers::ollama::snapshot()))),
         ("codebuff", Box::pin(guarded("codebuff", "Codebuff", providers::codebuff::snapshot()))),
         ("kilo", Box::pin(guarded("kilo", "Kilo", providers::kilo::snapshot()))),
+        ("aihubmix", Box::pin(guarded("aihubmix", "AihubMix", providers::aihubmix::snapshot()))),
     ];
     let futs: Vec<(&str, BoxedSnap)> = futs
         .into_iter()
@@ -752,6 +754,7 @@ fn set_api_key(provider: String, key: String) -> Result<(), String> {
             | "elevenlabs"
             | "codebuff"
             | "kilo"
+            | "aihubmix"
     ) {
         return Err(format!("unknown provider: {provider}"));
     }

--- a/src-tauri/src/providers/aihubmix.rs
+++ b/src-tauri/src/providers/aihubmix.rs
@@ -56,12 +56,13 @@ async fn fetch() -> Result<Snapshot, String> {
     let sub: Value = sub_resp.json().await.map_err(|e| format!("subscription parse: {e}"))?;
 
     // hard_limit_usd is the account's spending cap; soft_limit is the alert
-    // threshold. Meter against the hard limit — the real ceiling.
-    let limit = sub
-        .get("hard_limit_usd")
-        .or_else(|| sub.get("system_hard_limit_usd"))
-        .and_then(Value::as_f64)
-        .filter(|v| *v > 0.0);
+    // threshold. Meter against the hard limit — the real ceiling. Each
+    // field falls through on missing OR zero (an account with no custom
+    // limit reports hard_limit_usd 0 while the system limit still applies).
+    let limit = ["hard_limit_usd", "system_hard_limit_usd"]
+        .iter()
+        .filter_map(|k| sub.get(*k).and_then(Value::as_f64))
+        .find(|v| *v > 0.0);
 
     // Usage is best-effort: a missing/failed usage call still leaves a
     // valid card showing the limit, rather than erroring the whole card.

--- a/src-tauri/src/providers/aihubmix.rs
+++ b/src-tauri/src/providers/aihubmix.rs
@@ -15,11 +15,11 @@ const NAME: &str = "AihubMix";
 const SUBSCRIPTION: &str = "https://aihubmix.com/v1/dashboard/billing/subscription";
 const USAGE: &str = "https://aihubmix.com/v1/dashboard/billing/usage";
 
-/// The `total_usage` field's unit. AihubMix (a new-api-family gateway)
-/// reports the usage total in whole dollars, unlike the classic OpenAI
-/// endpoint which used cents. If a card ever shows spend 100x off, this is
-/// the knob.
-const USAGE_TO_USD: f64 = 1.0;
+/// The `total_usage` field's unit. AihubMix follows the classic OpenAI
+/// dashboard-billing convention: usage is reported in **cents**. Verified
+/// against a live console (total_usage 7.862 → $0.08 shown). If a card ever
+/// shows spend 100x off, this is the knob.
+const USAGE_TO_USD: f64 = 0.01;
 
 fn find_api_key() -> Option<String> {
     stored_api_key(ID, &["AIHUBMIX_API_KEY"])

--- a/src-tauri/src/providers/aihubmix.rs
+++ b/src-tauri/src/providers/aihubmix.rs
@@ -1,0 +1,98 @@
+//! AihubMix — an OpenAI-compatible multi-model gateway (aihubmix.com),
+//! pay-as-you-go against a top-up balance. It exposes the legacy OpenAI
+//! dashboard-billing endpoints, so Pane reads the account's spending limit
+//! and month-to-date usage and meters one against the other.
+//!
+//! Key source: pasted in Settings, `AIHUBMIX_API_KEY`, or — since AihubMix
+//! is typically used *through* OpenCode — the `aihubmix` entry OpenCode
+//! stores in its own auth.json (same reuse the OpenRouter provider does).
+
+use super::{http, stored_api_key, Metric, Snapshot};
+use serde_json::Value;
+
+const ID: &str = "aihubmix";
+const NAME: &str = "AihubMix";
+const SUBSCRIPTION: &str = "https://aihubmix.com/v1/dashboard/billing/subscription";
+const USAGE: &str = "https://aihubmix.com/v1/dashboard/billing/usage";
+
+/// The `total_usage` field's unit. AihubMix (a new-api-family gateway)
+/// reports the usage total in whole dollars, unlike the classic OpenAI
+/// endpoint which used cents. If a card ever shows spend 100x off, this is
+/// the knob.
+const USAGE_TO_USD: f64 = 1.0;
+
+fn find_api_key() -> Option<String> {
+    stored_api_key(ID, &["AIHUBMIX_API_KEY"])
+        .or_else(|| super::opencode::auth_entry_key("aihubmix"))
+}
+
+pub async fn snapshot() -> Snapshot {
+    match fetch().await {
+        Ok(s) => s,
+        Err(e) => Snapshot::error(ID, NAME, e),
+    }
+}
+
+async fn fetch() -> Result<Snapshot, String> {
+    let Some(key) = find_api_key() else {
+        return Ok(Snapshot::no_credentials(
+            ID,
+            NAME,
+            "Paste an AihubMix API key in Settings (or sign in to AihubMix via OpenCode).",
+        ));
+    };
+
+    let sub_req = http().get(SUBSCRIPTION).bearer_auth(&key).send();
+    let usage_req = http().get(USAGE).bearer_auth(&key).send();
+    let (sub_resp, usage_resp) = tokio::join!(sub_req, usage_req);
+
+    let sub_resp = sub_resp.map_err(|e| format!("subscription request: {e}"))?;
+    if sub_resp.status().as_u16() == 401 {
+        return Err("key was rejected — paste a fresh AihubMix key in Settings".into());
+    }
+    if !sub_resp.status().is_success() {
+        return Err(format!("subscription endpoint: HTTP {}", sub_resp.status()));
+    }
+    let sub: Value = sub_resp.json().await.map_err(|e| format!("subscription parse: {e}"))?;
+
+    // hard_limit_usd is the account's spending cap; soft_limit is the alert
+    // threshold. Meter against the hard limit — the real ceiling.
+    let limit = sub
+        .get("hard_limit_usd")
+        .or_else(|| sub.get("system_hard_limit_usd"))
+        .and_then(Value::as_f64)
+        .filter(|v| *v > 0.0);
+
+    // Usage is best-effort: a missing/failed usage call still leaves a
+    // valid card showing the limit, rather than erroring the whole card.
+    let used = match usage_resp {
+        Ok(resp) if resp.status().is_success() => resp
+            .json::<Value>()
+            .await
+            .ok()
+            .and_then(|d| d.get("total_usage").and_then(Value::as_f64))
+            .map(|v| v * USAGE_TO_USD),
+        _ => None,
+    };
+
+    let mut metrics = Vec::new();
+    match (limit, used) {
+        (Some(limit), Some(used)) => {
+            let pct = (used / limit * 100.0).clamp(0.0, 100.0);
+            metrics.push(Metric::progress(
+                "Usage",
+                pct,
+                Some(format!("${used:.2} of ${limit:.2}")),
+            ));
+        }
+        (Some(limit), None) => {
+            metrics.push(Metric::text("Limit", format!("${limit:.2}")));
+        }
+        (None, Some(used)) => {
+            metrics.push(Metric::text("Used", format!("${used:.2}")));
+        }
+        (None, None) => return Err("no billing data in response".into()),
+    }
+
+    Ok(Snapshot::ok(ID, NAME, Some("Pay as you go".into()), metrics))
+}

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -1,3 +1,4 @@
+pub mod aihubmix;
 pub mod antigravity;
 pub mod claude;
 pub mod codebuff;

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -244,9 +244,11 @@ fn utc_date(year: i32, month: u32, day: u32, h: u32, m: u32, s: u32, ms: u32) ->
         .unwrap_or(0.0)
 }
 
-/// (timestamp ms, cost $, tokens, model) of every priced message, any
-/// provider — this is money spent through OpenCode, used by Total Spend.
-pub fn collect_cost_events() -> Vec<(f64, f64, f64, String)> {
+/// (timestamp ms, cost $, tokens, model, provider) of every priced
+/// message, any provider — this is money spent through OpenCode, used by
+/// Total Spend. The provider id lets the spend engine split gateway
+/// providers (AihubMix) into their own slice.
+pub fn collect_cost_events() -> Vec<(f64, f64, f64, String, String)> {
     with_db_copy(|db| {
         Ok(read_messages(db)?
             .into_iter()
@@ -254,7 +256,7 @@ pub fn collect_cost_events() -> Vec<(f64, f64, f64, String)> {
             // tokens are usage facts and count at their true $0 price.
             // Rows with neither cost nor tokens (aborted turns) drop.
             .filter(|r| r.cost > 0.0 || r.tokens > 0.0)
-            .map(|r| (r.ts, r.cost, r.tokens, r.model))
+            .map(|r| (r.ts, r.cost, r.tokens, r.model, r.provider))
             .collect())
     })
     .unwrap_or_default()

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -1172,14 +1172,24 @@ fn grok() -> ProviderSpend {
 
 /// OpenCode stores real per-message costs in its database — no pricing
 /// table needed.
-fn opencode() -> ProviderSpend {
-    let mut data = FileData::default();
-    for (ts_ms, cost, tokens, model) in providers::opencode::collect_cost_events() {
+/// OpenCode's local log covers every provider routed through it. Gateway
+/// providers with their own Pane card (AihubMix) split into their own
+/// spend slice — their dollars belong to that account, and the split gives
+/// the card its Today/Yesterday/30d rows and Usage Trend; everything else
+/// stays under OpenCode.
+fn opencode() -> (ProviderSpend, ProviderSpend) {
+    let mut oc = FileData::default();
+    let mut aihubmix = FileData::default();
+    for (ts_ms, cost, tokens, model, provider) in providers::opencode::collect_cost_events() {
         if let Some(ts) = DateTime::from_timestamp_millis(ts_ms as i64) {
-            add_event(&mut data, ts, &model, cost, tokens);
+            let target = if provider == "aihubmix" { &mut aihubmix } else { &mut oc };
+            add_event(target, ts, &model, cost, tokens);
         }
     }
-    build_spend("opencode", "OpenCode", data)
+    (
+        build_spend("opencode", "OpenCode", oc),
+        build_spend("aihubmix", "AihubMix", aihubmix),
+    )
 }
 
 /// Devin CLI keeps per-request token metrics in its local sessions.db
@@ -1819,11 +1829,13 @@ pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
             hermes_rest.push(build_spend(id, name, data));
         }
     }
+    let (opencode_sp, aihubmix_sp) = opencode();
     let mut list = vec![
         claude_sp,
         codex(),
         grok(),
-        opencode(),
+        opencode_sp,
+        aihubmix_sp,
         devin(),
         minimax(minimax_extra),
         moonshot(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -260,6 +260,7 @@ const SPEND_COLORS: Record<string, string> = {
   cursor: "var(--spend-cursor)", // brand black, theme-flipped in CSS
   moonshot: "#e0b354", // moon gold
   hermes: "#c2a878", // Nous tan
+  aihubmix: "#5eead4", // hub teal
   __others__: "#8b8b94", // the folded small-spenders wedge
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -197,6 +197,7 @@ const ALL_PROVIDERS: [string, string][] = [
   ["ollama", "Ollama"],
   ["codebuff", "Codebuff"],
   ["kilo", "Kilo"],
+  ["aihubmix", "AihubMix"],
 ];
 
 // Same quick links the Mac app ships (status pages + vendor dashboards).
@@ -229,6 +230,7 @@ const PROVIDER_LINKS: Record<string, { label: string; url: string }[]> = {
     { label: "API Keys", url: "https://z.ai/manage-apikey/apikey-list" },
   ],
   opencode: [{ label: "Console", url: "https://opencode.ai/console" }],
+  aihubmix: [{ label: "Console", url: "https://console.aihubmix.com/" }],
   deepseek: [
     { label: "Status", url: "https://status.deepseek.com/" },
     { label: "Platform", url: "https://platform.deepseek.com/usage" },


### PR DESCRIPTION
Provider #18: [AihubMix](https://aihubmix.com), the OpenAI-compatible multi-model gateway, typically used through OpenCode.

**Card** — reads the account spending limit (`/v1/dashboard/billing/subscription`) and month-to-date usage (`/usage`), metering one against the other. `total_usage` is in **cents** (verified against a live console: 7.862 → $0.08). Usage lookup is best-effort: a failed call still shows the limit rather than erroring the card. Key sources: Settings paste, `AIHUBMIX_API_KEY`, or the `aihubmix` entry OpenCode stores (same reuse as OpenRouter).

**Spend** — OpenCode logs every routed provider; rows with `providerID: "aihubmix"` now split into their own ProviderSpend, giving the card Today/Yesterday/30-day rows + Usage Trend and the donut its own slice — those dollars belong to the AihubMix account, not the OpenCode plan (no double counting).

Registered across the app: fetch list, tray-strip ids, set_api_key whitelist, Settings key row, Console quick link, docs/providers.md, README ("18 and counting").

Verified live on a real account: card shows $0.08 of $20.00 (0.39%), spend rows and trend populate from real OpenCode-routed requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->