### PR TITLE
Share cards: copy exactly what you see + light-mode surface fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Changed
+- **Share cards copy exactly what you see, collapsed too** — a collapsed
+  card's ⧉ copy used to drop the Usage Trend and pace hints for a
+  "compact composition"; since both are visible on the card, the copy
+  read as missing data. Every share now includes everything the card
+  currently renders; only buttons, links, and carets stay out.
+
 ### Fixed
 - **Devin no longer shows a fresh bar when the weekly quota is spent** —
   Devin's API drops zero-valued fields from its JSON (proto3), so an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
   card's ⧉ copy used to drop the Usage Trend and pace hints for a
   "compact composition"; since both are visible on the card, the copy
   read as missing data. Every share now includes everything the card
-  currently renders; only buttons, links, and carets stay out.
+  currently renders; only buttons, links, and carets stay out. Light
+  mode shares also get a real surface hierarchy — grey frame, white
+  card with a soft shadow — instead of the washed grey-on-white blob.
 
 ### Fixed
 - **Devin no longer shows a fresh bar when the weekly quota is spent** —

--- a/src/main.ts
+++ b/src/main.ts
@@ -1507,24 +1507,18 @@ async function shareCard(id: string): Promise<void> {
     clone.style.width = `${W}px`;
     clone.style.boxSizing = "border-box";
 
-    // Shares match what's on screen. A collapsed card copies as the
-    // compact composition (meters + resets, no trend/spend/pace). An
-    // expanded card — its On Demand section is open — copies whole:
-    // trend chart, spend rows, and pace hints included. Interactive
-    // chrome (buttons, links, carets, grips) never belongs in an image.
+    // Shares are strictly what's on screen: everything the card currently
+    // renders — bars, pace hints, the trend, and the On Demand section
+    // when it's open — copies as-is. Only interactive chrome (buttons,
+    // links, carets, grips) never belongs in an image. (The old "compact
+    // composition" for collapsed cards is retired: it dropped the visible
+    // trend and pace hints, which read as missing data in the copy.)
     // .snap-card restores the card surface the popover no longer draws
     // (cards sit flat on the background there, panels carry the chrome).
     clone.classList.add("snap-card");
     if (id !== "__total__") {
-      const chrome = ".share-btn, .card-caret, .quick-links, .action-row, .drag-grip";
-      const expanded = clone.querySelector(".on-demand") !== null;
-      // The pace tick is visible data (the even-pace marker), so it stays
-      // in the what-you-see expanded copy and goes with the other pace
-      // elements in the compact one.
       clone
-        .querySelectorAll(
-          expanded ? chrome : `${chrome}, .metric.trend, [data-spend], .pace-note, .tick`
-        )
+        .querySelectorAll(".share-btn, .card-caret, .quick-links, .action-row, .drag-grip")
         .forEach((n) => n.remove());
     }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1748,8 +1748,20 @@ body.no-glass .cust-dock {
   border: none;
   padding: 14px 16px 12px;
 }
+/* Light snapshots: in the app's light theme --background and --card are
+   both near-white, which made the share read as a washed grey blob on
+   white. The snapshot flips to the app's real light hierarchy instead —
+   grey frame, white card lifted by a soft shadow, faint inset panel. */
+:root[data-theme="light"] #snap-root {
+  background: #e8eaee;
+}
+:root[data-theme="light"] .snap-card {
+  background: #ffffff;
+  border-color: rgba(0, 0, 0, 0.08);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.1);
+}
 :root[data-theme="light"] .snap-card .card-panel {
-  background: rgba(0, 0, 0, 0.05);
+  background: rgba(0, 0, 0, 0.045);
 }
 .snap-card .metric {
   margin: 12px 0;


### PR DESCRIPTION
## What

Two share-card fixes, verified together on a live install:

**Collapsed copies keep everything visible** — the old "compact composition" stripped the Usage Trend, pace notes (the 🔥 warnings), and the even-pace tick from a collapsed card's ⧉ copy even though all three are visible on the card, so copies read as missing data. Shares are now strictly what-you-see: everything the card currently renders copies as-is (expanded cards unchanged — they already copied whole); only interactive chrome (share button, caret, quick links, action rows, drag grip) is stripped.

**Light-mode shares get a real surface hierarchy** — light theme's `--background` and `--card` are both near-white, so snapshots rendered as a washed grey blob on white. The snapshot now mirrors the app's own light hierarchy: light grey frame, white card lifted by a soft shadow, faint inset panel. Dark shares unchanged.

## Testing

- `npx tsc --noEmit` clean; built + installed locally. Collapsed Claude card copy verified to include all three meters with 🔥 pace notes, ticks, resets, and the trend; light-mode copies verified against the app's light theme. User-approved both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->