### PR TITLE
Release 0.4.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.32 — 2026-08-11
 
 ### Added
 - **Multi-account Codex** — same treatment for Codex: every discovered

--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ whatever the community asks for loudest.
 
 ## Features
 
+- **Multi-account Claude & Codex** 🆕 — running a personal plan AND a
+  work/enterprise seat? Keep the second login in its own folder (via
+  `CLAUDE_CONFIG_DIR` / `CODEX_HOME`) and Pane shows one card per
+  account — each with its own limits, plan, credits, and spend, named
+  by its organization or email ("Claude — Acme"). The same account
+  signed in twice stays one card, and your existing setup is untouched.
 - **Pace projections** — colored bars and "will run out" warnings based on
   your burn rate within each reset window, plus optional Windows toasts.
 - **Local spend** — Today / Yesterday / 30 Days donut with per-model
@@ -189,10 +195,9 @@ whatever the community asks for loudest.
   undoes.
 - **Liquid glass UI** — real SDF lens refraction on the auto-hiding
   sidebar and glass bars, magnetic minimap trail, circular day/night wipe.
-- **Share cards** — hover a card, click ⧉, and paste anywhere: a
-  collapsed card copies as a clean compact composition, an expanded one
-  copies whole (trend, spend, pace hints — buttons and links stripped),
-  framed with the Pane icon and tagline.
+- **Share cards** — hover a card, click ⧉, and paste anywhere: the copy
+  is exactly what the card shows (bars, pace hints, trend — buttons and
+  links stripped), framed with the Pane icon and tagline.
 - **Quick links** — Status / Dashboard shortcuts on every card.
 - **[Local HTTP API](docs/local-http-api.md)** — `GET
   http://127.0.0.1:6736/v1/usage` for scripts, Rainmeter widgets, stream

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -34,6 +34,10 @@ same disclosed-and-toggleable approach as the Mac app Pane is a port of):
 - **`app_daily_active`** — once per day: "this install was alive today",
   the app version, which providers are enabled, which metrics you
   starred (stable IDs only), appearance/density/refresh settings.
+  Multi-account installs report only the plain provider family
+  ("claude", once) — account-scoped card ids are derived from your
+  account identity and never leave the machine, on any field of either
+  event.
 - **`provider_refresh_daily`** — per provider, summarizing the previous
   day: how many refreshes succeeded, went stale, or failed, with failure
   *categories* only (auth / rate-limit / server / network / other).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.31",
+  "version": "0.4.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.31",
+      "version": "0.4.32",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.31",
+  "version": "0.4.32",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.31"
+version = "0.4.32"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.31"
+version = "0.4.32"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.31",
+  "version": "0.4.32",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to 0.4.32 (all three manifests + both lockfiles), changelog retitled to `## 0.4.32 — 2026-08-11`, and docs headlining the release feature.

Ships:
- **Multi-account Claude & Codex** (#121, #122) — one card per discovered login, account-first design, fully review-hardened
- README features lead + privacy.md family-only telemetry note

pane.jazii.dev already updated and deployed (feature card, FAQ, provider counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->