### PR TITLE
Multi-account Claude and Codex: one card per discovered login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Multi-account Claude** — machines with more than one Claude login
+  (say a personal plan in `~\.claude` and an enterprise seat kept in a
+  second config dir via `CLAUDE_CONFIG_DIR`) now get one card per
+  account, each with its own limits, plan, and spend scoped to its own
+  logs. Discovery scans dot-folders in your home directory and
+  `~\.config` for Claude-shaped config dirs and only makes a card when
+  the dir can name its account (from its `.claude.json`); the same
+  account signed in twice stays one card. Extra cards are named from
+  the account's organization or email ("Claude — Acme"); the default
+  login keeps the plain `claude` identity, so existing layouts, stars,
+  and API consumers are untouched. Design follows upstream OpenUsage's
+  account-first model. Telemetry never learns account identities —
+  a multi-account install reports plain "claude" once.
+
 ## 0.4.31 — 2026-08-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## Unreleased
 
 ### Added
+- **Multi-account Codex** — same treatment for Codex: every discovered
+  `CODEX_HOME`-style login (identified by its ChatGPT account id, named
+  by the account email) gets its own card with its own limits, credits,
+  and spend from its own session logs. Reset-credit redemption routes
+  to the account whose card offered the credit, and each card's Extra
+  credits meter keeps its own high-water baseline. A cache identity
+  stamp also guards both families' default cards: if a different
+  account signs into the default folder between launches, the old
+  account's cached numbers are dropped instead of shown under the new
+  login.
 - **Multi-account Claude** — machines with more than one Claude login
   (say a personal plan in `~\.claude` and an enterprise seat kept in a
   second config dir via `CLAUDE_CONFIG_DIR`) now get one card per

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ success/failure counts — never amounts or error text) — see
 
 | Provider | How Pane connects |
 |---|---|
-| Claude (Claude Code) | `%USERPROFILE%\.claude\.credentials.json` + Anthropic usage API |
+| Claude (Claude Code) | `%USERPROFILE%\.claude\.credentials.json` + Anthropic usage API; multi-account — every discovered config-dir login gets its own card |
 | Codex (Codex CLI) | `%USERPROFILE%\.codex\auth.json` + ChatGPT usage API, incl. reset-credit redemption |
 | Cursor | Cursor's local state database + cursor.com API |
 | OpenCode (Go plan) | Local `opencode.db` spend vs documented plan limits* |

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ success/failure counts — never amounts or error text) — see
 | Provider | How Pane connects |
 |---|---|
 | Claude (Claude Code) | `%USERPROFILE%\.claude\.credentials.json` + Anthropic usage API; multi-account — every discovered config-dir login gets its own card |
-| Codex (Codex CLI) | `%USERPROFILE%\.codex\auth.json` + ChatGPT usage API, incl. reset-credit redemption |
+| Codex (Codex CLI) | `%USERPROFILE%\.codex\auth.json` + ChatGPT usage API, incl. reset-credit redemption; multi-account like Claude |
 | Cursor | Cursor's local state database + cursor.com API |
 | OpenCode (Go plan) | Local `opencode.db` spend vs documented plan limits* |
 | GitHub Copilot | Copilot editor login or GitHub CLI (Credential Manager) + GitHub API |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -44,7 +44,13 @@ Ground rules that apply to every provider:
 
 ## Codex (Codex CLI)
 
-- **Reads:** `%USERPROFILE%\.codex\auth.json`.
+- **Reads:** `%USERPROFILE%\.codex\auth.json` (honors `CODEX_HOME`).
+  **Multi-account:** same discovery as Claude — dot-folders and
+  `~\.config` dirs holding a Codex-shaped `auth.json` each become their
+  own card, identified by `tokens.account_id` (or the id_token's ChatGPT
+  account claim) and named by the account email; a dir that can't name
+  its account is skipped. Reset-credit redemption always uses the
+  account whose card offered the credit.
 - **Calls:** `chatgpt.com/backend-api/wham/usage` (limits, Spark windows,
   credits); `.../wham/rate-limit-reset-credits` (reset credits, and
   `/consume` only when you click Use on a credit); OpenAI token refresh.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -21,7 +21,13 @@ Ground rules that apply to every provider:
 
 - **Reads:** `%USERPROFILE%\.claude\.credentials.json` (honors
   `CLAUDE_CONFIG_DIR`) — the OAuth token Claude Code saved when you logged
-  in.
+  in. **Multi-account:** dot-folders in your home directory and dirs under
+  `%USERPROFILE%\.config` holding a Claude-shaped `.credentials.json` each
+  become their own card, identified by the `oauthAccount` in that dir's
+  `.claude.json` (a dir that can't name its account is skipped; the same
+  account in two places stays one card). Extra cards are named from the
+  account's organization or email; the default login keeps the plain
+  `claude` id. Each account's spend comes from its own dir's logs.
 - **Calls:** `api.anthropic.com/api/oauth/usage` (usage windows);
   `platform.claude.com/v1/oauth/token` (refresh, written back).
 - **Shows:** Session + Weekly windows, per-model weeklies, Extra Usage

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -474,6 +474,12 @@ fn fail_state() -> &'static std::sync::Mutex<std::collections::HashMap<String, F
     STATE.get_or_init(Default::default)
 }
 
+/// The provider family of a card id: "claude@ab12cd34" → "claude". The only
+/// spelling allowed to leave the machine in telemetry.
+fn family_of(id: &str) -> String {
+    id.split('@').next().unwrap_or(id).to_string()
+}
+
 // Owned id/name so dynamically discovered account cards (claude@<hash>)
 // can ride the same guard as the static providers under a 'static spawn.
 async fn guarded<F>(id: String, name: String, fut: F) -> providers::Snapshot
@@ -606,10 +612,12 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
     // Telemetry never learns account-scoped ids — a claude@<hash8> would
     // carry an account-derived hash off the machine. Report families,
     // deduplicated, so a multi-account install looks like "claude" once.
+    // (family_of is applied at EVERY telemetry boundary: enabled ids here,
+    // refresh outcomes, and starred-metric prefixes.)
     let enabled_ids: Vec<String> = {
         let mut fams: Vec<String> = Vec::new();
         for (id, _) in &futs {
-            let fam = id.split('@').next().unwrap_or(id).to_string();
+            let fam = family_of(id);
             if !fams.contains(&fam) {
                 fams.push(fam);
             }
@@ -685,9 +693,22 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
                 .unwrap_or_else(|| json!({}));
             if stored != current {
                 let mut map = cache.lock().unwrap();
+                let mut removed = false;
                 for fam in ["claude", "codex"] {
-                    if stored.get(fam) != current.get(fam) {
-                        map.remove(fam);
+                    if stored.get(fam) != current.get(fam) && map.remove(fam).is_some() {
+                        removed = true;
+                    }
+                }
+                // Persist the PRUNED cache before the new stamp: if this
+                // refresh finds nothing ok (offline launch) the on-disk
+                // cache would otherwise keep the old account's entry while
+                // the stamp already claims the new one, resurrecting the
+                // wrong numbers next launch. Stamp last, so a failed write
+                // just re-prunes next time.
+                let _ = std::fs::create_dir_all(providers::config_dir());
+                if removed {
+                    if let Ok(serialized) = serde_json::to_string(&*map) {
+                        let _ = std::fs::write(&cache_file, serialized);
                     }
                 }
                 drop(map);
@@ -750,14 +771,26 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
                             .map(|a| {
                                 a.iter()
                                     .filter_map(Value::as_str)
-                                    .map(|m| format!("{pid}/{m}"))
+                                    // Family prefix only — an account-scoped
+                                    // pid would ship an account-derived hash.
+                                    .map(|m| format!("{}/{m}", family_of(pid)))
                                     .collect::<Vec<_>>()
                             })
                             .unwrap_or_default()
                     })
-                    .collect()
+                    .collect::<Vec<String>>()
             })
             .unwrap_or_default();
+        // Two accounts starring the same metric collapse to one entry.
+        let starred_metrics: Vec<String> = {
+            let mut out: Vec<String> = Vec::new();
+            for m in starred_metrics {
+                if !out.contains(&m) {
+                    out.push(m);
+                }
+            }
+            out
+        };
         let snap = telemetry::ConfigSnapshot {
             app_version: app.package_info().version.to_string(),
             enabled_providers: enabled_ids,
@@ -777,7 +810,10 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
         let outcomes: Vec<telemetry::Outcome> = all
             .iter()
             .map(|s| telemetry::Outcome {
-                id: s.id.clone(),
+                // Family only: account-scoped ids never leave the machine.
+                // Multiple accounts fold into one family row (accumulate
+                // sums same-key counters).
+                id: family_of(&s.id),
                 status: s.status.clone(),
                 stale: s.stale,
                 error: s.error.clone().or_else(|| s.warning.clone()),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -474,10 +474,14 @@ fn fail_state() -> &'static std::sync::Mutex<std::collections::HashMap<String, F
     STATE.get_or_init(Default::default)
 }
 
-async fn guarded<F>(id: &str, name: &str, fut: F) -> providers::Snapshot
+// Owned id/name so dynamically discovered account cards (claude@<hash>)
+// can ride the same guard as the static providers under a 'static spawn.
+async fn guarded<F>(id: String, name: String, fut: F) -> providers::Snapshot
 where
     F: std::future::Future<Output = providers::Snapshot>,
 {
+    let id = id.as_str();
+    let name = name.as_str();
     let now = now_ms() as i64;
     let benched = {
         let map = fail_state().lock().unwrap();
@@ -547,32 +551,60 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
     // auto-updater downloaded a fresh installer to %TEMP% on every refresh
     // (gigabytes within days). Futures are lazy, so building and dropping
     // a disabled entry here runs none of its code.
-    let futs: Vec<(&str, BoxedSnap)> = vec![
-        ("claude", Box::pin(guarded("claude", "Claude", providers::claude::snapshot()))),
-        ("codex", Box::pin(guarded("codex", "Codex", providers::codex::snapshot()))),
-        ("cursor", Box::pin(guarded("cursor", "Cursor", providers::cursor::snapshot()))),
-        ("opencode", Box::pin(guarded("opencode", "OpenCode", providers::opencode::snapshot()))),
-        ("copilot", Box::pin(guarded("copilot", "Copilot", providers::copilot::snapshot()))),
-        ("grok", Box::pin(guarded("grok", "Grok", providers::grok::snapshot()))),
-        ("devin", Box::pin(guarded("devin", "Devin", providers::devin::snapshot()))),
-        ("minimax", Box::pin(guarded("minimax", "MiniMax", providers::minimax::snapshot()))),
-        ("openrouter", Box::pin(guarded("openrouter", "OpenRouter", providers::openrouter::snapshot()))),
-        ("zai", Box::pin(guarded("zai", "Z.ai", providers::zai::snapshot()))),
-        ("antigravity", Box::pin(guarded("antigravity", "Antigravity", providers::antigravity::snapshot()))),
-        ("deepseek", Box::pin(guarded("deepseek", "DeepSeek", providers::deepseek::snapshot()))),
-        ("moonshot", Box::pin(guarded("moonshot", "Moonshot", providers::moonshot::snapshot()))),
-        ("elevenlabs", Box::pin(guarded("elevenlabs", "ElevenLabs", providers::elevenlabs::snapshot()))),
-        ("ollama", Box::pin(guarded("ollama", "Ollama", providers::ollama::snapshot()))),
-        ("codebuff", Box::pin(guarded("codebuff", "Codebuff", providers::codebuff::snapshot()))),
-        ("kilo", Box::pin(guarded("kilo", "Kilo", providers::kilo::snapshot()))),
-        ("aihubmix", Box::pin(guarded("aihubmix", "AihubMix", providers::aihubmix::snapshot()))),
-        ("qwen", Box::pin(guarded("qwen", "Qwen Code", providers::qwen::snapshot()))),
+    let base: Vec<(&str, BoxedSnap)> = vec![
+        ("claude", Box::pin(guarded("claude".into(), "Claude".into(), providers::claude::snapshot()))),
+        ("codex", Box::pin(guarded("codex".into(), "Codex".into(), providers::codex::snapshot()))),
+        ("cursor", Box::pin(guarded("cursor".into(), "Cursor".into(), providers::cursor::snapshot()))),
+        ("opencode", Box::pin(guarded("opencode".into(), "OpenCode".into(), providers::opencode::snapshot()))),
+        ("copilot", Box::pin(guarded("copilot".into(), "Copilot".into(), providers::copilot::snapshot()))),
+        ("grok", Box::pin(guarded("grok".into(), "Grok".into(), providers::grok::snapshot()))),
+        ("devin", Box::pin(guarded("devin".into(), "Devin".into(), providers::devin::snapshot()))),
+        ("minimax", Box::pin(guarded("minimax".into(), "MiniMax".into(), providers::minimax::snapshot()))),
+        ("openrouter", Box::pin(guarded("openrouter".into(), "OpenRouter".into(), providers::openrouter::snapshot()))),
+        ("zai", Box::pin(guarded("zai".into(), "Z.ai".into(), providers::zai::snapshot()))),
+        ("antigravity", Box::pin(guarded("antigravity".into(), "Antigravity".into(), providers::antigravity::snapshot()))),
+        ("deepseek", Box::pin(guarded("deepseek".into(), "DeepSeek".into(), providers::deepseek::snapshot()))),
+        ("moonshot", Box::pin(guarded("moonshot".into(), "Moonshot".into(), providers::moonshot::snapshot()))),
+        ("elevenlabs", Box::pin(guarded("elevenlabs".into(), "ElevenLabs".into(), providers::elevenlabs::snapshot()))),
+        ("ollama", Box::pin(guarded("ollama".into(), "Ollama".into(), providers::ollama::snapshot()))),
+        ("codebuff", Box::pin(guarded("codebuff".into(), "Codebuff".into(), providers::codebuff::snapshot()))),
+        ("kilo", Box::pin(guarded("kilo".into(), "Kilo".into(), providers::kilo::snapshot()))),
+        ("aihubmix", Box::pin(guarded("aihubmix".into(), "AihubMix".into(), providers::aihubmix::snapshot()))),
+        ("qwen", Box::pin(guarded("qwen".into(), "Qwen Code".into(), providers::qwen::snapshot()))),
     ];
-    let futs: Vec<(&str, BoxedSnap)> = futs
+    let mut futs: Vec<(String, BoxedSnap)> =
+        base.into_iter().map(|(id, fut)| (id.to_string(), fut)).collect();
+    // Extra Claude accounts (multi-login machines): each discovered config
+    // dir renders its own card under a claude@<hash8> id, running the same
+    // provider flow scoped to its dir. The default login keeps the bare id.
+    for acct in providers::claude::discover_extra_accounts() {
+        let (id, name, dir) = (acct.id, acct.name, acct.dir);
+        futs.push((
+            id.clone(),
+            Box::pin(guarded(
+                id.clone(),
+                name.clone(),
+                providers::claude::snapshot_at(dir, id, name),
+            )),
+        ));
+    }
+    let futs: Vec<(String, BoxedSnap)> = futs
         .into_iter()
         .filter(|(id, _)| !disabled.iter().any(|d| d == id))
         .collect();
-    let enabled_ids: Vec<String> = futs.iter().map(|(id, _)| id.to_string()).collect();
+    // Telemetry never learns account-scoped ids — a claude@<hash8> would
+    // carry an account-derived hash off the machine. Report families,
+    // deduplicated, so a multi-account install looks like "claude" once.
+    let enabled_ids: Vec<String> = {
+        let mut fams: Vec<String> = Vec::new();
+        for (id, _) in &futs {
+            let fam = id.split('@').next().unwrap_or(id).to_string();
+            if !fams.contains(&fam) {
+                fams.push(fam);
+            }
+        }
+        fams
+    };
     let handles: Vec<_> = futs
         .into_iter()
         .map(|(_, fut)| tauri::async_runtime::spawn(fut))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -588,6 +588,17 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
             )),
         ));
     }
+    for acct in providers::codex::discover_extra_accounts() {
+        let (id, name, dir) = (acct.id, acct.name, acct.dir);
+        futs.push((
+            id.clone(),
+            Box::pin(guarded(
+                id.clone(),
+                name.clone(),
+                providers::codex::snapshot_at(dir, id, name),
+            )),
+        ));
+    }
     let futs: Vec<(String, BoxedSnap)> = futs
         .into_iter()
         .filter(|(id, _)| !disabled.iter().any(|d| d == id))
@@ -656,6 +667,36 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
                 .unwrap_or_default();
             Mutex::new(loaded)
         });
+        // Cache identity stamp (upstream's Phase 1): if a DIFFERENT account
+        // signed into a default home since the cache was written, that
+        // family's cached last-good snapshot belongs to the old account —
+        // drop it instead of painting the wrong account's numbers under the
+        // bare id. Extra-account cards are immune: their ids are derived
+        // from the account identity itself.
+        {
+            let stamp_file = providers::config_dir().join("cache_identities.json");
+            let current = json!({
+                "claude": providers::claude::default_identity(),
+                "codex": providers::codex::default_identity(),
+            });
+            let stored: Value = std::fs::read_to_string(&stamp_file)
+                .ok()
+                .and_then(|raw| serde_json::from_str(&raw).ok())
+                .unwrap_or_else(|| json!({}));
+            if stored != current {
+                let mut map = cache.lock().unwrap();
+                for fam in ["claude", "codex"] {
+                    if stored.get(fam) != current.get(fam) {
+                        map.remove(fam);
+                    }
+                }
+                drop(map);
+                let _ = std::fs::write(
+                    &stamp_file,
+                    serde_json::to_string_pretty(&current).unwrap_or_default(),
+                );
+            }
+        }
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_millis() as i64)
@@ -871,8 +912,14 @@ fn set_shortcut(app: tauri::AppHandle, shortcut: String) -> Result<(), String> {
 /// Spends one banked Codex rate-limit reset credit. Irreversible — the
 /// frontend shows a confirm dialog before calling this.
 #[tauri::command]
-async fn codex_redeem_credit(credit_id: String) -> Result<String, String> {
-    providers::codex::redeem_credit(&credit_id).await
+async fn codex_redeem_credit(
+    credit_id: String,
+    provider_id: Option<String>,
+) -> Result<String, String> {
+    // provider_id routes multi-account redeems; absent = the default card
+    // (older frontend builds during an update overlap).
+    let pid = provider_id.unwrap_or_else(|| "codex".into());
+    providers::codex::redeem_credit(&pid, &credit_id).await
 }
 
 /// Updater with the app version stamped into the endpoint by us. Tauri's

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -8,26 +8,130 @@ const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const ID: &str = "claude";
 const NAME: &str = "Claude";
 
-fn creds_path() -> PathBuf {
-    let config_dir = std::env::var("CLAUDE_CONFIG_DIR")
+fn default_dir() -> PathBuf {
+    std::env::var("CLAUDE_CONFIG_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".claude"));
-    config_dir.join(".credentials.json")
+        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".claude"))
+}
+
+/// One discovered Claude login. The account at the default config dir keeps
+/// the bare "claude" id forever (upstream OpenUsage's migration-killing
+/// decision: existing layouts, pins, and API consumers never move); every
+/// extra account mints "claude@<hash8>" from its accountUuid.
+pub struct ClaudeAccount {
+    pub id: String,
+    pub name: String,
+    pub dir: PathBuf,
+}
+
+/// The account identity living in a config dir: (accountUuid, label).
+/// Claude Code keeps `.claude.json` inside a custom CLAUDE_CONFIG_DIR but
+/// as a home-level sibling (`~/.claude.json`) for the default `~/.claude`.
+fn dir_identity(dir: &std::path::Path) -> Option<(String, Option<String>)> {
+    let mut candidates = vec![dir.join(".claude.json")];
+    if let Some(home) = dirs::home_dir() {
+        if dir == home.join(".claude") {
+            candidates.push(home.join(".claude.json"));
+        }
+    }
+    for p in candidates {
+        let Ok(raw) = std::fs::read_to_string(&p) else { continue };
+        let Ok(doc) = serde_json::from_str::<Value>(&raw) else { continue };
+        let Some(acct) = doc.get("oauthAccount") else { continue };
+        let Some(uuid) = acct.get("accountUuid").and_then(Value::as_str) else { continue };
+        let label = acct
+            .get("organizationName")
+            .and_then(Value::as_str)
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| acct.get("emailAddress").and_then(Value::as_str))
+            .map(str::to_string);
+        return Some((uuid.to_string(), label));
+    }
+    None
+}
+
+/// Extra Claude logins beyond the default config dir: dot-dirs in the home
+/// folder plus dirs under ~/.config that hold a `.credentials.json` with a
+/// claudeAiOauth entry (how a second account is kept via CLAUDE_CONFIG_DIR).
+/// Identity extraction is validation (upstream's rule): a dir that can't
+/// name its account never becomes a card, and a dir naming an already-seen
+/// account is just another source of it — skipped, so duplicate cards are
+/// structurally impossible.
+pub fn discover_extra_accounts() -> Vec<ClaudeAccount> {
+    let Some(home) = dirs::home_dir() else { return Vec::new() };
+    let default = default_dir();
+    let mut seen: Vec<String> = dir_identity(&default).map(|(u, _)| u).into_iter().collect();
+
+    let mut roots: Vec<PathBuf> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&home) {
+        for e in entries.flatten() {
+            let p = e.path();
+            let dotted = p
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with('.'));
+            if dotted && p.is_dir() {
+                roots.push(p);
+            }
+        }
+    }
+    if let Ok(entries) = std::fs::read_dir(home.join(".config")) {
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                roots.push(p);
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    for dir in roots {
+        if dir == default {
+            continue;
+        }
+        let has_oauth = std::fs::read_to_string(dir.join(".credentials.json"))
+            .ok()
+            .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+            .is_some_and(|doc| doc.get("claudeAiOauth").is_some());
+        if !has_oauth {
+            continue;
+        }
+        let Some((uuid, label)) = dir_identity(&dir) else { continue };
+        if seen.iter().any(|u| u == &uuid) {
+            continue;
+        }
+        seen.push(uuid.clone());
+        let hash8: String = uuid.chars().filter(|c| *c != '-').take(8).collect();
+        let name = match label {
+            Some(l) => format!("Claude — {l}"),
+            None => format!("Claude @{hash8}"),
+        };
+        out.push(ClaudeAccount { id: format!("claude@{hash8}"), name, dir });
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    out
 }
 
 pub async fn snapshot() -> Snapshot {
-    match fetch().await {
+    snapshot_at(default_dir(), ID.to_string(), NAME.to_string()).await
+}
+
+/// Snapshot for one account's config dir — the default card and every
+/// discovered extra account run the exact same flow, only the paths and
+/// the card identity differ.
+pub async fn snapshot_at(dir: PathBuf, id: String, name: String) -> Snapshot {
+    match fetch(&dir, &id, &name).await {
         Ok(s) => s,
-        Err(e) => Snapshot::error(ID, NAME, e),
+        Err(e) => Snapshot::error(&id, &name, e),
     }
 }
 
-async fn fetch() -> Result<Snapshot, String> {
-    let path = creds_path();
+async fn fetch(dir: &std::path::Path, id: &str, name: &str) -> Result<Snapshot, String> {
+    let path = dir.join(".credentials.json");
     if !path.exists() {
         return Ok(Snapshot::no_credentials(
-            ID,
-            NAME,
+            id,
+            name,
             "Claude Code sign-in not found. Run `claude` in a terminal and log in.",
         ));
     }
@@ -200,7 +304,7 @@ async fn fetch() -> Result<Snapshot, String> {
     if metrics.is_empty() {
         return Err("usage response had no recognizable limit windows".into());
     }
-    Ok(Snapshot::ok(ID, NAME, plan, metrics))
+    Ok(Snapshot::ok(id, name, plan, metrics))
 }
 
 /// `resets_at` arrives as ISO-8601 or epoch (seconds when < 1e10, else ms).

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -58,34 +58,11 @@ fn dir_identity(dir: &std::path::Path) -> Option<(String, Option<String>)> {
 /// account is just another source of it — skipped, so duplicate cards are
 /// structurally impossible.
 pub fn discover_extra_accounts() -> Vec<ClaudeAccount> {
-    let Some(home) = dirs::home_dir() else { return Vec::new() };
     let default = default_dir();
     let mut seen: Vec<String> = dir_identity(&default).map(|(u, _)| u).into_iter().collect();
 
-    let mut roots: Vec<PathBuf> = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(&home) {
-        for e in entries.flatten() {
-            let p = e.path();
-            let dotted = p
-                .file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(|n| n.starts_with('.'));
-            if dotted && p.is_dir() {
-                roots.push(p);
-            }
-        }
-    }
-    if let Ok(entries) = std::fs::read_dir(home.join(".config")) {
-        for e in entries.flatten() {
-            let p = e.path();
-            if p.is_dir() {
-                roots.push(p);
-            }
-        }
-    }
-
     let mut out = Vec::new();
-    for dir in roots {
+    for dir in super::account_scan_roots() {
         if dir == default {
             continue;
         }
@@ -110,6 +87,13 @@ pub fn discover_extra_accounts() -> Vec<ClaudeAccount> {
     }
     out.sort_by(|a, b| a.id.cmp(&b.id));
     out
+}
+
+/// The default login's account identity, for the snapshot-cache stamp: a
+/// different account signing into the default dir between launches must
+/// not be served the previous account's cached card.
+pub fn default_identity() -> Option<String> {
+    dir_identity(&default_dir()).map(|(uuid, _)| uuid)
 }
 
 pub async fn snapshot() -> Snapshot {

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -88,7 +88,14 @@ mod tests {
 /// structurally impossible.
 pub fn discover_extra_accounts() -> Vec<ClaudeAccount> {
     let default = default_dir();
-    let mut seen: Vec<String> = dir_identity(&default).map(|(u, _)| u).into_iter().collect();
+    let default_identity = dir_identity(&default);
+    // If the default dir HAS a login but can't name its account, the
+    // duplicate-card guarantee is gone (a candidate holding that same
+    // account would card twice) — discover nothing rather than risk it.
+    if default.join(".credentials.json").exists() && default_identity.is_none() {
+        return Vec::new();
+    }
+    let mut seen: Vec<String> = default_identity.map(|(u, _)| u).into_iter().collect();
 
     let mut out = Vec::new();
     for dir in super::account_scan_roots() {

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -37,17 +37,46 @@ fn dir_identity(dir: &std::path::Path) -> Option<(String, Option<String>)> {
     for p in candidates {
         let Ok(raw) = std::fs::read_to_string(&p) else { continue };
         let Ok(doc) = serde_json::from_str::<Value>(&raw) else { continue };
-        let Some(acct) = doc.get("oauthAccount") else { continue };
-        let Some(uuid) = acct.get("accountUuid").and_then(Value::as_str) else { continue };
-        let label = acct
-            .get("organizationName")
-            .and_then(Value::as_str)
-            .filter(|s| !s.trim().is_empty())
-            .or_else(|| acct.get("emailAddress").and_then(Value::as_str))
-            .map(str::to_string);
-        return Some((uuid.to_string(), label));
+        if let Some(identity) = identity_from(&doc) {
+            return Some(identity);
+        }
     }
     None
+}
+
+/// (accountUuid, label) from a parsed .claude.json — org name first, email
+/// as the fallback label; no uuid, no identity.
+fn identity_from(doc: &Value) -> Option<(String, Option<String>)> {
+    let acct = doc.get("oauthAccount")?;
+    let uuid = acct.get("accountUuid").and_then(Value::as_str)?;
+    let label = acct
+        .get("organizationName")
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| acct.get("emailAddress").and_then(Value::as_str))
+        .map(str::to_string);
+    Some((uuid.to_string(), label))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::identity_from;
+    use serde_json::json;
+
+    #[test]
+    fn claude_identity_extraction_is_validation() {
+        // Org name wins the label; email is the fallback.
+        let org = json!({"oauthAccount": {"accountUuid": "u-1",
+            "organizationName": "Acme", "emailAddress": "a@b.c"}});
+        assert_eq!(identity_from(&org), Some(("u-1".into(), Some("Acme".into()))));
+        let email_only = json!({"oauthAccount": {"accountUuid": "u-2",
+            "organizationName": "  ", "emailAddress": "a@b.c"}});
+        assert_eq!(identity_from(&email_only), Some(("u-2".into(), Some("a@b.c".into()))));
+        // No uuid → no identity → no card (a dir that can't name its
+        // account never becomes one).
+        assert_eq!(identity_from(&json!({"oauthAccount": {}})), None);
+        assert_eq!(identity_from(&json!({})), None);
+    }
 }
 
 /// Extra Claude logins beyond the default config dir: dot-dirs in the home

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -31,6 +31,13 @@ pub struct CodexAccount {
 fn dir_identity(dir: &std::path::Path) -> Option<(String, Option<String>)> {
     let raw = std::fs::read_to_string(dir.join("auth.json")).ok()?;
     let doc: Value = serde_json::from_str(&raw).ok()?;
+    identity_from(&doc)
+}
+
+/// (account id, email label) from a parsed auth.json: tokens.account_id
+/// first, the id_token's ChatGPT account claim as the fallback; a file
+/// that names neither has no identity and never becomes a card.
+fn identity_from(doc: &Value) -> Option<(String, Option<String>)> {
     let tokens = doc.get("tokens")?;
     let claims = tokens
         .get("id_token")
@@ -366,8 +373,32 @@ fn credits_balance(usage: &Value) -> Option<f64> {
 
 #[cfg(test)]
 mod tests {
-    use super::credits_balance;
+    use super::{credits_balance, identity_from};
+    use base64::Engine;
     use serde_json::json;
+
+    fn fake_id_token(claims: serde_json::Value) -> String {
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&claims).unwrap());
+        format!("x.{payload}.y")
+    }
+
+    #[test]
+    fn codex_identity_extraction_is_validation() {
+        // account_id field wins; email claim labels the card.
+        let direct = json!({"tokens": {"account_id": "acct-1",
+            "id_token": fake_id_token(json!({"email": "e@corp.com"}))}});
+        assert_eq!(identity_from(&direct), Some(("acct-1".into(), Some("e@corp.com".into()))));
+        // Empty account_id falls through to the id_token's ChatGPT claim.
+        let via_claim = json!({"tokens": {"account_id": "",
+            "id_token": fake_id_token(json!({
+                "https://api.openai.com/auth": {"chatgpt_account_id": "acct-2"}}))}});
+        assert_eq!(identity_from(&via_claim), Some(("acct-2".into(), None)));
+        // Neither → no identity → no card.
+        let anonymous = json!({"tokens": {"access_token": "k"}});
+        assert_eq!(identity_from(&anonymous), None);
+        assert_eq!(identity_from(&json!({})), None);
+    }
 
     #[test]
     fn credit_balance_parses_number_and_string_spellings() {

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -68,7 +68,13 @@ fn identity_from(doc: &Value) -> Option<(String, Option<String>)> {
 /// rules, and dedup-by-account as the Claude discovery.
 pub fn discover_extra_accounts() -> Vec<CodexAccount> {
     let default = default_home();
-    let mut seen: Vec<String> = dir_identity(&default).map(|(a, _)| a).into_iter().collect();
+    let default_identity = dir_identity(&default);
+    // Same conservative rule as Claude: a default login that can't name
+    // its account voids the dedup guarantee — discover nothing.
+    if default.join("auth.json").exists() && default_identity.is_none() {
+        return Vec::new();
+    }
+    let mut seen: Vec<String> = default_identity.map(|(a, _)| a).into_iter().collect();
 
     let mut out = Vec::new();
     for dir in super::account_scan_roots() {

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -9,11 +9,84 @@ const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const ID: &str = "codex";
 const NAME: &str = "Codex";
 
-fn auth_path() -> PathBuf {
-    let home = std::env::var("CODEX_HOME")
+fn default_home() -> PathBuf {
+    std::env::var("CODEX_HOME")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".codex"));
-    home.join("auth.json")
+        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".codex"))
+}
+
+/// One discovered Codex login. Mirrors the Claude account model (and
+/// upstream OpenUsage's Phase 5a design): the default CODEX_HOME keeps the
+/// bare "codex" id; extras mint "codex@<hash8>" from the account id.
+pub struct CodexAccount {
+    pub id: String,
+    pub name: String,
+    pub dir: PathBuf,
+}
+
+/// The account identity in a Codex home, under upstream's strict rule: a
+/// credential file that can't name its account (tokens.account_id, else
+/// the id_token's ChatGPT account claim) never becomes a card. The email
+/// claim doubles as the card label.
+fn dir_identity(dir: &std::path::Path) -> Option<(String, Option<String>)> {
+    let raw = std::fs::read_to_string(dir.join("auth.json")).ok()?;
+    let doc: Value = serde_json::from_str(&raw).ok()?;
+    let tokens = doc.get("tokens")?;
+    let claims = tokens
+        .get("id_token")
+        .and_then(Value::as_str)
+        .and_then(jwt_claims);
+    let account_id = tokens
+        .get("account_id")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            claims
+                .as_ref()?
+                .pointer("/https:~1~1api.openai.com~1auth/chatgpt_account_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })?;
+    let email = claims
+        .as_ref()
+        .and_then(|c| c.get("email"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string);
+    Some((account_id, email))
+}
+
+/// Extra Codex logins beyond the default home — same scan roots, identity
+/// rules, and dedup-by-account as the Claude discovery.
+pub fn discover_extra_accounts() -> Vec<CodexAccount> {
+    let default = default_home();
+    let mut seen: Vec<String> = dir_identity(&default).map(|(a, _)| a).into_iter().collect();
+
+    let mut out = Vec::new();
+    for dir in super::account_scan_roots() {
+        if dir == default {
+            continue;
+        }
+        let Some((account_id, email)) = dir_identity(&dir) else { continue };
+        if seen.iter().any(|a| a == &account_id) {
+            continue;
+        }
+        seen.push(account_id.clone());
+        let hash8: String = account_id.chars().filter(|c| *c != '-').take(8).collect();
+        let name = match email {
+            Some(e) => format!("Codex — {e}"),
+            None => format!("Codex @{hash8}"),
+        };
+        out.push(CodexAccount { id: format!("codex@{hash8}"), name, dir });
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    out
+}
+
+/// The default login's account identity, for the snapshot-cache stamp.
+pub fn default_identity() -> Option<String> {
+    dir_identity(&default_home()).map(|(a, _)| a)
 }
 
 /// Access tokens are JWTs: three base64 chunks separated by dots. The middle
@@ -27,9 +100,15 @@ fn jwt_claims(token: &str) -> Option<Value> {
 }
 
 pub async fn snapshot() -> Snapshot {
-    match fetch().await {
+    snapshot_at(default_home(), ID.to_string(), NAME.to_string()).await
+}
+
+/// Snapshot for one account's Codex home — the default card and every
+/// discovered extra account run the same flow scoped to their dir.
+pub async fn snapshot_at(dir: PathBuf, id: String, name: String) -> Snapshot {
+    match fetch(&dir, &id, &name).await {
         Ok(s) => s,
-        Err(e) => Snapshot::error(ID, NAME, e),
+        Err(e) => Snapshot::error(&id, &name, e),
     }
 }
 
@@ -41,8 +120,8 @@ struct Access {
 
 /// Loads (and if needed refreshes + writes back) the Codex OAuth access
 /// token. Shared by the usage fetch and the reset-credit redeem command.
-async fn load_access() -> Result<Access, String> {
-    let path = auth_path();
+async fn load_access(dir: &std::path::Path) -> Result<Access, String> {
+    let path = dir.join("auth.json");
     let raw = std::fs::read_to_string(&path).map_err(|e| format!("read auth.json: {e}"))?;
     let mut doc: Value = serde_json::from_str(&raw).map_err(|e| format!("parse auth.json: {e}"))?;
     let tokens = doc
@@ -138,15 +217,15 @@ async fn load_access() -> Result<Access, String> {
     Ok(Access { token: access, account_id, plan })
 }
 
-async fn fetch() -> Result<Snapshot, String> {
-    if !auth_path().exists() {
+async fn fetch(dir: &std::path::Path, id: &str, name: &str) -> Result<Snapshot, String> {
+    if !dir.join("auth.json").exists() {
         return Ok(Snapshot::no_credentials(
-            ID,
-            NAME,
+            id,
+            name,
             "Codex sign-in not found. Run `codex login` in a terminal.",
         ));
     }
-    let auth = load_access().await?;
+    let auth = load_access(dir).await?;
     let (access, account_id) = (auth.token, auth.account_id);
     let mut plan = auth.plan;
 
@@ -209,7 +288,10 @@ async fn fetch() -> Result<Snapshot, String> {
         if credits > 0.0 {
             let dollars = credits * 0.04;
             let suffix = format!(" · {credits:.0} credits");
-            match super::credit_meter_labeled("codex-extra", "$", dollars, "Extra credits", &suffix)
+            // High-water baseline keyed per CARD, not per family — two
+            // accounts' balances must never share one baseline.
+            let meter_key = format!("{id}-extra");
+            match super::credit_meter_labeled(&meter_key, "$", dollars, "Extra credits", &suffix)
             {
                 Some(m) => metrics.push(m),
                 None => metrics.push(Metric::text(
@@ -264,7 +346,7 @@ async fn fetch() -> Result<Snapshot, String> {
     if metrics.is_empty() {
         return Err("usage response had no recognizable rate limits".into());
     }
-    Ok(Snapshot::ok(ID, NAME, plan, metrics))
+    Ok(Snapshot::ok(id, name, plan, metrics))
 }
 
 /// The credit balance from the usage body. The API serializes it
@@ -360,8 +442,20 @@ async fn fetch_reset_credits(access: &str, account_id: &str) -> Option<Vec<(Stri
 
 /// Consumes one banked reset credit — irreversible; the UI confirms first.
 /// POST /consume with a fresh idempotency key; the windows reset server-side.
-pub async fn redeem_credit(credit_id: &str) -> Result<String, String> {
-    let auth = load_access().await?;
+pub async fn redeem_credit(provider_id: &str, credit_id: &str) -> Result<String, String> {
+    // Route the redeem to the account whose card offered the credit — an
+    // extra account's Use button must spend ITS credit, not the default
+    // login's (upstream's CodexResetClaimRouter, in one lookup).
+    let dir = if provider_id == ID {
+        default_home()
+    } else {
+        discover_extra_accounts()
+            .into_iter()
+            .find(|a| a.id == provider_id)
+            .map(|a| a.dir)
+            .ok_or_else(|| format!("unknown Codex account: {provider_id}"))?
+    };
+    let auth = load_access(&dir).await?;
     let redeem_request_id = format!(
         "openusage-{}-{}",
         Utc::now().timestamp_millis(),

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -283,6 +283,36 @@ pub fn credit_meter_labeled(
     ))
 }
 
+/// Candidate roots where a second account's CLI config dir may live:
+/// dot-folders in the home directory plus dirs under ~/.config — the
+/// places CLAUDE_CONFIG_DIR / CODEX_HOME setups conventionally point.
+/// Shared by every provider family that supports multi-account discovery.
+pub(crate) fn account_scan_roots() -> Vec<std::path::PathBuf> {
+    let Some(home) = dirs::home_dir() else { return Vec::new() };
+    let mut roots = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&home) {
+        for e in entries.flatten() {
+            let p = e.path();
+            let dotted = p
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with('.'));
+            if dotted && p.is_dir() {
+                roots.push(p);
+            }
+        }
+    }
+    if let Ok(entries) = std::fs::read_dir(home.join(".config")) {
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                roots.push(p);
+            }
+        }
+    }
+    roots
+}
+
 /// API key lookup: our saved config file first, then environment variables.
 pub fn stored_api_key(provider: &str, env_vars: &[&str]) -> Option<String> {
     let path = config_dir().join(format!("{provider}.json"));

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -38,8 +38,8 @@ pub struct Window {
 
 #[derive(Serialize, Clone)]
 pub struct ProviderSpend {
-    pub id: &'static str,
-    pub name: &'static str,
+    pub id: String,
+    pub name: String,
     pub today: Window,
     pub yesterday: Window,
     pub last30: Window,
@@ -266,15 +266,15 @@ fn finalize_models(raw: HashMap<String, (f64, f64)>, window_cost: f64) -> Vec<Mo
     named
 }
 
-fn build_spend(id: &'static str, name: &'static str, data: FileData) -> ProviderSpend {
+fn build_spend(id: impl Into<String>, name: impl Into<String>, data: FileData) -> ProviderSpend {
     let today = Local::now().date_naive().num_days_from_ce();
     let mut unpriced_models: Vec<String> = data.unpriced.keys().cloned().collect();
     unpriced_models.sort();
     unpriced_models.truncate(5);
     let days = data.days;
     let mut sp = ProviderSpend {
-        id,
-        name,
+        id: id.into(),
+        name: name.into(),
         today: Window::default(),
         yesterday: Window::default(),
         last30: Window::default(),
@@ -658,6 +658,32 @@ fn claude(extra: FileData) -> (ProviderSpend, FileData, FileData) {
     // appear there) — those dollars belong on the AihubMix card.
     let qwen_via_aihubmix = split_models(&mut all, "qwen");
     (build_spend("claude", "Claude", all), minimax, qwen_via_aihubmix)
+}
+
+/// Spend for each discovered extra Claude account, scanned from that
+/// account's own config dir (each dir keeps its own projects/ logs, so the
+/// scopes never mix). MiniMax/qwen-routed rows split out the same way the
+/// default account's do and are handed back for the caller to merge into
+/// those cards.
+fn claude_extra_accounts() -> (Vec<ProviderSpend>, FileData, FileData) {
+    let mut spends = Vec::new();
+    let mut minimax_extra = FileData::default();
+    let mut qwen_extra = FileData::default();
+    for acct in providers::claude::discover_extra_accounts() {
+        let root = acct.dir.join("projects");
+        let mut files = Vec::new();
+        recent_jsonl_files(&root, &mut files);
+        let mut all = FileData::default();
+        for file in files {
+            let mut state = ClaudeFileState::default();
+            let data = file_days(&file, &mut |line, data| claude_line(&mut state, line, data));
+            merge_data(&mut all, data);
+        }
+        merge_data(&mut minimax_extra, split_models(&mut all, "MiniMax"));
+        merge_data(&mut qwen_extra, split_models(&mut all, "qwen"));
+        spends.push(build_spend(acct.id, acct.name, all));
+    }
+    (spends, minimax_extra, qwen_extra)
 }
 
 /// MiniMax spend: the Agent CLI's local token_usage store (its own cost_usd
@@ -2117,7 +2143,12 @@ pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
         t.clear();
     }
     let (pi_claude, pi_codex) = pi();
-    let (claude_sp, mut minimax_extra, qwen_via_claude) = claude(pi_claude);
+    let (claude_sp, mut minimax_extra, mut qwen_via_claude) = claude(pi_claude);
+    // Extra Claude accounts: own spend cards, with their MiniMax/qwen-routed
+    // rows folded into the same destinations as the default account's.
+    let (extra_claude_spends, mm2, qw2) = claude_extra_accounts();
+    merge_data(&mut minimax_extra, mm2);
+    merge_data(&mut qwen_via_claude, qw2);
     // Hermes rows going to an existing slice merge into it (MiniMax via the
     // extra-data path); the rest become their own spend entries.
     let mut hermes_rest = Vec::new();
@@ -2142,6 +2173,7 @@ pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
         moonshot(),
         qwen(),
     ];
+    list.extend(extra_claude_spends);
     list.extend(hermes_rest);
     if let Some(csv) = cursor_csv {
         list.push(cursor_from_csv(&csv));

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -1087,13 +1087,10 @@ fn codex_line(st: &mut CodexFileState, line: &str, data: &mut FileData) {
 /// the surrounding turn_context/session_meta lines. Child sessions (subagent
 /// spawns and forks) replay the parent's entire history at spawn — those
 /// lines are skipped via a replay gate (see `codex_line`).
-fn codex(extra: FileData) -> ProviderSpend {
-    let home = std::env::var("CODEX_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".codex"));
-
-    // An archived session is often a byte-for-byte copy of one still in
-    // sessions/ — count each relative path once, sessions/ winning.
+/// Session logs of one Codex home. An archived session is often a
+/// byte-for-byte copy of one still in sessions/ — count each relative path
+/// once, sessions/ winning.
+fn codex_session_files(home: &Path) -> Vec<PathBuf> {
     let sessions_root = home.join("sessions");
     let archived_root = home.join("archived_sessions");
     let mut files = Vec::new();
@@ -1109,16 +1106,39 @@ fn codex(extra: FileData) -> ProviderSpend {
             .map(|rel| !live_rel.contains(rel))
             .unwrap_or(true)
     }));
+    files
+}
 
+fn codex_scan(home: &Path) -> FileData {
     let mut all = FileData::default();
-    for file in files {
+    for file in codex_session_files(home) {
         let mut state = CodexFileState::default();
         let data = file_days(&file, &mut |line, data| codex_line(&mut state, line, data));
         merge_data(&mut all, data);
     }
+    all
+}
+
+fn codex(extra: FileData) -> ProviderSpend {
+    let home = std::env::var("CODEX_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".codex"));
+    let mut all = codex_scan(&home);
     // Pi sessions that drove a Codex account (passed in from the pi scan).
     merge_data(&mut all, extra);
     build_spend("codex", "Codex", all)
+}
+
+/// Spend for each discovered extra Codex account, scanned from that
+/// account's own home (each keeps its own sessions/ logs).
+fn codex_extra_accounts() -> Vec<ProviderSpend> {
+    providers::codex::discover_extra_accounts()
+        .into_iter()
+        .map(|acct| {
+            let data = codex_scan(&acct.dir);
+            build_spend(acct.id, acct.name, data)
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -2174,6 +2194,7 @@ pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
         qwen(),
     ];
     list.extend(extra_claude_spends);
+    list.extend(codex_extra_accounts());
     list.extend(hermes_rest);
     if let Some(csv) = cursor_csv {
         list.push(cursor_from_csv(&csv));

--- a/src/main.ts
+++ b/src/main.ts
@@ -781,9 +781,15 @@ function renderItem(s: Snapshot, spend: ProviderSpend | undefined, key: string):
   return metric ? renderMetric(metric) : "";
 }
 
+/// Account-scoped cards (claude@<hash>) inherit their family's chrome —
+/// icon, quick links — while keeping their own identity everywhere else.
+function providerFamily(id: string): string {
+  return id.split("@")[0];
+}
+
 function renderCard(s: Snapshot): string {
   const plan = s.plan ? `<span class="plan">${escapeHtml(s.plan)}</span>` : "";
-  const icon = PROVIDER_ICONS[s.id] ?? "";
+  const icon = PROVIDER_ICONS[s.id] ?? PROVIDER_ICONS[providerFamily(s.id)] ?? "";
   const muted = s.status === "ok" ? "" : " muted";
 
   let body: string;
@@ -810,7 +816,7 @@ function renderCard(s: Snapshot): string {
   const stale = s.stale
     ? `<span class="stale" title="${escapeHtml(staleHelp(s))}">⚠ Outdated</span>`
     : "";
-  const links = (PROVIDER_LINKS[s.id] ?? [])
+  const links = (PROVIDER_LINKS[s.id] ?? PROVIDER_LINKS[providerFamily(s.id)] ?? [])
     .map((l) => `<button class="quick-link" data-link="${escapeHtml(l.url)}">${escapeHtml(l.label)}</button>`)
     .join("<span class='quick-sep'>·</span>");
   const linksRow = links ? `<div class="quick-links">${links}</div>` : "";
@@ -1867,8 +1873,10 @@ function renderCustomize(): string {
   const order = config.layout?.providerOrder ?? ALL_PROVIDERS.map(([id]) => id);
   const blocks = order
     .map((id) => {
-      const name = ALL_PROVIDERS.find(([pid]) => pid === id)?.[1] ?? id;
       const snapshot = lastSnapshots.find((s) => s.id === id);
+      // Dynamic account cards carry their name in the snapshot
+      // ("Claude — Org"); static providers come from the fixed list.
+      const name = ALL_PROVIDERS.find(([pid]) => pid === id)?.[1] ?? snapshot?.name ?? id;
       const L = providerLayout(id);
       const enabled = !config.disabled.includes(id);
 
@@ -2178,9 +2186,13 @@ async function refresh(force = false): Promise<void> {
       // ids, which rendered ghost rows in Customize. Prune anything the app
       // no longer knows.
       const valid = new Set(ALL_PROVIDERS.map(([id]) => id));
-      const prunedOrder = config.layout.providerOrder.filter((id) => valid.has(id));
-      const staleLayout = Object.keys(config.layout.providers).filter((id) => !valid.has(id));
-      const prunedDisabled = config.disabled.filter((id) => valid.has(id));
+      // Account-scoped ids (claude@<hash>) are valid whenever their family
+      // is — pruning them here would wipe a multi-account user's layout and
+      // disabled choices on every launch.
+      const isValid = (id: string) => valid.has(id) || valid.has(providerFamily(id));
+      const prunedOrder = config.layout.providerOrder.filter(isValid);
+      const staleLayout = Object.keys(config.layout.providers).filter((id) => !isValid(id));
+      const prunedDisabled = config.disabled.filter(isValid);
       if (
         prunedOrder.length !== config.layout.providerOrder.length ||
         staleLayout.length ||

--- a/src/main.ts
+++ b/src/main.ts
@@ -1862,6 +1862,10 @@ systemLight.addEventListener("change", () => {
 // ---------------------------------------------------------------------------
 
 function isStarrable(s: Snapshot | undefined, key: string): boolean {
+  // Account-scoped cards (claude@<hash>) can't reach the tray strip — the
+  // Rust side validates ids against a fixed allowlist — so offering the ★
+  // there would be a silent no-op. Default family cards only.
+  if (s && s.id.includes("@")) return false;
   return s?.metrics.some((m) => m.label === key && m.kind === "progress") ?? false;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2872,6 +2872,10 @@ window.addEventListener("DOMContentLoaded", () => {
     const redeem = target.closest<HTMLElement>("[data-redeem]");
     if (redeem) {
       const creditId = redeem.dataset.redeem!;
+      // Multi-account: the redeem must ride the account whose card offered
+      // the credit, not the default login's token.
+      const providerId =
+        redeem.closest<HTMLElement>("article.provider")?.dataset.provider ?? "codex";
       void appConfirm({
         title: "Use a reset credit?",
         message:
@@ -2881,7 +2885,7 @@ window.addEventListener("DOMContentLoaded", () => {
         if (!ok) return;
         const status = document.querySelector("#status")!;
         status.textContent = "Redeeming reset credit…";
-        void invoke<string>("codex_redeem_credit", { creditId })
+        void invoke<string>("codex_redeem_credit", { creditId, providerId })
           .then((msg) => {
             status.textContent = msg;
             void refresh(true);


### PR DESCRIPTION
## What

Multi-account support for both OAuth families, following upstream OpenUsage''s locked account-first design (their shipped Phases 1–2b for Claude, and their **unshipped Phase 5a** design for Codex — we build ahead of their beta). Requested by a real Pane user tracking an enterprise seat alongside a personal plan.

**The model**
- Every card is an account. Discovery scans dot-folders in home + `~/.config` subdirs for provider-shaped credential files.
- **Identity extraction is validation**: Claude ids from `.claude.json` `oauthAccount.accountUuid`, Codex from `tokens.account_id` (else the id_token''s ChatGPT account claim). A dir that can''t name its account never becomes a card; a dir naming an already-seen account is another source of it — duplicate cards are structurally impossible.
- **Zero migration**: the default login keeps the bare `claude`/`codex` id forever; extras mint `claude@<hash8>`/`codex@<hash8>`, named by org or email ("Claude — Acme", "Codex — e@corp.com").
- Cards render while their source exists and retire when it disappears; deterministic ids mean a returning login reattaches to its old layout.

**Per-account everything**
- Limits/plan per card; spend scoped to each dir''s own logs (Claude `projects/`, Codex `sessions/`+`archived_sessions/`), with MiniMax/qwen-routed rows still splitting to their cards.
- Codex reset-credit redemption **routes to the account whose card offered the credit** (frontend sends the owning card id; older frontends default to the bare card during update overlap).
- Each card''s Extra credits meter keeps its own high-water baseline.
- **Cache identity stamp** (upstream Phase 1): a different account signing into the default home between launches drops that family''s cached last-good snapshot instead of painting the old account''s numbers under the new login.
- Telemetry never learns account-scoped ids — families only, deduped.
- Frontend: account cards inherit family icon/links, take names from snapshots, and the ghost-row pruner treats family-known ids as valid (it would otherwise wipe their layouts every launch).

## Testing

- 51 passed / 0 failed (new: identity-extraction validation tests for both families), tsc clean.
- Live lifecycle verified on a real install, both families: synthetic second account → own card rendered; same account in two dirs → one card; source removed → card retires; real cards pixel-identical throughout (the zero-migration promise).
- Honest limits: a second account with *working* credentials, live redeem routing, and per-account spend with real log data await the requesting user''s enterprise setup — same soak model upstream uses for these phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->