### PR TITLE
Security hardening: credential provenance + low-severity fixes from external report

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,16 +19,20 @@ jobs:
       # scope, so without this the dispatch 403s (and continue-on-error
       # would hide it, silently reproducing the never-publishes bug).
       actions: write
+    # Third-party actions are pinned to commit SHAs: a moving tag like @v4
+    # lets whoever controls that repo swap in new code that runs inside
+    # this signing pipeline. The trailing comment names the tag the SHA
+    # was taken from; bump by updating both together.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch, 2026-08 (still installs latest stable Rust)
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: src-tauri
 
@@ -72,7 +76,7 @@ jobs:
 
       - name: Upload artifacts (dry run only)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pane-installer
           path: |

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -32,7 +32,9 @@ jobs:
   winget:
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal9/winget-releaser@v2
+      # Pinned to a commit SHA (was @v2): this third-party action receives
+      # WINGET_TOKEN, so a hijacked tag could exfiltrate it.
+      - uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: Pane.Pane
           installers-regex: '-setup\.exe$'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@
   github.com; the MiniMax CLI fallback reads exactly
   `provider.minimax.options.apiKey` from `~/.minimax/config.yaml`
   instead of the first `apiKey:` line anywhere in the file.
+- **Disabled Cursor makes no requests** — the spend scan's Cursor CSV
+  export (an authenticated network call) now honors the provider
+  toggle, matching how usage refresh already skips disabled providers.
+- **Local API rejects non-loopback Host headers** — the read-only
+  usage API on 127.0.0.1:6736 now refuses requests whose Host header
+  isn't a loopback spelling, closing the DNS-rebinding read that CORS
+  alone can't prevent.
+- **Release workflows pin actions to commit SHAs** — third-party
+  GitHub Actions in the signed release and winget pipelines are pinned
+  to exact commits instead of movable tags.
 
 ## 0.4.32 — 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Security
+- **Credential provenance hardening** (from an external security
+  report — thank you): credential discovery now proves a token belongs
+  to the provider it will be sent to, instead of accepting the first
+  field-shape match. Extra Codex accounts found by the multi-account
+  scan must carry OpenAI's own claim namespace in their `id_token`
+  before any request or refresh (a foreign `auth.json` that merely has
+  a `tokens.account_id` no longer qualifies); Copilot token lookup is
+  scoped to the `github.com` entry in `apps.json`/`hosts.json` and to
+  the `github.com` section of the GitHub CLI's `hosts.yml`, so a
+  GitHub Enterprise token sharing the file is never sent to
+  github.com; the MiniMax CLI fallback reads exactly
+  `provider.minimax.options.apiKey` from `~/.minimax/config.yaml`
+  instead of the first `apiKey:` line anywhere in the file.
+
 ## 0.4.32 — 2026-08-11
 
 ### Added

--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -39,6 +39,15 @@ Wire format (compatible with the macOS OpenUsage API):
   read your usage), Pane sends no CORS headers — so browsers block web
   pages from reading this API. PowerShell, curl, Rainmeter, and native
   apps are unaffected; CORS only constrains browsers.
+- **Loopback Host headers only.** Requests whose `Host` header isn't a
+  loopback spelling (`127.0.0.1`, `localhost`, or `[::1]`, with or
+  without `:6736`) get `403 {"error": "forbidden_host"}`. This blocks
+  DNS rebinding — a malicious page pointing its own hostname at
+  127.0.0.1 to sidestep the browser's cross-origin rules. Plain
+  scripts are unaffected (curl and PowerShell send a loopback Host
+  automatically; a missing Host header is also fine), but if you call
+  the API through a hosts-file alias or a proxy that rewrites Host,
+  use one of the loopback spellings instead.
 - **No authentication.** Any program running as your Windows user can
   read this API — that is what makes zero-config widgets and scripts
   possible, and it is a deliberate trade-off. What such a program gets is

--- a/src-tauri/src/httpapi.rs
+++ b/src-tauri/src/httpapi.rs
@@ -66,6 +66,15 @@ fn iso8601(epoch_ms: i64) -> String {
         .unwrap_or_default()
 }
 
+/// Only loopback spellings may appear in the Host header. A missing header
+/// is allowed (HTTP/1.0 scripts); a rebound hostname is not.
+fn host_ok(host: Option<&str>) -> bool {
+    let Some(host) = host else { return true };
+    let host = host.trim().to_ascii_lowercase();
+    let bare = host.strip_suffix(":6736").unwrap_or(&host);
+    matches!(bare, "127.0.0.1" | "localhost" | "[::1]")
+}
+
 fn route(method: &tiny_http::Method, url: &str) -> (u16, String) {
     let path = url.split('?').next().unwrap_or(url);
     match method {
@@ -110,7 +119,20 @@ pub fn start() {
         };
         eprintln!("[pane] local API: http://127.0.0.1:6736/v1/usage");
         for request in server.incoming_requests() {
-            let (status, body) = route(request.method(), request.url());
+            // DNS-rebinding guard: a page can point its own hostname at
+            // 127.0.0.1, making this server "same-origin" in the victim's
+            // browser — CORS never applies then. Legitimate local clients
+            // address us by loopback names only; anything else is refused.
+            let host = request
+                .headers()
+                .iter()
+                .find(|h| h.field.equiv("Host"))
+                .map(|h| h.value.as_str().to_string());
+            let (status, body) = if host_ok(host.as_deref()) {
+                route(request.method(), request.url())
+            } else {
+                (403, json!({"error": "forbidden_host"}).to_string())
+            };
             let mut response = tiny_http::Response::from_string(body).with_status_code(status);
             // Deliberately NO Access-Control-Allow-Origin header: with
             // permissive CORS, any website the user visits could silently
@@ -126,4 +148,24 @@ pub fn start() {
             let _ = request.respond(response);
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::host_ok;
+
+    #[test]
+    fn host_header_must_be_loopback() {
+        // Loopback spellings, with and without the port.
+        for good in ["127.0.0.1:6736", "127.0.0.1", "localhost:6736", "LOCALHOST", "[::1]:6736"] {
+            assert!(host_ok(Some(good)), "{good} should be allowed");
+        }
+        // Absent header (HTTP/1.0 scripts) stays allowed.
+        assert!(host_ok(None));
+        // A rebound hostname resolving to 127.0.0.1 is refused — this is
+        // the DNS-rebinding case CORS can't catch.
+        for bad in ["evil.example:6736", "evil.example", "127.0.0.1.evil.example:6736", "localhost.evil.example"] {
+            assert!(!host_ok(Some(bad)), "{bad} should be refused");
+        }
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -857,8 +857,18 @@ async fn fetch_spend() -> Vec<spend::ProviderSpend> {
     eprintln!("[pane] spend: scan starting");
     let started = std::time::Instant::now();
     // Cursor's CSV export needs the async client; fetch it here and hand it
-    // to the blocking scan.
-    let cursor_csv = providers::cursor::fetch_usage_csv().await;
+    // to the blocking scan. Unlike every other spend source it's an
+    // authenticated NETWORK call, so it honors the disabled toggle the same
+    // way fetch_usage does — a switched-off Cursor makes no requests.
+    let cursor_disabled = config_with_defaults(load_config())
+        .get("disabled")
+        .and_then(Value::as_array)
+        .is_some_and(|a| a.iter().any(|v| v.as_str() == Some("cursor")));
+    let cursor_csv = if cursor_disabled {
+        None
+    } else {
+        providers::cursor::fetch_usage_csv().await
+    };
     let result = tauri::async_runtime::spawn_blocking(move || spend::collect(cursor_csv))
         .await
         .unwrap_or_default();

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -29,9 +29,24 @@ pub struct CodexAccount {
 /// the id_token's ChatGPT account claim) never becomes a card. The email
 /// claim doubles as the card label.
 fn dir_identity(dir: &std::path::Path) -> Option<(String, Option<String>)> {
+    identity_from(&read_auth(dir)?)
+}
+
+fn read_auth(dir: &std::path::Path) -> Option<Value> {
     let raw = std::fs::read_to_string(dir.join("auth.json")).ok()?;
-    let doc: Value = serde_json::from_str(&raw).ok()?;
-    identity_from(&doc)
+    serde_json::from_str(&raw).ok()
+}
+
+/// Proof a discovered auth.json actually belongs to OpenAI: its id_token
+/// carries OpenAI's own claim namespace. `auth.json` + `tokens.account_id`
+/// is not an OpenAI-specific shape — broad scanning could otherwise
+/// misclassify another tool's credential file as a Codex login and send
+/// its tokens to OpenAI endpoints (refresh could even write back into it).
+fn openai_provenance(doc: &Value) -> bool {
+    doc.pointer("/tokens/id_token")
+        .and_then(Value::as_str)
+        .and_then(jwt_claims)
+        .is_some_and(|c| c.get("https://api.openai.com/auth").is_some())
 }
 
 /// (account id, email label) from a parsed auth.json: tokens.account_id
@@ -81,7 +96,14 @@ pub fn discover_extra_accounts() -> Vec<CodexAccount> {
         if dir == default {
             continue;
         }
-        let Some((account_id, email)) = dir_identity(&dir) else { continue };
+        // The default home is user-designated; broadly scanned dirs must
+        // additionally PROVE they're OpenAI's before their tokens can enter
+        // the Codex request path.
+        let Some(doc) = read_auth(&dir) else { continue };
+        if !openai_provenance(&doc) {
+            continue;
+        }
+        let Some((account_id, email)) = identity_from(&doc) else { continue };
         if seen.iter().any(|a| a == &account_id) {
             continue;
         }
@@ -379,7 +401,7 @@ fn credits_balance(usage: &Value) -> Option<f64> {
 
 #[cfg(test)]
 mod tests {
-    use super::{credits_balance, identity_from};
+    use super::{credits_balance, identity_from, openai_provenance};
     use base64::Engine;
     use serde_json::json;
 
@@ -387,6 +409,25 @@ mod tests {
         let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(serde_json::to_vec(&claims).unwrap());
         format!("x.{payload}.y")
+    }
+
+    #[test]
+    fn provenance_requires_openais_claim_namespace() {
+        // A foreign auth.json with the right field SHAPE but no OpenAI
+        // claim — the misclassification case — must not pass.
+        let foreign = json!({"tokens": {"account_id": "some-other-account",
+            "access_token": "foreign-access", "refresh_token": "foreign-refresh"}});
+        assert!(!openai_provenance(&foreign));
+        // Even with a JWT id_token, foreign claims don't count.
+        let foreign_jwt = json!({"tokens": {"account_id": "acct",
+            "id_token": fake_id_token(json!({"iss": "https://example.com"}))}});
+        assert!(!openai_provenance(&foreign_jwt));
+        // A real Codex login carries OpenAI's claim namespace.
+        let real = json!({"tokens": {"account_id": "acct",
+            "id_token": fake_id_token(json!({
+                "https://api.openai.com/auth": {"chatgpt_account_id": "acct"}}))}});
+        assert!(openai_provenance(&real));
+        assert!(!openai_provenance(&json!({})));
     }
 
     #[test]

--- a/src-tauri/src/providers/copilot.rs
+++ b/src-tauri/src/providers/copilot.rs
@@ -6,6 +6,9 @@ const ID: &str = "copilot";
 const NAME: &str = "Copilot";
 
 /// GitHub tokens can come from Copilot's editor config or the GitHub CLI.
+/// Every source is scoped to github.com: this snapshot only ever talks to
+/// api.github.com, so a token owned by any other host (a GitHub Enterprise
+/// login sharing the same file) must never be selected.
 fn find_token() -> Option<String> {
     let mut candidates: Vec<PathBuf> = Vec::new();
     if let Ok(local) = std::env::var("LOCALAPPDATA") {
@@ -18,13 +21,8 @@ fn find_token() -> Option<String> {
     }
     for path in candidates {
         let Ok(raw) = std::fs::read_to_string(&path) else { continue };
-        let Ok(doc) = serde_json::from_str::<Value>(&raw) else { continue };
-        if let Some(map) = doc.as_object() {
-            for entry in map.values() {
-                if let Some(tok) = entry.get("oauth_token").and_then(Value::as_str) {
-                    return Some(tok.to_string());
-                }
-            }
+        if let Some(tok) = copilot_json_token(&raw) {
+            return Some(tok);
         }
     }
     // GitHub CLI. Older versions kept oauth_token in hosts.yml; modern gh
@@ -34,27 +32,8 @@ fn find_token() -> Option<String> {
     if let Ok(appdata) = std::env::var("APPDATA") {
         let hosts = PathBuf::from(appdata).join("GitHub CLI").join("hosts.yml");
         if let Ok(raw) = std::fs::read_to_string(&hosts) {
-            let mut in_users = false;
-            for line in raw.lines() {
-                let trimmed = line.trim();
-                if let Some(tok) = trimmed.strip_prefix("oauth_token:") {
-                    let tok = tok.trim();
-                    if !tok.is_empty() {
-                        return Some(tok.to_string());
-                    }
-                }
-                // Collect usernames under a "users:" block for the
-                // Credential Manager lookup below.
-                if trimmed == "users:" {
-                    in_users = true;
-                } else if in_users {
-                    let indent = line.len() - line.trim_start().len();
-                    if indent >= 8 && trimmed.ends_with(':') {
-                        usernames.push(trimmed.trim_end_matches(':').to_string());
-                    } else if indent <= 4 && !trimmed.is_empty() {
-                        in_users = false;
-                    }
-                }
+            if let Some(tok) = hosts_yml_token(&raw, &mut usernames) {
+                return Some(tok);
             }
         }
     }
@@ -67,6 +46,63 @@ fn find_token() -> Option<String> {
             let token = token.trim().to_string();
             if !token.is_empty() {
                 return Some(token);
+            }
+        }
+    }
+    None
+}
+
+/// The github.com entry's oauth_token from a Copilot apps.json/hosts.json.
+/// apps.json keys carry a client-id suffix ("github.com:Iv1.…"); hosts.json
+/// keys are bare hostnames. Entries under any other host are ignored.
+fn copilot_json_token(raw: &str) -> Option<String> {
+    let doc = serde_json::from_str::<Value>(raw).ok()?;
+    for (host, entry) in doc.as_object()? {
+        if host != "github.com" && !host.starts_with("github.com:") {
+            continue;
+        }
+        if let Some(tok) = entry.get("oauth_token").and_then(Value::as_str) {
+            if !tok.is_empty() {
+                return Some(tok.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// The github.com section's oauth_token from the gh CLI's hosts.yml, plus
+/// its usernames for the Credential Manager lookup. Lines under any other
+/// top-level host section are skipped entirely.
+fn hosts_yml_token(raw: &str, usernames: &mut Vec<String>) -> Option<String> {
+    let mut in_github = false;
+    let mut in_users = false;
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = line.len() - line.trim_start().len();
+        if indent == 0 {
+            in_github = trimmed == "github.com:";
+            in_users = false;
+            continue;
+        }
+        if !in_github {
+            continue;
+        }
+        if let Some(tok) = trimmed.strip_prefix("oauth_token:") {
+            let tok = tok.trim();
+            if !tok.is_empty() {
+                return Some(tok.to_string());
+            }
+        }
+        if trimmed == "users:" {
+            in_users = true;
+        } else if in_users {
+            if indent >= 8 && trimmed.ends_with(':') {
+                usernames.push(trimmed.trim_end_matches(':').to_string());
+            } else if indent <= 4 {
+                in_users = false;
             }
         }
     }
@@ -133,6 +169,46 @@ async fn fetch() -> Result<Snapshot, String> {
 
 #[cfg(test)]
 mod tests {
+    use super::{copilot_json_token, hosts_yml_token};
+
+    #[test]
+    fn copilot_json_is_host_scoped() {
+        // An enterprise entry listed first must not win over github.com.
+        let raw = r#"{
+            "github.enterprise.example:Iv1.aaa": {"oauth_token": "enterprise-secret"},
+            "github.com:Iv1.bbb": {"oauth_token": "dotcom-secret"}
+        }"#;
+        assert_eq!(copilot_json_token(raw), Some("dotcom-secret".into()));
+        // hosts.json style: bare hostname keys.
+        let raw = r#"{"ghe.internal": {"oauth_token": "x"}, "github.com": {"oauth_token": "y"}}"#;
+        assert_eq!(copilot_json_token(raw), Some("y".into()));
+        // Enterprise-only file yields nothing rather than the wrong token.
+        let raw = r#"{"ghe.internal:Iv1.ccc": {"oauth_token": "enterprise-secret"}}"#;
+        assert_eq!(copilot_json_token(raw), None);
+        // A hostname merely *containing* github.com must not match.
+        let raw = r#"{"github.com.evil.example": {"oauth_token": "z"}}"#;
+        assert_eq!(copilot_json_token(raw), None);
+    }
+
+    #[test]
+    fn hosts_yml_is_host_scoped() {
+        let raw = "github.enterprise.example:\n    oauth_token: enterprise-secret\n    user: boss\ngithub.com:\n    oauth_token: dotcom-secret\n    user: me\n";
+        let mut users = Vec::new();
+        assert_eq!(hosts_yml_token(raw, &mut users), Some("dotcom-secret".into()));
+
+        // Enterprise-only file: no token, no usernames.
+        let raw = "github.enterprise.example:\n    users:\n        boss:\n            oauth_token: enterprise-secret\n";
+        let mut users = Vec::new();
+        assert_eq!(hosts_yml_token(raw, &mut users), None);
+        assert!(users.is_empty());
+
+        // Modern gh layout: usernames collected from github.com only.
+        let raw = "ghe.internal:\n    users:\n        boss:\ngithub.com:\n    users:\n        me:\n        alt:\n    git_protocol: https\n";
+        let mut users = Vec::new();
+        assert_eq!(hosts_yml_token(raw, &mut users), None);
+        assert_eq!(users, vec!["me".to_string(), "alt".to_string()]);
+    }
+
     /// Live probe with this machine's real GitHub login — run manually via
     /// `cargo test --lib copilot -- --ignored --nocapture`. Prints statuses
     /// and counts only, never token values.

--- a/src-tauri/src/providers/minimax.rs
+++ b/src-tauri/src/providers/minimax.rs
@@ -23,18 +23,43 @@ fn find_api_key() -> Option<String> {
     if let Some(key) = super::stored_api_key(ID, &["MINIMAX_API_KEY"]) {
         return Some(key);
     }
-    // MiniMax Agent CLI config: provider.minimax.options.apiKey. A two-space
-    // YAML file we only need one scalar out of, so a line scan is enough.
     let path = dirs::home_dir()?.join(".minimax").join("config.yaml");
     let raw = std::fs::read_to_string(path).ok()?;
+    cli_config_key(&raw)
+}
+
+/// The MiniMax Agent CLI key at exactly provider.minimax.options.apiKey —
+/// an indent-tracked walk of the mapping path (still no YAML dependency).
+/// Matching any `apiKey:` line in the file would let a same-named key that
+/// belongs to a DIFFERENT provider in a shared config be sent to MiniMax's
+/// endpoints.
+fn cli_config_key(raw: &str) -> Option<String> {
+    let mut stack: Vec<(usize, String)> = Vec::new();
     for line in raw.lines() {
-        if let Some(v) = line.trim().strip_prefix("apiKey:") {
-            let v = v.trim().trim_matches('"').trim_matches('\'');
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = line.len() - line.trim_start().len();
+        while stack.last().is_some_and(|(i, _)| *i >= indent) {
+            stack.pop();
+        }
+        let Some((key, value)) = trimmed.split_once(':') else { continue };
+        let (key, value) = (key.trim(), value.trim());
+        if value.is_empty() {
+            stack.push((indent, key.to_string()));
+            continue;
+        }
+        if key == "apiKey"
+            && stack.iter().map(|(_, k)| k.as_str()).eq(["provider", "minimax", "options"])
+        {
+            let v = value.trim_matches('"').trim_matches('\'');
             // Real MiniMax keys are long; fresh CLI installs carry a short
             // "sk-…" placeholder that would only produce a confusing error.
             if v.len() > 20 {
                 return Some(v.to_string());
             }
+            return None;
         }
     }
     None
@@ -295,6 +320,27 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
 
 #[cfg(test)]
 mod tests {
+    use super::cli_config_key;
+
+    #[test]
+    fn cli_key_requires_the_minimax_path() {
+        // Another provider's key listed first must not be picked up.
+        let raw = "provider:\n  another_service:\n    options:\n      apiKey: another-provider-secret-over-20-chars\n  minimax:\n    options:\n      apiKey: actual-minimax-secret-over-20-chars\n";
+        assert_eq!(cli_config_key(raw), Some("actual-minimax-secret-over-20-chars".into()));
+
+        // A file with only the foreign provider yields nothing.
+        let raw = "provider:\n  another_service:\n    options:\n      apiKey: another-provider-secret-over-20-chars\n";
+        assert_eq!(cli_config_key(raw), None);
+
+        // The real location still works, quotes stripped.
+        let raw = "provider:\n  minimax:\n    options:\n      apiKey: \"real-minimax-secret-over-20-chars\"\n";
+        assert_eq!(cli_config_key(raw), Some("real-minimax-secret-over-20-chars".into()));
+
+        // Short placeholder keys are still rejected.
+        let raw = "provider:\n  minimax:\n    options:\n      apiKey: sk-short\n";
+        assert_eq!(cli_config_key(raw), None);
+    }
+
     /// Live probe with this machine's real key — run manually via
     /// `cargo test --lib minimax -- --ignored --nocapture`. Prints statuses
     /// and numbers only, never the key.


### PR DESCRIPTION
## Summary

An external security report (Codex Security scan of the 0.4.31 source) found one medium-severity bug family and five low-severity weaknesses. Every claim was verified against current main before fixing; this PR addresses the medium family and three of the lows. All fixes were written from scratch against main rather than applying the reporter's 0.4.31-based patch.

## Medium: credential provenance ("wrong token, correct fixed server")

Three discovery paths accepted the first field-shape match, so a credential belonging to a different provider or host could be selected and sent to a fixed vendor endpoint:

- **Codex** — broadly scanned dirs must now carry OpenAI's own claim namespace (`https://api.openai.com/auth`) in their `id_token` before becoming an account. A foreign `auth.json` that merely has `tokens.account_id` no longer qualifies, so its tokens can never enter the request/refresh path. The default `CODEX_HOME`/`~/.codex` is user-designated and unchanged, and automatic multi-account discovery keeps working for real Codex logins (chosen over the reporter's manual-allowlist proposal, which would have dropped auto-discovery).
- **Copilot** — `apps.json`/`hosts.json` lookup is scoped to the `github.com` entry, and the gh CLI `hosts.yml` scan to the `github.com` section, so a GitHub Enterprise token sharing the file is never sent to api.github.com.
- **MiniMax** — the `~/.minimax/config.yaml` fallback reads exactly `provider.minimax.options.apiKey` via an indent-tracked walk instead of the first `apiKey:` line anywhere in the file. The multi-endpoint fallback is kept deliberately: CN-region keys need it, and all endpoints are MiniMax-owned.

## Low-severity hardening

- **Cursor** — `fetch_spend` now honors the disabled toggle before the authenticated CSV export; a switched-off Cursor makes no network requests.
- **Local API** — the read-only usage API on 127.0.0.1:6736 refuses non-loopback `Host` headers, closing the DNS-rebinding read that the deliberate no-CORS stance can't prevent. Missing Host (HTTP/1.0 scripts) stays allowed.
- **CI supply chain** — release and winget workflows pin all third-party actions to commit SHAs (tag noted in a trailing comment).

Not addressed here (lowest-value remainder): pricing-feed resource limits and the install.ps1 pipe-to-shell recommendation.

## Testing

- 56 Rust unit tests pass, including new tests covering the exact attack scenarios from the report: enterprise-token-first Copilot files, foreign `auth.json` shapes with the right fields but no OpenAI claim, wrong-provider `apiKey:` listed first, and rebound Host headers.
- Claude's discovery was audited for the same pattern and is already scoped by an Anthropic-specific marker (`claudeAiOauth`) — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->