### PR TITLE
Multi-account hardening: fix all review round-2 findings

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,14 @@ All of this is auditable in the source — links go to the exact code.
   ([`src-tauri/src/providers/`](src-tauri/src/providers/) — one module per
   provider; see [docs/providers.md](docs/providers.md) for the exact files
   read and endpoints called).
+- **Multi-account discovery widens where credentials are *found*, never
+  where they are *sent*.** To support second logins kept via
+  `CLAUDE_CONFIG_DIR`/`CODEX_HOME`, Pane scans dot-folders in your home
+  directory and `~\.config` for Claude/Codex-shaped credential files —
+  the places those official mechanisms put them. A discovered credential
+  follows the exact same lane rule (its own vendor's API only, token
+  refresh written back beside it), and a file that cannot name its
+  account is never used at all.
 - **No analytics SDK, no crash reporter, no event streams.** Pane's
   entire self-reporting surface is two anonymous channels, both
   documented field-by-field in [docs/privacy.md](docs/privacy.md): the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -695,7 +695,16 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
                 let mut map = cache.lock().unwrap();
                 let mut removed = false;
                 for fam in ["claude", "codex"] {
-                    if stored.get(fam) != current.get(fam) && map.remove(fam).is_some() {
+                    // Only a KNOWN stored identity differing from a KNOWN
+                    // current one is evidence of an account swap. A missing
+                    // stamp (first launch after updating) or a momentarily
+                    // unreadable identity file must not dump the last-good
+                    // cache — that's the safety net, not a swap.
+                    let swap = match (stored.get(fam), current.get(fam)) {
+                        (Some(s), Some(c)) => !s.is_null() && !c.is_null() && s != c,
+                        _ => false,
+                    };
+                    if swap && map.remove(fam).is_some() {
                         removed = true;
                     }
                 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -691,39 +691,45 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
                 .ok()
                 .and_then(|raw| serde_json::from_str(&raw).ok())
                 .unwrap_or_else(|| json!({}));
-            if stored != current {
-                let mut map = cache.lock().unwrap();
-                let mut removed = false;
-                for fam in ["claude", "codex"] {
-                    // Only a KNOWN stored identity differing from a KNOWN
-                    // current one is evidence of an account swap. A missing
-                    // stamp (first launch after updating) or a momentarily
-                    // unreadable identity file must not dump the last-good
-                    // cache — that's the safety net, not a swap.
-                    let swap = match (stored.get(fam), current.get(fam)) {
-                        (Some(s), Some(c)) => !s.is_null() && !c.is_null() && s != c,
-                        _ => false,
-                    };
-                    if swap && map.remove(fam).is_some() {
-                        removed = true;
-                    }
+            let mut map = cache.lock().unwrap();
+            let mut removed = false;
+            let mut to_store = serde_json::Map::new();
+            for fam in ["claude", "codex"] {
+                let cur = current.get(fam).cloned().unwrap_or(Value::Null);
+                let old = stored.get(fam).cloned().unwrap_or(Value::Null);
+                // Only a KNOWN stored identity differing from a KNOWN
+                // current one is evidence of an account swap. A missing
+                // stamp (first launch after updating) or a momentarily
+                // unreadable identity file must not dump the last-good
+                // cache — that's the safety net, not a swap.
+                if !old.is_null() && !cur.is_null() && old != cur && map.remove(fam).is_some() {
+                    removed = true;
                 }
-                // Persist the PRUNED cache before the new stamp: if this
-                // refresh finds nothing ok (offline launch) the on-disk
-                // cache would otherwise keep the old account's entry while
-                // the stamp already claims the new one, resurrecting the
-                // wrong numbers next launch. Stamp last, so a failed write
-                // just re-prunes next time.
-                let _ = std::fs::create_dir_all(providers::config_dir());
-                if removed {
-                    if let Ok(serialized) = serde_json::to_string(&*map) {
-                        let _ = std::fs::write(&cache_file, serialized);
-                    }
+                // And a transient null never OVERWRITES a known identity:
+                // erasing it would make a swap that happens before the next
+                // launch undetectable.
+                to_store.insert(
+                    fam.to_string(),
+                    if cur.is_null() && !old.is_null() { old } else { cur },
+                );
+            }
+            // Persist the PRUNED cache before the new stamp: if this
+            // refresh finds nothing ok (offline launch) the on-disk cache
+            // would otherwise keep the old account's entry while the stamp
+            // already claims the new one, resurrecting the wrong numbers
+            // next launch. Stamp last, so a failed write just re-prunes.
+            let _ = std::fs::create_dir_all(providers::config_dir());
+            if removed {
+                if let Ok(serialized) = serde_json::to_string(&*map) {
+                    let _ = std::fs::write(&cache_file, serialized);
                 }
-                drop(map);
+            }
+            drop(map);
+            let to_store = Value::Object(to_store);
+            if to_store != stored {
                 let _ = std::fs::write(
                     &stamp_file,
-                    serde_json::to_string_pretty(&current).unwrap_or_default(),
+                    serde_json::to_string_pretty(&to_store).unwrap_or_default(),
                 );
             }
         }

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -34,14 +34,34 @@ fn dir_identity(dir: &std::path::Path) -> Option<(String, Option<String>)> {
             candidates.push(home.join(".claude.json"));
         }
     }
-    for p in candidates {
-        let Ok(raw) = std::fs::read_to_string(&p) else { continue };
-        let Ok(doc) = serde_json::from_str::<Value>(&raw) else { continue };
-        if let Some(identity) = identity_from(&doc) {
-            return Some(identity);
+    candidates.into_iter().find_map(|p| cached_identity_of(&p))
+}
+
+/// Identity parses memoized by (mtime, size): ~/.claude.json carries far
+/// more than the oauthAccount and grows to multiple MB on active installs,
+/// and identity is consulted several times per refresh cycle (discovery in
+/// the fetch, the cache stamp, and the spend scan).
+fn cached_identity_of(path: &std::path::Path) -> Option<(String, Option<String>)> {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    use std::time::SystemTime;
+    type Entry = (SystemTime, u64, Option<(String, Option<String>)>);
+    static CACHE: OnceLock<Mutex<HashMap<PathBuf, Entry>>> = OnceLock::new();
+
+    let meta = std::fs::metadata(path).ok()?;
+    let (mtime, size) = (meta.modified().ok()?, meta.len());
+    let cache = CACHE.get_or_init(Default::default);
+    if let Some((m, s, v)) = cache.lock().unwrap().get(path) {
+        if *m == mtime && *s == size {
+            return v.clone();
         }
     }
-    None
+    let parsed = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .and_then(|doc| identity_from(&doc));
+    cache.lock().unwrap().insert(path.to_path_buf(), (mtime, size, parsed.clone()));
+    parsed
 }
 
 /// (accountUuid, label) from a parsed .claude.json — org name first, email

--- a/src/main.ts
+++ b/src/main.ts
@@ -1878,6 +1878,10 @@ function renderCustomize(): string {
   const blocks = order
     .map((id) => {
       const snapshot = lastSnapshots.find((s) => s.id === id);
+      // A retired account card (its login left this machine) keeps its
+      // layout for reattachment but must not haunt Customize as a bare
+      // "claude@ab12cd34" block with nothing under it.
+      if (id.includes("@") && !snapshot) return "";
       // Dynamic account cards carry their name in the snapshot
       // ("Claude — Org"); static providers come from the fixed list.
       const name = ALL_PROVIDERS.find(([pid]) => pid === id)?.[1] ?? snapshot?.name ?? id;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1880,8 +1880,11 @@ function renderCustomize(): string {
       const snapshot = lastSnapshots.find((s) => s.id === id);
       // A retired account card (its login left this machine) keeps its
       // layout for reattachment but must not haunt Customize as a bare
-      // "claude@ab12cd34" block with nothing under it.
-      if (id.includes("@") && !snapshot) return "";
+      // "claude@ab12cd34" block with nothing under it. A card the USER
+      // disabled also has no snapshot (disabled providers are never
+      // fetched) — that one must keep rendering, or its re-enable toggle
+      // vanishes with it and the account is stuck off forever.
+      if (id.includes("@") && !snapshot && !config.disabled.includes(id)) return "";
       // Dynamic account cards carry their name in the snapshot
       // ("Claude — Org"); static providers come from the fixed list.
       const name = ALL_PROVIDERS.find(([pid]) => pid === id)?.[1] ?? snapshot?.name ?? id;


### PR DESCRIPTION
Follow-up to #121 addressing every finding from its second review round (the maintainer cannot test multi-account locally, so review findings all get fixed rather than assessed):

- **Cache stamp first-launch bug** — `stored={}` vs a known current identity was treated as an account swap, dumping both families'' last-good cache on the first launch after updating (and on any transient identity-read failure). Only known-vs-known mismatches prune now.
- **Perf** — `~/.claude.json` (multi-MB on active installs) was fully parsed at least 3× per refresh cycle across discovery, the cache stamp, and the spend scan. Identity parses are now memoized by (mtime, size).
- **Ghost Customize blocks** — a retired account''s layout survives for reattachment but no longer renders as a bare `claude@<hash>` block with nothing under it.
- **Discovery surface documented** — SECURITY.md now states explicitly: multi-account widens where credentials are *found* (dot-folders/`~\.config`, the places `CLAUDE_CONFIG_DIR`/`CODEX_HOME` setups put them), never where they are *sent*; the lane rule and identity-is-validation still gate every use.

51 passed / 0 failed, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->