### PR TITLE
README: winget install Pane.Pane is the install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ winget install Pane.Pane
 Pane is in [Microsoft's official winget community repo](https://github.com/microsoft/winget-pkgs/tree/master/manifests/p/Pane/Pane) —
 reviewed, hash-verified, no SmartScreen prompt.
 
+### One-liner (PowerShell)
+
+```powershell
+irm https://pane.jazii.dev/install.ps1 | iex
+```
+
+Downloads the latest release, verifies its SHA-256, installs per-user
+(no admin), and launches Pane. No SmartScreen prompt. Read
+[install.ps1](install.ps1) first if you like — it's one short, commented script.
+
 ### Installer (.exe)
 
 1. Grab **`Pane_x.y.z_x64-setup.exe`** from the

--- a/README.md
+++ b/README.md
@@ -35,15 +35,14 @@ broader AI-workflow companion from there.
 Every release binary is built and published by GitHub Actions straight
 from the tagged source — public build logs, verifiable provenance.
 
-### One-liner (PowerShell — recommended)
+### winget (recommended)
 
-```powershell
-irm https://pane.jazii.dev/install.ps1 | iex
+```
+winget install Pane.Pane
 ```
 
-Downloads the latest release, verifies its SHA-256, installs per-user
-(no admin), and launches Pane. No SmartScreen prompt. Read
-[install.ps1](install.ps1) first if you like — it's one short, commented script.
+Pane is in [Microsoft's official winget community repo](https://github.com/microsoft/winget-pkgs/tree/master/manifests/p/Pane/Pane) —
+reviewed, hash-verified, no SmartScreen prompt.
 
 ### Installer (.exe)
 
@@ -59,17 +58,9 @@ Downloads the latest release, verifies its SHA-256, installs per-user
 
 Silent install (for scripts): `Pane_x.y.z_x64-setup.exe /S`
 
-### winget *(pending review)*
-
-Pane is [submitted to the winget community repo](https://github.com/microsoft/winget-pkgs/pull/399096).
-Once Microsoft's review merges it, this works:
-
-```
-winget install pane
-```
-
-Pane keeps itself current after that either way — every install checks for
-signed updates and offers a one-click restart when a new version ships.
+Whichever way you install, Pane keeps itself current — every install
+checks for signed updates and offers a one-click restart when a new
+version ships.
 
 ### Build from source
 


### PR DESCRIPTION
Pane.Pane is merged into [Microsoft's winget community repo](https://github.com/microsoft/winget-pkgs/pull/399096) 🎉

- `winget install Pane.Pane` becomes the recommended install (reviewed, hash-verified, no SmartScreen prompt)
- The `irm | iex` one-liner stays as the second method (maintainer's call after initial removal); the .exe section follows
- The stale "winget (pending review)" section is retired

pane.jazii.dev shows the winget command only, already deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)