### PR TITLE
Fix winget auto-publish never firing on CI-created releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,15 @@ jobs:
             $exe.FullName "$($exe.FullName).sig" latest.json
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Releases created with GITHUB_TOKEN emit no workflow-triggering
+      # `release` event, so hand the baton to the winget workflow
+      # explicitly (workflow_dispatch is exempt from that rule).
+      # Non-fatal: a failed dispatch must not fail a shipped release.
+      - name: Dispatch winget publish
+        if: startsWith(github.ref, 'refs/tags/')
+        continue-on-error: true
+        shell: pwsh
+        run: gh workflow run winget.yml -f tag=$env:GITHUB_REF_NAME
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: write
+      # The winget dispatch step creates a workflow_dispatch event, which
+      # needs actions: write — a permissions block nulls every unlisted
+      # scope, so without this the dispatch 403s (and continue-on-error
+      # would hide it, silently reproducing the never-publishes bug).
+      actions: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,9 +1,15 @@
-# Winget auto-publish: whenever CI publishes a GitHub release, this opens
-# the version-update PR against microsoft/winget-pkgs automatically (new
-# manifests under manifests/p/Pane/Pane/<version>/ with the fresh installer
-# URL + SHA-256) — the PR that used to be submitted by hand. Update PRs to
-# an existing package are auto-validated by winget's pipeline and merge
+# Winget auto-publish: opens the version-update PR against
+# microsoft/winget-pkgs (new manifests with the fresh installer URL +
+# SHA-256) — the PR that used to be submitted by hand. Update PRs to an
+# existing package are auto-validated by winget's pipeline and merge
 # without human review, so releases reach winget within hours.
+#
+# Two triggers because of a GitHub Actions rule: events created with the
+# default GITHUB_TOKEN never start other workflows (anti-recursion), and
+# our releases are created BY the Release workflow — so its `release`
+# event is invisible here. The Release workflow therefore dispatches this
+# one explicitly (workflow_dispatch is exempt from that rule); the
+# `release` trigger still covers releases published by hand.
 #
 # Needs a WINGET_TOKEN repository secret: a classic personal access token
 # with ONLY the `public_repo` scope (create at github.com/settings/tokens).
@@ -15,6 +21,12 @@ name: Publish to winget
 on:
   release:
     types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v0.4.30)"
+        required: true
+        type: string
 
 jobs:
   winget:
@@ -24,4 +36,5 @@ jobs:
         with:
           identifier: Pane.Pane
           installers-regex: '-setup\.exe$'
+          release-tag: ${{ inputs.tag || github.event.release.tag_name }}
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
The 0.4.30 release proved the winget workflow never runs: our releases are created by the Release workflow using the default `GITHUB_TOKEN`, and [GitHub suppresses workflow-triggering events from that token](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) to prevent recursion — so `on: release` is invisible for CI-created releases.

- The Release workflow now dispatches `winget.yml` explicitly after creating the release (`workflow_dispatch` is exempt from the suppression rule). Marked `continue-on-error` so a failed dispatch can never fail an already-shipped release.
- `winget.yml` gains the `workflow_dispatch` trigger with a `tag` input (`release-tag: inputs.tag || event tag`), keeping `on: release` for hand-published releases.
- 0.4.30 was submitted to winget by hand meanwhile ([winget-pkgs#413732](https://github.com/microsoft/winget-pkgs/pull/413732)); this fix is for 0.4.31 onward. Still needs the `WINGET_TOKEN` secret (not yet created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->