### PR TITLE
Show a "What's new" popup after updates + changelog viewer in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Added
+- **"What's new" after every update** — the first time you open Pane on a
+  new version, a card-styled popup shows that version's changelog (click
+  anywhere outside it to dismiss). Settings also gains a **What's new ·
+  Changelog** button that lists every released version. Fresh installs
+  keep the welcome card only — no double popup.
 - **AihubMix provider (#18)** — the OpenAI-compatible multi-model
   gateway gets a full card: usage metered against your account's
   spending limit (key auto-detected from OpenCode, or pasted in

--- a/index.html
+++ b/index.html
@@ -263,6 +263,10 @@
         </div></div>
       </div>
 
+      <button id="changelog-btn" type="button">
+        What&#8217;s new &#183; Changelog
+      </button>
+
       <p class="settings-note" style="margin-top: 12px">
         Providers, row order, and tray-strip stars live in
         <strong>Customize</strong> (&#9776; in the sidebar). Star up to 2

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -92,6 +92,9 @@ fn config_with_defaults(mut cfg: Value) -> Value {
     obj.entry("proxy").or_insert(json!({ "enabled": false, "url": "" }));
     obj.entry("showTotalSpend").or_insert(json!(true));
     obj.entry("welcomeDismissed").or_insert(json!(false));
+    // Empty = "never recorded": the frontend uses it to tell a fresh
+    // install (no What's-new popup) from an update (popup with the notes).
+    obj.entry("lastSeenVersion").or_insert(json!(""));
     // Telemetry defaults ON and must SAY so: without this default the
     // Settings toggle read `undefined` (rendered off) while the sender's
     // own default kept transmitting — a switch that displays off while
@@ -134,6 +137,7 @@ const CONFIG_KEYS: &[&str] = &[
     "proxy",
     "showTotalSpend",
     "welcomeDismissed",
+    "lastSeenVersion",
     "telemetry",
 ];
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1319,8 +1319,11 @@ function parseChangelog(): ChangelogSection[] {
 }
 
 /// Markdown-lite for changelog bodies: ### subheads, - bullets (with hanging
-/// continuation lines), **bold**, `code`. Input is escaped before any markup
-/// is applied, so the changelog can never inject HTML.
+/// continuation lines), plain paragraphs, **bold**, `code`. Bullets and
+/// paragraphs accumulate as raw markdown and are transformed only on flush,
+/// so a bold/code span wrapped across the file's ~70-column lines still
+/// matches. Input is escaped before any markup is applied, so the changelog
+/// can never inject HTML.
 function renderChangelogBody(md: string): string {
   const inline = (s: string) =>
     escapeHtml(s)
@@ -1328,21 +1331,34 @@ function renderChangelogBody(md: string): string {
       .replace(/`([^`]+)`/g, "<code>$1</code>");
   let html = "";
   let items: string[] = [];
-  const flush = () => {
-    if (items.length) html += `<ul>${items.map((i) => `<li>${i}</li>`).join("")}</ul>`;
+  let para = "";
+  const flushItems = () => {
+    if (items.length) html += `<ul>${items.map((i) => `<li>${inline(i)}</li>`).join("")}</ul>`;
     items = [];
+  };
+  const flushPara = () => {
+    if (para) html += `<p>${inline(para)}</p>`;
+    para = "";
   };
   for (const line of md.split("\n")) {
     if (line.startsWith("### ")) {
-      flush();
+      flushItems();
+      flushPara();
       html += `<h5>${escapeHtml(line.slice(4).trim())}</h5>`;
     } else if (line.startsWith("- ")) {
-      items.push(inline(line.slice(2)));
+      flushPara();
+      items.push(line.slice(2));
     } else if (/^\s+\S/.test(line) && items.length) {
-      items[items.length - 1] += " " + inline(line.trim());
+      items[items.length - 1] += " " + line.trim();
+    } else if (line.trim()) {
+      flushItems();
+      para += (para ? " " : "") + line.trim();
+    } else {
+      flushPara();
     }
   }
-  flush();
+  flushItems();
+  flushPara();
   return html;
 }
 
@@ -1408,8 +1424,11 @@ function computeWhatsNew(version: string): ChangelogSection[] | null {
   if (!last) {
     // First run with this feature. An install that already dismissed the
     // welcome card is an *update* — show the new version's notes. A true
-    // fresh install gets the welcome card instead, not two popups.
-    return config.welcomeDismissed ? all.filter((s) => s.version === version) : null;
+    // fresh install gets the welcome card instead, not two popups. Guard
+    // the empty case (e.g. a build whose notes are still Unreleased) —
+    // an empty array is truthy and would present a blank dialog.
+    const own = config.welcomeDismissed ? all.filter((s) => s.version === version) : [];
+    return own.length ? own : null;
   }
   const out: ChangelogSection[] = [];
   for (const s of all) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,9 @@ import openrouterIcon from "./assets/providers/openrouter.svg?raw";
 import paneLogo from "./assets/pane-logo.png?inline";
 import paneIcon from "./assets/pane-icon.png?inline";
 import zaiIcon from "./assets/providers/zai.svg?raw";
+// The repo's changelog ships inside the bundle, so the "What's new" dialog
+// and the Settings changelog viewer read the exact file releases maintain.
+import changelogRaw from "../CHANGELOG.md?raw";
 
 const PROVIDER_ICONS: Record<string, string> = {
   antigravity: antigravityIcon,
@@ -177,6 +180,7 @@ interface Config {
   proxy: { enabled: boolean; url: string };
   showTotalSpend: boolean;
   welcomeDismissed: boolean;
+  lastSeenVersion: string;
 }
 
 const ALL_PROVIDERS: [string, string][] = [
@@ -304,6 +308,7 @@ let config: Config = {
   proxy: { enabled: false, url: "" },
   showTotalSpend: true,
   welcomeDismissed: false,
+  lastSeenVersion: "",
 };
 let lastFetch = 0;
 let refreshing = false;
@@ -1281,6 +1286,137 @@ function appConfirm(opts: {
     document.body.appendChild(overlay);
     overlay.querySelector<HTMLButtonElement>("#confirm-ok")!.focus();
   });
+}
+
+// ---------------------------------------------------------------------------
+// Changelog — "What's new" after an update + the Settings viewer
+// ---------------------------------------------------------------------------
+
+interface ChangelogSection {
+  version: string;
+  date: string;
+  body: string;
+}
+
+/// CHANGELOG.md split into per-version sections, newest first. The
+/// "Unreleased" section is skipped — a shipped build's own notes carry its
+/// version header (release retitles Unreleased), so users only ever see
+/// released entries.
+function parseChangelog(): ChangelogSection[] {
+  const sections: ChangelogSection[] = [];
+  for (const block of changelogRaw.split(/^## /m).slice(1)) {
+    const nl = block.indexOf("\n");
+    const header = block.slice(0, nl).trim();
+    if (/^unreleased$/i.test(header)) continue;
+    const m = header.match(/^([\d.]+)\s*—\s*(.+)$/);
+    sections.push({
+      version: m ? m[1] : header,
+      date: m ? m[2] : "",
+      body: block.slice(nl + 1).trim(),
+    });
+  }
+  return sections;
+}
+
+/// Markdown-lite for changelog bodies: ### subheads, - bullets (with hanging
+/// continuation lines), **bold**, `code`. Input is escaped before any markup
+/// is applied, so the changelog can never inject HTML.
+function renderChangelogBody(md: string): string {
+  const inline = (s: string) =>
+    escapeHtml(s)
+      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+      .replace(/`([^`]+)`/g, "<code>$1</code>");
+  let html = "";
+  let items: string[] = [];
+  const flush = () => {
+    if (items.length) html += `<ul>${items.map((i) => `<li>${i}</li>`).join("")}</ul>`;
+    items = [];
+  };
+  for (const line of md.split("\n")) {
+    if (line.startsWith("### ")) {
+      flush();
+      html += `<h5>${escapeHtml(line.slice(4).trim())}</h5>`;
+    } else if (line.startsWith("- ")) {
+      items.push(inline(line.slice(2)));
+    } else if (/^\s+\S/.test(line) && items.length) {
+      items[items.length - 1] += " " + inline(line.trim());
+    }
+  }
+  flush();
+  return html;
+}
+
+/// Same lifecycle as dismissConfirm: the popover reopen routine clears a
+/// stale dialog left behind by hide-on-focus-loss.
+let dismissWhatsNew: (() => void) | null = null;
+
+/// Card-styled scrollable dialog listing changelog sections. Esc, backdrop
+/// clicks (anywhere outside the card), and the Got it button all dismiss.
+function showChangelogDialog(title: string, sections: ChangelogSection[]): void {
+  dismissWhatsNew?.();
+  const overlay = document.createElement("div");
+  overlay.id = "whatsnew-overlay";
+  const list = sections
+    .map(
+      (s) =>
+        `<section><h4>v${escapeHtml(s.version)}${
+          s.date ? `<span>${escapeHtml(s.date)}</span>` : ""
+        }</h4>${renderChangelogBody(s.body)}</section>`,
+    )
+    .join("");
+  overlay.innerHTML = `
+    <div id="whatsnew-box" role="dialog" aria-modal="true">
+      <h3>${escapeHtml(title)}</h3>
+      <div id="whatsnew-body">${list}</div>
+      <div id="whatsnew-actions">
+        <button id="whatsnew-ok" type="button">Got it</button>
+      </div>
+    </div>`;
+  const done = () => {
+    dismissWhatsNew = null;
+    document.removeEventListener("keydown", onKey, true);
+    overlay.remove();
+  };
+  dismissWhatsNew = done;
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      done();
+    }
+  };
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) done();
+  });
+  overlay.querySelector("#whatsnew-ok")!.addEventListener("click", done);
+  document.addEventListener("keydown", onKey, true);
+  document.body.appendChild(overlay);
+}
+
+/// The sections a just-updated install hasn't seen yet (newest first,
+/// capped), or null when there's nothing to announce. Marks the current
+/// version as seen immediately so the dialog can only ever appear once per
+/// version, even if it's dismissed by closing the popover.
+let appVersion = "";
+let pendingWhatsNew: ChangelogSection[] | null = null;
+
+function computeWhatsNew(version: string): ChangelogSection[] | null {
+  const last = config.lastSeenVersion;
+  if (last === version) return null;
+  void patchConfig({ lastSeenVersion: version });
+  const all = parseChangelog();
+  if (!last) {
+    // First run with this feature. An install that already dismissed the
+    // welcome card is an *update* — show the new version's notes. A true
+    // fresh install gets the welcome card instead, not two popups.
+    return config.welcomeDismissed ? all.filter((s) => s.version === version) : null;
+  }
+  const out: ChangelogSection[] = [];
+  for (const s of all) {
+    if (s.version === last || out.length >= 5) break;
+    out.push(s);
+  }
+  return out.length ? out : null;
 }
 
 async function shareCard(id: string): Promise<void> {
@@ -2527,6 +2663,7 @@ window.addEventListener("DOMContentLoaded", () => {
     }
   });
   void getVersion().then((v) => {
+    appVersion = v;
     buildText = `v${v} · build ${__BUILD_STAMP__}`;
     renderBuildInfo();
     void checkForUpdate();
@@ -2542,6 +2679,10 @@ window.addEventListener("DOMContentLoaded", () => {
     setSettings(!document.body.classList.contains("settings-open"));
   });
   document.querySelector("#settings-close")!.addEventListener("click", () => setSettings(false));
+  document.querySelector("#changelog-btn")!.addEventListener("click", () => {
+    setSettings(false);
+    showChangelogDialog("Changelog", parseChangelog());
+  });
   document.querySelectorAll<HTMLElement>(".acc-head").forEach((head) => {
     head.addEventListener("click", () => head.parentElement!.classList.toggle("open"));
   });
@@ -2773,6 +2914,12 @@ window.addEventListener("DOMContentLoaded", () => {
     setDrawer(false);
     setSettings(false);
     dismissConfirm?.();
+    dismissWhatsNew?.();
+    // A fresh update's notes present on the first open after launch.
+    if (pendingWhatsNew) {
+      showChangelogDialog(`What's new in v${appVersion}`, pendingWhatsNew);
+      pendingWhatsNew = null;
+    }
     // Replay any renders skipped while hidden, before the reveal plays.
     if (pendingRender) {
       pendingRender = false;
@@ -2787,6 +2934,12 @@ window.addEventListener("DOMContentLoaded", () => {
   void initSettings().then(() => {
     scheduleAutoRefresh();
     void refresh(true);
+    // Queued, not shown: the window is usually still hidden in the tray at
+    // startup — the first popover-shown presents it. Runs after the config
+    // load so lastSeenVersion is the real stored value, not the default.
+    void getVersion().then((v) => {
+      pendingWhatsNew = computeWhatsNew(v);
+    });
   });
 
   // Countdown texts ("Resets in 3h 41m") tick every 30 s — but only for

--- a/src/styles.css
+++ b/src/styles.css
@@ -1881,3 +1881,153 @@ body.no-glass .cust-dock {
     animation: none;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   What's new / Changelog dialog — confirm-dialog styling, scrollable body
+--------------------------------------------------------------------------- */
+
+#whatsnew-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 0.45);
+  backdrop-filter: blur(6px) saturate(1.2);
+  -webkit-backdrop-filter: blur(6px) saturate(1.2);
+  animation: confirm-fade 0.16s ease;
+}
+
+#whatsnew-box {
+  display: flex;
+  flex-direction: column;
+  width: min(92%, 340px);
+  max-height: 78vh;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 18px 18px 14px;
+  box-shadow:
+    0 24px 60px rgb(0 0 0 / 0.45),
+    inset 0 1px 0 rgb(255 255 255 / 0.06);
+  animation: confirm-pop 0.18s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+
+#whatsnew-box h3 {
+  font-size: 14px;
+  font-weight: 650;
+  margin: 0 0 10px;
+}
+
+#whatsnew-body {
+  overflow-y: auto;
+  min-height: 0;
+  margin: 0 -6px 12px 0;
+  padding-right: 6px;
+}
+
+#whatsnew-body section + section {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+#whatsnew-body h4 {
+  font-size: 13px;
+  font-weight: 650;
+  margin: 0 0 4px;
+}
+
+#whatsnew-body h4 span {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  margin-left: 8px;
+}
+
+#whatsnew-body h5 {
+  font-size: 11px;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted-foreground);
+  margin: 8px 0 4px;
+}
+
+#whatsnew-body ul {
+  margin: 0;
+  padding-left: 16px;
+}
+
+#whatsnew-body li {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--secondary-foreground);
+  margin: 4px 0;
+}
+
+#whatsnew-body li strong {
+  color: var(--foreground);
+}
+
+#whatsnew-body code {
+  font-size: 11px;
+  background: var(--accent);
+  border-radius: 4px;
+  padding: 0 4px;
+}
+
+#whatsnew-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+#whatsnew-actions button {
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 5px 14px;
+  cursor: pointer;
+  background: var(--primary);
+  border: 1px solid transparent;
+  color: var(--primary-foreground);
+  transition: opacity 0.15s ease, transform 0.1s ease;
+}
+
+#whatsnew-actions button:hover {
+  opacity: 0.85;
+}
+
+#whatsnew-actions button:active {
+  transform: scale(0.95);
+}
+
+/* The Settings entry point: a quiet full-width pill above the footer note. */
+#changelog-btn {
+  display: block;
+  width: 100%;
+  margin-top: 14px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 6px 14px;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--secondary-foreground);
+  transition: background 0.15s ease;
+}
+
+#changelog-btn:hover {
+  background: var(--accent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #whatsnew-overlay,
+  #whatsnew-box {
+    animation: none;
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1989,11 +1989,16 @@ body.no-glass .cust-dock {
   padding-left: 16px;
 }
 
-#whatsnew-body li {
+#whatsnew-body li,
+#whatsnew-body p {
   font-size: 12px;
   line-height: 1.5;
   color: var(--secondary-foreground);
   margin: 4px 0;
+}
+
+#whatsnew-body p strong {
+  color: var(--foreground);
 }
 
 #whatsnew-body li strong {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1794,15 +1794,23 @@ body.no-glass .cust-dock {
   animation: confirm-fade 0.16s ease;
 }
 
+/* Same liquid-glass material as the What's-new dialog. */
 #confirm-box {
   width: min(88%, 300px);
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0) 38%),
+    rgba(24, 24, 27, 0.55);
+  backdrop-filter: blur(24px) saturate(1.5) brightness(1.04);
+  -webkit-backdrop-filter: blur(24px) saturate(1.5) brightness(1.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 18px;
   padding: 18px 18px 14px;
   box-shadow:
-    0 24px 60px rgb(0 0 0 / 0.45),
-    inset 0 1px 0 rgb(255 255 255 / 0.06);
+    0 24px 60px rgb(0 0 0 / 0.5),
+    inset 0 1px 1.5px rgba(255, 255, 255, 0.35),
+    inset 0 -1px 1px rgba(255, 255, 255, 0.08),
+    inset 1.5px 0 1.5px rgba(255, 255, 255, 0.06),
+    inset -1.5px 0 1.5px rgba(255, 255, 255, 0.06);
   animation: confirm-pop 0.18s cubic-bezier(0.2, 0.8, 0.3, 1);
 }
 
@@ -1899,19 +1907,40 @@ body.no-glass .cust-dock {
   animation: confirm-fade 0.16s ease;
 }
 
+/* Liquid glass — the sidebar/footer/dock recipe, plus a soft top sheen. */
 #whatsnew-box {
   display: flex;
   flex-direction: column;
   width: min(92%, 340px);
   max-height: 78vh;
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0) 38%),
+    rgba(24, 24, 27, 0.55);
+  backdrop-filter: blur(24px) saturate(1.5) brightness(1.04);
+  -webkit-backdrop-filter: blur(24px) saturate(1.5) brightness(1.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 18px;
   padding: 18px 18px 14px;
   box-shadow:
-    0 24px 60px rgb(0 0 0 / 0.45),
-    inset 0 1px 0 rgb(255 255 255 / 0.06);
+    0 24px 60px rgb(0 0 0 / 0.5),
+    inset 0 1px 1.5px rgba(255, 255, 255, 0.35),
+    inset 0 -1px 1px rgba(255, 255, 255, 0.08),
+    inset 1.5px 0 1.5px rgba(255, 255, 255, 0.06),
+    inset -1.5px 0 1.5px rgba(255, 255, 255, 0.06);
   animation: confirm-pop 0.18s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+
+#whatsnew-body::-webkit-scrollbar {
+  width: 5px;
+}
+
+#whatsnew-body::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+}
+
+#whatsnew-body::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 #whatsnew-box h3 {
@@ -2023,6 +2052,31 @@ body.no-glass .cust-dock {
 
 #changelog-btn:hover {
   background: var(--accent);
+}
+
+/* Light theme: white glass, same as the sidebar's light recipe. */
+:root[data-theme="light"] #whatsnew-box,
+:root[data-theme="light"] #confirm-box {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 38%),
+    rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow:
+    0 24px 60px rgb(0 0 0 / 0.3),
+    inset 0 1px 1.5px rgba(255, 255, 255, 0.7);
+}
+
+:root[data-theme="light"] #whatsnew-body::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.18);
+}
+
+/* Glass effects off: flat opaque surfaces, like every other glass layer. */
+body.no-glass #whatsnew-box,
+body.no-glass #confirm-box {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  background: var(--card) !important;
+  border-color: var(--border) !important;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## What

- **"What's new" after updates** — the bundled `CHANGELOG.md` is parsed into per-version sections; on the first popover open after an update, a dialog presents the notes for every version the install hasn't seen (newest first, capped at 5). Esc, the Got it button, or clicking anywhere outside the card dismiss it, and it can only ever appear once per version (`lastSeenVersion` is recorded at queue time).
- **Settings → "What's new · Changelog"** — a button at the bottom of Settings opens the same dialog listing every released version, scrollable.
- **Liquid-glass material** — the new dialog *and* the existing confirm dialogs now use the sidebar/footer/dock glass recipe (translucent blurred base, inset highlights, top sheen, 18px radius). Light theme gets the white-glass variant; `body.no-glass` falls back to flat opaque cards like every other glass layer.

## Design notes

- `lastSeenVersion` is added to `CONFIG_KEYS` **and** seeded in `config_with_defaults` (the telemetry-toggle lesson: a key missing from the whitelist silently never persists).
- Empty `lastSeenVersion` distinguishes install-kind: a fresh install shows only the welcome card (no double popup); an install that already dismissed the welcome is an update and gets the current version's notes.
- The pending popup is computed **after** `initSettings()` resolves, so the stored `lastSeenVersion` — not the default — decides update-vs-fresh (computing it in `getVersion().then` raced the config load).
- The popup queues at startup and presents on `popover-shown` (the window is hidden in the tray at launch); the reopen routine dismisses a stale dialog the same way it does for `appConfirm`.
- Changelog markdown is escaped before the markdown-lite transforms, so the file can never inject HTML.
- "Unreleased" sections are skipped — a shipped build's own notes carry a version header because release retitles it.

## Testing

- `npx tsc --noEmit` and `cargo check --lib` clean; `cargo test` 43 passed.
- Built + installed locally: popup appeared once with the v0.4.27 notes and never re-appeared; Settings button lists the full history; glass renders correctly and user-approved the look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->