### PR TITLE
Price "-priority" model slugs at base rates times the priority multiplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **"-priority" model slugs are priced** — Devin logs OpenAI's priority
+  service tier inside the model name (`gpt-5.6-luna-xhigh-priority`),
+  which no catalog carries, so those requests counted tokens but no
+  dollars. They now bill at the base model's rates times the priority
+  multiplier (2× standard, 2.5× for gpt-5.5), matching how Codex
+  priority turns are already priced.
+
 ## 0.4.28 — 2026-07-31
 
 ### Added

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -161,7 +161,7 @@ pub fn generation() -> u64 {
 /// fingerprinted below — an app update that reprices the same files would
 /// otherwise leave history at the old dollars until upstream happens to
 /// rewrite a catalog.
-const CORRECTIONS_REV: u32 = 1;
+const CORRECTIONS_REV: u32 = 2; // 2: "-priority" slugs price at base × multiplier
 
 /// Stable fingerprint of the effective pricing inputs: the on-disk catalog
 /// files plus this binary's corrections revision. The persistent spend

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -480,6 +480,24 @@ pub fn lookup(model: &str) -> Option<Price> {
     result
 }
 
+/// Every rate in `p` multiplied by `m` — service tiers (fast, priority)
+/// bill at a multiple of the base model's whole rate card.
+fn scaled_price(p: &Price, m: f64) -> Price {
+    let scale = |v: Option<f64>| v.map(|x| x * m);
+    Price {
+        input: p.input * m,
+        output: p.output * m,
+        cache_read: p.cache_read * m,
+        cache_write: p.cache_write * m,
+        input_200k: scale(p.input_200k),
+        output_200k: scale(p.output_200k),
+        cache_read_200k: scale(p.cache_read_200k),
+        cache_write_200k: scale(p.cache_write_200k),
+        cache_write_1h: scale(p.cache_write_1h),
+        cache_write_1h_200k: scale(p.cache_write_1h_200k),
+    }
+}
+
 fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
     // Alias rules come from a third-party URL; a crafted rule set could
     // otherwise bounce a name between an alias and the -max strip below
@@ -522,19 +540,25 @@ fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
             }
         };
         if let Some(p) = resolve(s, base, depth + 1) {
-            let scale = |v: Option<f64>| v.map(|x| x * m);
-            return Some(Price {
-                input: p.input * m,
-                output: p.output * m,
-                cache_read: p.cache_read * m,
-                cache_write: p.cache_write * m,
-                input_200k: scale(p.input_200k),
-                output_200k: scale(p.output_200k),
-                cache_read_200k: scale(p.cache_read_200k),
-                cache_write_200k: scale(p.cache_write_200k),
-                cache_write_1h: scale(p.cache_write_1h),
-                cache_write_1h_200k: scale(p.cache_write_1h_200k),
-            });
+            return Some(scaled_price(&p, m));
+        }
+    }
+    // Priority processing tier: some CLIs (Devin) bake the service tier
+    // into the slug itself ("gpt-5.6-luna-xhigh-priority") instead of
+    // flagging it per turn the way Codex rollouts do. OpenAI bills
+    // priority at a per-model multiplier over the standard rate — keep
+    // this table in sync with spend.rs's codex_priority_multiplier.
+    if let Some(base) = canonical.strip_suffix("-priority") {
+        let mut mkey = base;
+        while let Some(next) = ["-xhigh", "-light", "-low", "-medium", "-high", "-max", "-ultra"]
+            .iter()
+            .find_map(|suf| mkey.strip_suffix(suf))
+        {
+            mkey = next;
+        }
+        let m = if matches!(mkey, "gpt-5.5" | "gpt-5.5-pro") { 2.5 } else { 2.0 };
+        if let Some(p) = resolve(s, base, depth + 1) {
+            return Some(scaled_price(&p, m));
         }
     }
     // LiteLLM fuzzy: provider-prefixed keys like "anthropic/claude-…".
@@ -609,6 +633,25 @@ mod tests {
         let map = super::parse_modelsdev(&doc);
         let p = map.get("kimi-k3").expect("kimi-k3 parsed");
         assert_eq!((p.input, p.output, p.cache_read, p.cache_write), (3.0, 15.0, 0.3, 3.0));
+    }
+
+    #[test]
+    fn priority_slugs_price_at_base_times_priority_multiplier() {
+        let mut store = super::Store::default();
+        store
+            .supplement
+            .insert("gpt-5.6-luna".into(), super::Price::flat(0.2, 1.2, 0.02, 0.25));
+        // Devin logs the service tier inside the slug; effort tokens between
+        // the base and -priority must not break resolution.
+        let p = super::resolve(&store, "gpt-5.6-luna-xhigh-priority", 0).unwrap();
+        assert!((p.input - 0.4).abs() < 1e-9);
+        assert!((p.output - 2.4).abs() < 1e-9);
+        assert!((p.cache_read - 0.04).abs() < 1e-9);
+
+        // gpt-5.5's priority tier is 2.5x, not the default 2x.
+        store.supplement.insert("gpt-5.5".into(), super::Price::flat(10.0, 45.0, 1.0, 1.25));
+        let p55 = super::resolve(&store, "gpt-5.5-priority", 0).unwrap();
+        assert!((p55.input - 25.0).abs() < 1e-9);
     }
 
     #[test]


### PR DESCRIPTION
## What

Devin bakes OpenAI's priority service tier into the model name itself (`gpt-5.6-luna-xhigh-priority`). No public catalog carries those slugs, so the resolver found no price and the requests counted tokens with zero dollars (surfacing in the ⚠ unpriced warning).

- `resolve()` gains a `-priority` branch mirroring the `-fast` one: strip the suffix, resolve the base through the whole chain (effort tokens like `-xhigh` peel as usual), and scale the full rate card by the per-model priority multiplier — 2× standard, 2.5× for gpt-5.5, matching `spend.rs::codex_priority_multiplier` (a comment on each notes the pairing).
- Rate-card scaling is factored into `scaled_price()`, now shared by the `-fast` and `-priority` branches.
- `CORRECTIONS_REV` bumped to 2: the persistent spend cache holds pre-priced totals, and without a stamp change the previously-$0 priority requests would stay $0 until upstream happened to rewrite a catalog file (the #104 lesson).

Devin's unpriceable internals (`compactor`, `summarizer`, `swe-1-6`) intentionally stay token-only — no public pricing exists.

## Testing

- New test `priority_slugs_price_at_base_times_priority_multiplier`: luna-xhigh-priority resolves to luna × 2 and gpt-5.5-priority to × 2.5. Full suite: 44 passed.
- Built + installed locally: the Devin card's ⚠ list no longer includes the luna slug, and 30-day history repriced upward after the cache invalidation. User-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->