### PR TITLE
Show bought Codex credits as a plan-style Extra credits meter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   it), feeding pace colors and the Almost Out notification like every
   other window — with the dollar and credit count in the caption.
   Devin's Extra balance gets the same meter treatment when funded.
+  Layouts learned a matching rule: progress bars never hide behind
+  Show more and always sit above the Usage Trend, so an upgraded row
+  (or one saved as a text row in an older layout) surfaces properly.
 
 ## 0.4.29 — 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Bought Codex credits show up now** — the ChatGPT API sends the
+  credit balance as a quoted string in some responses, which the parser
+  didn't accept, so buying Extra credits made the row vanish from the
+  card entirely (an empty balance still rendered via a fallback). A
+  funded balance now shows as an **Extra credits** plan-style meter —
+  percent bar against the highest balance Pane has seen (top-ups raise
+  it), feeding pace colors and the Almost Out notification like every
+  other window — with the dollar and credit count in the caption.
+  Devin's Extra balance gets the same meter treatment when funded.
+
 ## 0.4.29 — 2026-08-05
 
 ### Added

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -194,21 +194,26 @@ async fn fetch() -> Result<Snapshot, String> {
         }
     }
 
-    // Extra Usage: pay-as-you-go credit balance ($0.04 per credit). A spent
-    // balance still reads "$0.00 · 0 credits" — that's information, not noise.
-    let credit_balance = usage
-        .pointer("/credits/balance")
-        .and_then(Value::as_f64)
-        .or_else(|| {
-            (usage.pointer("/credits/has_credits").and_then(Value::as_bool) == Some(false))
-                .then_some(0.0)
-        });
-    if let Some(balance) = credit_balance {
-        let credits = balance.floor().max(0.0);
-        metrics.push(Metric::text(
-            "Extra usage",
-            format!("${:.2} · {credits:.0} credits", credits * 0.04),
-        ));
+    // Extra Usage: pay-as-you-go credit balance ($0.04 per credit). A
+    // positive balance gets a plan-style meter against the highest balance
+    // seen (a top-up raises it, same mechanism as Moonshot/DeepSeek); a
+    // spent balance still reads "$0.00 · 0 credits" — that's information,
+    // not noise.
+    if usage.pointer("/credits/unlimited").and_then(Value::as_bool) == Some(true) {
+        metrics.push(Metric::text("Extra credits", "Unlimited".into()));
+    } else if let Some(credits) = credits_balance(&usage) {
+        if credits > 0.0 {
+            let dollars = credits * 0.04;
+            match super::credit_meter_labeled("codex-extra", "$", dollars, "Extra credits") {
+                Some(m) => metrics.push(m),
+                None => metrics.push(Metric::text(
+                    "Extra credits",
+                    format!("${dollars:.2} · {credits:.0} credits"),
+                )),
+            }
+        } else {
+            metrics.push(Metric::text("Extra usage", "$0.00 · 0 credits".into()));
+        }
     }
 
     // Per-credit rows with exact expiry (and a Use button in the UI) from
@@ -254,6 +259,43 @@ async fn fetch() -> Result<Snapshot, String> {
         return Err("usage response had no recognizable rate limits".into());
     }
     Ok(Snapshot::ok(ID, NAME, plan, metrics))
+}
+
+/// The credit balance from the usage body. The API serializes it
+/// inconsistently — a JSON number in some responses, a quoted string in
+/// others (rollout logs show `"balance":"0"`) — so both spellings parse.
+/// A missing balance with `has_credits: false` reads as an explicit zero.
+fn credits_balance(usage: &Value) -> Option<f64> {
+    usage
+        .pointer("/credits/balance")
+        .and_then(|v| v.as_f64().or_else(|| v.as_str().and_then(|s| s.trim().parse().ok())))
+        .map(|b| b.floor().max(0.0))
+        .or_else(|| {
+            (usage.pointer("/credits/has_credits").and_then(Value::as_bool) == Some(false))
+                .then_some(0.0)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::credits_balance;
+    use serde_json::json;
+
+    #[test]
+    fn credit_balance_parses_number_and_string_spellings() {
+        // String balance (the shape rollout logs show) — the bug that made
+        // a freshly bought balance vanish from the card entirely.
+        let s = json!({"credits": {"has_credits": true, "balance": "2500"}});
+        assert_eq!(credits_balance(&s), Some(2500.0));
+        // Number balance.
+        let n = json!({"credits": {"has_credits": true, "balance": 125.0}});
+        assert_eq!(credits_balance(&n), Some(125.0));
+        // No balance field, explicitly no credits → explicit zero row.
+        let none = json!({"credits": {"has_credits": false}});
+        assert_eq!(credits_balance(&none), Some(0.0));
+        // No credits object at all → no row.
+        assert_eq!(credits_balance(&json!({})), None);
+    }
 }
 
 const CREDITS_URL: &str = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -199,16 +199,22 @@ async fn fetch() -> Result<Snapshot, String> {
     // seen (a top-up raises it, same mechanism as Moonshot/DeepSeek); a
     // spent balance still reads "$0.00 · 0 credits" — that's information,
     // not noise.
-    if usage.pointer("/credits/unlimited").and_then(Value::as_bool) == Some(true) {
+    // The same serializer that quotes the balance may quote this flag.
+    let unlimited = usage
+        .pointer("/credits/unlimited")
+        .is_some_and(|v| v.as_bool() == Some(true) || v.as_str().map(str::trim) == Some("true"));
+    if unlimited {
         metrics.push(Metric::text("Extra credits", "Unlimited".into()));
     } else if let Some(credits) = credits_balance(&usage) {
         if credits > 0.0 {
             let dollars = credits * 0.04;
-            match super::credit_meter_labeled("codex-extra", "$", dollars, "Extra credits") {
+            let suffix = format!(" · {credits:.0} credits");
+            match super::credit_meter_labeled("codex-extra", "$", dollars, "Extra credits", &suffix)
+            {
                 Some(m) => metrics.push(m),
                 None => metrics.push(Metric::text(
                     "Extra credits",
-                    format!("${dollars:.2} · {credits:.0} credits"),
+                    format!("${dollars:.2}{suffix}"),
                 )),
             }
         } else {

--- a/src-tauri/src/providers/devin.rs
+++ b/src-tauri/src/providers/devin.rs
@@ -135,10 +135,16 @@ async fn fetch() -> Result<Snapshot, String> {
         _ => {}
     }
     if let Some(micros) = as_num(plan_status.get("overageBalanceMicros")) {
-        metrics.push(Metric::text(
-            "Extra balance",
-            format!("${:.2}", micros.max(0.0) / 1_000_000.0),
-        ));
+        let dollars = micros.max(0.0) / 1_000_000.0;
+        // A funded balance meters like a plan window (against the highest
+        // balance seen — a top-up raises it); an empty one stays a plain row.
+        let meter = (dollars > 0.0)
+            .then(|| super::credit_meter_labeled("devin-extra", "$", dollars, "Extra balance"))
+            .flatten();
+        match meter {
+            Some(m) => metrics.push(m),
+            None => metrics.push(Metric::text("Extra balance", format!("${dollars:.2}"))),
+        }
     }
 
     if metrics.is_empty() {

--- a/src-tauri/src/providers/devin.rs
+++ b/src-tauri/src/providers/devin.rs
@@ -139,7 +139,7 @@ async fn fetch() -> Result<Snapshot, String> {
         // A funded balance meters like a plan window (against the highest
         // balance seen — a top-up raises it); an empty one stays a plain row.
         let meter = (dollars > 0.0)
-            .then(|| super::credit_meter_labeled("devin-extra", "$", dollars, "Extra balance"))
+            .then(|| super::credit_meter_labeled("devin-extra", "$", dollars, "Extra balance", ""))
             .flatten();
         match meter {
             Some(m) => metrics.push(m),

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -235,6 +235,18 @@ pub fn credential_string(target: &str) -> Option<String> {
 /// keep the story. As a progress row it also feeds the notification rules
 /// ("Almost Out" fires under 10% remaining) like every other meter.
 pub fn credit_meter(provider: &str, sign: &str, balance: f64) -> Option<Metric> {
+    credit_meter_labeled(provider, sign, balance, "Credits used")
+}
+
+/// credit_meter with a caller-chosen row label — purchased-credit pools
+/// (Codex Extra credits, Devin's extra balance) meter identically but
+/// shouldn't all be called "Credits used".
+pub fn credit_meter_labeled(
+    provider: &str,
+    sign: &str,
+    balance: f64,
+    label: &str,
+) -> Option<Metric> {
     if !balance.is_finite() || balance < 0.0 {
         return None;
     }
@@ -263,7 +275,7 @@ pub fn credit_meter(provider: &str, sign: &str, balance: f64) -> Option<Metric> 
     }
     let used = ((1.0 - balance / high) * 100.0).clamp(0.0, 100.0);
     Some(Metric::progress(
-        "Credits used",
+        label,
         used,
         Some(format!("{sign}{balance:.2} of {sign}{high:.2} left")),
     ))

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -235,17 +235,19 @@ pub fn credential_string(target: &str) -> Option<String> {
 /// keep the story. As a progress row it also feeds the notification rules
 /// ("Almost Out" fires under 10% remaining) like every other meter.
 pub fn credit_meter(provider: &str, sign: &str, balance: f64) -> Option<Metric> {
-    credit_meter_labeled(provider, sign, balance, "Credits used")
+    credit_meter_labeled(provider, sign, balance, "Credits used", "")
 }
 
-/// credit_meter with a caller-chosen row label — purchased-credit pools
-/// (Codex Extra credits, Devin's extra balance) meter identically but
-/// shouldn't all be called "Credits used".
+/// credit_meter with a caller-chosen row label and caption suffix —
+/// purchased-credit pools (Codex Extra credits, Devin's extra balance)
+/// meter identically but shouldn't all be called "Credits used", and some
+/// carry an extra unit in the caption ("· N credits").
 pub fn credit_meter_labeled(
     provider: &str,
     sign: &str,
     balance: f64,
     label: &str,
+    caption_suffix: &str,
 ) -> Option<Metric> {
     if !balance.is_finite() || balance < 0.0 {
         return None;
@@ -277,7 +279,7 @@ pub fn credit_meter_labeled(
     Some(Metric::progress(
         label,
         used,
-        Some(format!("{sign}{balance:.2} of {sign}{high:.2} left")),
+        Some(format!("{sign}{balance:.2} of {sign}{high:.2} left{caption_suffix}")),
     ))
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -470,9 +470,33 @@ function ensureLayout(): void {
     // New metrics ship once; spend rows appear when spend data first exists.
     for (const m of s.metrics) {
       if (!L.metricOrder.includes(m.label)) {
-        L.metricOrder.push(m.label);
+        // Progress bars slot in above the Usage Trend (bars first, trend
+        // after, like the Mac cards); everything else appends at the end.
+        const trendAt = L.metricOrder.indexOf(TREND_KEY);
+        if (m.kind === "progress" && trendAt >= 0) {
+          L.metricOrder.splice(trendAt, 0, m.label);
+        } else {
+          L.metricOrder.push(m.label);
+        }
         if (m.kind !== "progress") L.onDemand.push(m.label);
         changed = true;
+      }
+      // A metric that upgraded from text to a progress bar (Extra
+      // credits/balance when funded) must surface like one: bars never
+      // hide behind Show more, and they sit above the Usage Trend.
+      if (m.kind === "progress") {
+        const tucked = L.onDemand.indexOf(m.label);
+        if (tucked >= 0) {
+          L.onDemand.splice(tucked, 1);
+          changed = true;
+        }
+        const at = L.metricOrder.indexOf(m.label);
+        const trendAt = L.metricOrder.indexOf(TREND_KEY);
+        if (at >= 0 && trendAt >= 0 && at > trendAt) {
+          L.metricOrder.splice(at, 1);
+          L.metricOrder.splice(L.metricOrder.indexOf(TREND_KEY), 0, m.label);
+          changed = true;
+        }
       }
     }
     if (spend) {


### PR DESCRIPTION
## What

Buying Codex Extra credits made them **vanish** from the card: the ChatGPT API serializes `credits.balance` as a quoted string in some responses (rollout logs show `"balance":"0"`), the parser only accepted JSON numbers, and only the zero-balance case survived via the `has_credits: false` fallback. So the row displayed `$0.00 · 0 credits` right up until you paid, then disappeared.

- `credits_balance()` now parses both spellings (number and quoted string), with the explicit-zero fallback preserved; covered by a unit test over all four shapes.
- A funded balance renders as an **Extra credits** plan-style meter: percent bar against the highest balance Pane has seen (a top-up raises it automatically — the shared `credit_meter` mechanism from Moonshot/DeepSeek, now label-parameterized as `credit_meter_labeled`), caption `$X of $Y left`, feeding pace colors and the Almost Out notification like every other window.
- `credits.unlimited: true` renders a plain "Unlimited" row instead of a meter.
- Devin's **Extra balance** gets the same meter when funded; an empty balance stays a plain text row on both cards.
- The meter uses a fresh "Extra credits" label (rather than reusing "Extra usage") so existing layouts surface it always-visible like other progress rows instead of inheriting the old text row's tucked-away slot.

## Testing

- `cargo test`: 48 passed (new `credit_balance_parses_number_and_string_spellings`).
- Built + installed on a machine with freshly bought credits: the bar appeared with the correct balance; verified via the local HTTP API and user-confirmed on the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->