### PR TITLE
Report leftovers: pricing-feed size cap + inspectable install path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@
 - **Release workflows pin actions to commit SHAs** — third-party
   GitHub Actions in the signed release and winget pipelines are pinned
   to exact commits instead of movable tags.
+- **Pricing catalogs download under a hard size cap** — the three
+  third-party pricing feeds are read in bounded chunks (32 MB cap), so
+  a compromised feed can no longer exhaust memory or disk. This also
+  makes SECURITY.md's existing "inputs are size-capped" claim true.
+- **README offers a look-before-you-run install path** — alongside the
+  one-liner, a two-step download-inspect-run variant and a pointer to
+  winget for anyone who prefers not to pipe scripts into PowerShell.
 
 ## 0.4.32 — 2026-08-11
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,19 @@ irm https://pane.jazii.dev/install.ps1 | iex
 ```
 
 Downloads the latest release, verifies its SHA-256, installs per-user
-(no admin), and launches Pane. No SmartScreen prompt. Read
-[install.ps1](install.ps1) first if you like — it's one short, commented script.
+(no admin), and launches Pane. No SmartScreen prompt.
+
+Piping a script straight into PowerShell runs whatever the server sends
+at that moment. Prefer to look first? Same script, two steps:
+
+```powershell
+iwr https://pane.jazii.dev/install.ps1 -OutFile install.ps1
+# read install.ps1 — one short, commented script — then:
+powershell -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+(Or skip the script question entirely: `winget install Pane.Pane` above
+is hash-verified by Microsoft's pipeline.)
 
 ### Installer (.exe)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,7 +87,9 @@ All of this is auditable in the source — links go to the exact code.
   (an attacker who can replace the installer can replace the manifest,
   and the script itself, too). The cryptographic guarantee is the
   auto-updater's minisign verification once installed; the first install
-  ultimately trusts GitHub.
+  ultimately trusts GitHub. Anyone who'd rather not pipe a script into
+  PowerShell at all can use winget or download-and-read first — the
+  README shows both.
 - Model prices (LiteLLM, models.dev, the OpenUsage supplement) are
   fetched without signatures — tampered pricing data could at worst show
   wrong *display* dollars. Inputs are size-capped and never touch

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -122,6 +122,11 @@ const SOURCES: [(&str, &str); 3] = [
 ];
 const REFRESH_MS: i64 = 24 * 3600 * 1000;
 const RETRY_MS: i64 = 30 * 60 * 1000;
+/// The catalogs are third-party feeds; a compromised one must not be able
+/// to fill memory (and then the disk cache) with an arbitrarily large
+/// response. Largest legitimate source today is LiteLLM at ~3 MB — 32 MB
+/// leaves room to grow while still bounding the damage.
+const MAX_CATALOG_BYTES: usize = 32 * 1024 * 1024;
 
 #[derive(Default)]
 struct Store {
@@ -415,7 +420,7 @@ pub fn ensure_fresh() {
             if !etag.is_empty() {
                 req = req.header("If-None-Match", etag.clone());
             }
-            let resp = req.send().await.map_err(|e| e.to_string())?;
+            let mut resp = req.send().await.map_err(|e| e.to_string())?;
             let status = resp.status().as_u16();
             if status == 304 {
                 return Ok((304u16, String::new(), String::new()));
@@ -429,7 +434,20 @@ pub fn ensure_fresh() {
                 .and_then(|v| v.to_str().ok())
                 .unwrap_or("")
                 .to_string();
-            let body = resp.text().await.map_err(|e| e.to_string())?;
+            // Read with a hard byte cap instead of resp.text() — the
+            // declared Content-Length check alone wouldn't bound a
+            // chunked/lying response.
+            if resp.content_length().is_some_and(|l| l as usize > MAX_CATALOG_BYTES) {
+                return Err("catalog larger than the size cap".into());
+            }
+            let mut bytes: Vec<u8> = Vec::new();
+            while let Some(chunk) = resp.chunk().await.map_err(|e| e.to_string())? {
+                if bytes.len() + chunk.len() > MAX_CATALOG_BYTES {
+                    return Err("catalog larger than the size cap".into());
+                }
+                bytes.extend_from_slice(&chunk);
+            }
+            let body = String::from_utf8(bytes).map_err(|e| e.to_string())?;
             Ok((status, body, new_etag))
         });
 


### PR DESCRIPTION
## Summary

The final two (lowest-severity) items from the external security report, closing it out completely.

- **Pricing-feed size cap** — the three third-party pricing catalogs (LiteLLM, models.dev, the OpenUsage supplement) were read with an unbounded `resp.text()` and written to the disk cache; a compromised feed could exhaust memory/disk. Downloads are now read in chunks under a hard 32 MB cap (largest legitimate catalog today is ~3 MB), with a fast reject on a too-large declared Content-Length. Bonus: SECURITY.md already claimed pricing "inputs are size-capped" — this makes that sentence true.
- **Inspectable install path** — the README's `irm | iex` one-liner now sits next to an explicit download-inspect-run two-step variant and a pointer to winget, with an honest sentence about what piping a script into PowerShell means. SECURITY.md's known-limitations bullet references the alternatives.

## Testing

All 56 Rust unit tests pass. The size-cap path is compile-checked; the cap logic is a straight bounded-accumulate loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->