### PR TITLE
Auto-publish releases to winget

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,27 @@
+# Winget auto-publish: whenever CI publishes a GitHub release, this opens
+# the version-update PR against microsoft/winget-pkgs automatically (new
+# manifests under manifests/p/Pane/Pane/<version>/ with the fresh installer
+# URL + SHA-256) — the PR that used to be submitted by hand. Update PRs to
+# an existing package are auto-validated by winget's pipeline and merge
+# without human review, so releases reach winget within hours.
+#
+# Needs a WINGET_TOKEN repository secret: a classic personal access token
+# with ONLY the `public_repo` scope (create at github.com/settings/tokens).
+# The action uses it to push a branch to the ItsJazii/winget-pkgs fork and
+# open the PR. Without the secret the job fails loudly and the release is
+# otherwise unaffected.
+name: Publish to winget
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  winget:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: Pane.Pane
+          installers-regex: '-setup\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Now that [Pane.Pane is in winget](https://github.com/microsoft/winget-pkgs/pull/399096), every future release should flow there automatically.

This adds a workflow that fires when CI publishes a release: [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) generates the new version manifests from the release assets (installer URL + SHA-256, matched by `-setup\.exe$` so the `.sig` and `latest.json` are ignored) and opens the update PR against microsoft/winget-pkgs from the existing ItsJazii/winget-pkgs fork. Update PRs to an existing package auto-validate and merge without human review.

**Action required after merge:** create a classic PAT with only the `public_repo` scope ([github.com/settings/tokens](https://github.com/settings/tokens)) and save it as the `WINGET_TOKEN` repository secret (Settings → Secrets and variables → Actions). Until then the job fails loudly on release and nothing else is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->