### PR TITLE
Drop "this PC only" from OpenCode meter captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   the long-context rate table to the new tiers.
 
 ### Changed
+- **OpenCode meters drop the "this PC only" tag** — the caveat crowded
+  every row of the card (and its share cards); the local-counting
+  caveat now lives in the docs instead. Also fixed a cosmetic quirk
+  where an idle session could read "$-0.00 of $12".
 - **Confirmations look like Pane now** — using a Codex reset credit or
   resetting all layouts used to pop the browser's bare "localhost says"
   dialog; both now use an in-app card-styled dialog matching the app

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -67,11 +67,10 @@ Ground rules that apply to every provider:
   documented plan limits using OpenCode's real windows: a rolling
   5-hour session (resets as the oldest in-window spend ages out), a UTC
   Monday-start week, and a monthly cycle anchored to your first-ever Go
-  usage. **The meters say "this PC only" because they are:** Go quotas
-  are counted account-wide on OpenCode's servers, so usage from your
-  other devices or from other participants on a shared subscription
-  can't appear here. The Console quick-link shows the account-wide
-  truth.
+  usage. **Note the meters count this PC only:** Go quotas are counted
+  account-wide on OpenCode's servers, so usage from your other devices
+  or from other participants on a shared subscription can't appear
+  here. The Console quick-link shows the account-wide truth.
 
 ## GitHub Copilot
 

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -101,19 +101,19 @@ fn fetch() -> Result<Snapshot, String> {
         Metric::progress(
             "Session",
             w.session / SESSION_LIMIT * 100.0,
-            Some(format!("${:.2} of ${SESSION_LIMIT:.0} · this PC only", w.session)),
+            Some(format!("${:.2} of ${SESSION_LIMIT:.0}", w.session)),
         )
         .with_reset(Some(w.session_resets_at), Some(SESSION_MS as i64)),
         Metric::progress(
             "Weekly",
             w.weekly / WEEKLY_LIMIT * 100.0,
-            Some(format!("${:.2} of ${WEEKLY_LIMIT:.0} · this PC only", w.weekly)),
+            Some(format!("${:.2} of ${WEEKLY_LIMIT:.0}", w.weekly)),
         )
         .with_reset(Some(w.weekly_resets_at), Some(WEEK_MS as i64)),
         Metric::progress(
             "Monthly",
             w.monthly / MONTHLY_LIMIT * 100.0,
-            Some(format!("${:.2} of ${MONTHLY_LIMIT:.0} · this PC only", w.monthly)),
+            Some(format!("${:.2} of ${MONTHLY_LIMIT:.0}", w.monthly)),
         )
         .with_reset(Some(w.monthly_resets_at), Some(w.monthly_period_ms)),
     ];
@@ -140,8 +140,9 @@ fn go_windows(rows: &[(f64, f64)], now_ms: f64) -> GoWindows {
     let sum_range = |start: f64, end: f64| -> f64 {
         let total: f64 =
             rows.iter().filter(|(ts, _)| *ts >= start && *ts < end).map(|(_, c)| c).sum();
-        // Snap to a hundredth of a cent to shed float-summation noise.
-        (total * 10_000.0).round() / 10_000.0
+        // Snap to a hundredth of a cent to shed float-summation noise;
+        // max(0.0) also normalizes -0.0, which would render as "$-0.00".
+        ((total * 10_000.0).round() / 10_000.0).max(0.0)
     };
 
     let session_start = now_ms - SESSION_MS;


### PR DESCRIPTION
## What

- Removes the ` · this PC only` suffix from the OpenCode Session / Weekly / Monthly meter captions — it repeated on every row of the card and every share card. The local-counting caveat still lives in `docs/providers.md` (reworded, same substance).
- Clamps the Go window sums to `>= 0.0`, which also normalizes IEEE `-0.0` — an idle session could previously render as `$-0.00 of $12`.

## Why

Requested cleanup: the caption was noisy, and the `$-0.00` showed up on a real share card.

## Testing

- `cargo test`: 43 passed, 0 failed.
- Built + installed locally; verified via the local HTTP API and on the live card that captions render as `$6.14 of $60` with no suffix and the idle session shows `$0.00`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->