### PR TITLE
Boot performance: instant first paint, deferred catalog refresh, fast connect fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,26 @@
 
 ## Unreleased
 
+### Fixed
+- **Launch shows your numbers instantly** — the window now paints the
+  previous run's snapshots from disk (marked Outdated) the moment it
+  opens, then swaps in live data as it arrives. Before, the first paint
+  waited for the slowest provider's full network round — at boot, with
+  Wi-Fi still connecting, that was 30-40 seconds of "Refreshing…".
+- **The daily pricing refresh no longer lands at login** — a catalog
+  update discards the spend cache and re-reads every session log
+  (gigabytes on long-lived installs), and with autostart that landed
+  exactly when Windows was busiest. Catalog downloads now wait out the
+  first 10 minutes after launch; a first run with no catalogs on disk
+  still fetches immediately.
+- **Dead networks fail fast** — provider requests now give up on
+  connecting after 5 seconds instead of riding the full 20-second
+  request timeout, so a boot-time refresh with no network settles in
+  seconds.
+
 ### Security
 - **Credential provenance hardening** (from an external security
-  report — thank you): credential discovery now proves a token belongs
+  report): credential discovery now proves a token belongs
   to the provider it will be sent to, instead of accepting the first
   field-shape match. Extra Codex accounts found by the multi-account
   scan must carry OpenAI's own claim namespace in their `id_token`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -850,6 +850,76 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
     all
 }
 
+/// The previous run's last-good snapshots, straight from the disk cache —
+/// the instant first paint at launch. Cards show numbers in milliseconds
+/// instead of a blank "Refreshing…" while the slowest provider answers
+/// (at boot, with the network still coming up, that wait ran 30-40 s).
+/// Everything is marked stale; the first live fetch replaces it.
+#[tauri::command]
+fn cached_usage() -> Vec<providers::Snapshot> {
+    #[derive(serde::Deserialize)]
+    struct CachedSnap {
+        at: i64,
+        snap: providers::Snapshot,
+    }
+    const MAX_STALE_MS: i64 = 24 * 60 * 60 * 1000;
+    let Ok(raw) = std::fs::read_to_string(providers::config_dir().join("last_snapshots.json"))
+    else {
+        return Vec::new();
+    };
+    let Ok(map) = serde_json::from_str::<std::collections::HashMap<String, CachedSnap>>(&raw)
+    else {
+        return Vec::new();
+    };
+
+    let cfg = config_with_defaults(load_config());
+    let disabled: Vec<String> = cfg
+        .get("disabled")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).map(str::to_string).collect())
+        .unwrap_or_default();
+
+    // Same account-swap rule as the live path: if a different account
+    // signed into a default home since the cache was written, that
+    // family's bare-id entry belongs to the old account — never paint it,
+    // not even for the seconds until the live fetch lands.
+    let stored: Value = std::fs::read_to_string(providers::config_dir().join("cache_identities.json"))
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_else(|| json!({}));
+    let swapped: Vec<&str> = [
+        ("claude", providers::claude::default_identity()),
+        ("codex", providers::codex::default_identity()),
+    ]
+    .into_iter()
+    .filter(|(fam, current)| {
+        let old = stored.get(fam).cloned().unwrap_or(Value::Null);
+        matches!((current, &old), (Some(cur), Value::String(o)) if cur != o)
+    })
+    .map(|(fam, _)| fam)
+    .collect();
+
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    let mut out: Vec<providers::Snapshot> = map
+        .into_iter()
+        .filter(|(id, c)| {
+            now_ms - c.at <= MAX_STALE_MS
+                && !disabled.iter().any(|d| d == id)
+                && !swapped.iter().any(|f| f == id)
+        })
+        .map(|(_, c)| {
+            let mut s = c.snap;
+            s.stale = true;
+            s
+        })
+        .collect();
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    out
+}
+
 /// Computes local spend (Today / Yesterday / Last 30 Days) from the CLIs'
 /// own session logs. Heavy file IO, so it runs on a blocking thread.
 #[tauri::command]
@@ -1150,6 +1220,7 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .invoke_handler(tauri::generate_handler![
             fetch_usage,
+            cached_usage,
             fetch_spend,
             set_api_key,
             get_config,

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -398,6 +398,25 @@ pub fn ensure_fresh() {
         }
     }
 
+    // Boot grace: a successful catalog download changes catalog_stamp(),
+    // which discards the whole persisted spend cache and re-parses every
+    // session log (gigabytes on long-lived installs). With autostart, the
+    // daily refresh was landing exactly at Windows login — the one moment
+    // the disk is already saturated. Serve yesterday's catalogs for the
+    // first stretch and refresh once the boot storm has passed; prices
+    // are at most a day + grace stale. First run (no catalogs on disk)
+    // still downloads immediately — no prices at all is worse.
+    {
+        static FIRST_CALL: OnceLock<std::time::Instant> = OnceLock::new();
+        const BOOT_GRACE: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+        let first = *FIRST_CALL.get_or_init(std::time::Instant::now);
+        let all_on_disk =
+            SOURCES.iter().all(|(source, _)| dir().join(format!("{source}.json")).exists());
+        if all_on_disk && first.elapsed() < BOOT_GRACE {
+            return;
+        }
+    }
+
     let mut state = load_state();
     let now = now_ms();
     let refresh_ms = if UNPRICED_HINT.load(std::sync::atomic::Ordering::Relaxed) {

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -402,20 +402,16 @@ pub fn ensure_fresh() {
     // which discards the whole persisted spend cache and re-parses every
     // session log (gigabytes on long-lived installs). With autostart, the
     // daily refresh was landing exactly at Windows login — the one moment
-    // the disk is already saturated. Serve yesterday's catalogs for the
-    // first stretch and refresh once the boot storm has passed; prices
-    // are at most a day + grace stale. First run (no catalogs on disk)
-    // still downloads immediately — no prices at all is worse.
-    {
-        static FIRST_CALL: OnceLock<std::time::Instant> = OnceLock::new();
-        const BOOT_GRACE: std::time::Duration = std::time::Duration::from_secs(10 * 60);
-        let first = *FIRST_CALL.get_or_init(std::time::Instant::now);
-        let all_on_disk =
-            SOURCES.iter().all(|(source, _)| dir().join(format!("{source}.json")).exists());
-        if all_on_disk && first.elapsed() < BOOT_GRACE {
-            return;
-        }
-    }
+    // the disk is already saturated. Serve yesterday's copy of any catalog
+    // already on disk and refresh once the boot storm has passed; prices
+    // are at most a day + grace stale. Gated per source: a catalog with no
+    // file yet (first run, or a feed this machine can never reach) still
+    // fetches immediately — no prices at all is worse, and one dead feed
+    // must not disable the deferral for the others.
+    static FIRST_CALL: OnceLock<std::time::Instant> = OnceLock::new();
+    const BOOT_GRACE: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+    let in_grace =
+        FIRST_CALL.get_or_init(std::time::Instant::now).elapsed() < BOOT_GRACE;
 
     let mut state = load_state();
     let now = now_ms();
@@ -430,6 +426,9 @@ pub fn ensure_fresh() {
         let failed_at = entry.get("failedAt").and_then(Value::as_i64).unwrap_or(0);
         let due = now - fetched_at > refresh_ms && now - failed_at > RETRY_MS;
         if !due {
+            continue;
+        }
+        if in_grace && dir().join(format!("{source}.json")).exists() {
             continue;
         }
         let etag = entry.get("etag").and_then(Value::as_str).unwrap_or("").to_string();

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -152,7 +152,12 @@ fn proxy_url() -> Option<&'static str> {
 pub fn http() -> reqwest::Client {
     let mut builder = reqwest::Client::builder()
         .user_agent("Pane-Windows/0.3")
-        .timeout(std::time::Duration::from_secs(20));
+        .timeout(std::time::Duration::from_secs(20))
+        // At boot the network is often still coming up; without a connect
+        // cap every request rides the full 20 s, and the UI's first paint
+        // waits on the slowest provider chain. Failing to connect in 5 s
+        // is a dead network — fail fast, serve the cached snapshot.
+        .connect_timeout(std::time::Duration::from_secs(5));
     if let Some(url) = proxy_url() {
         if let Ok(proxy) = reqwest::Proxy::all(url) {
             let proxy = proxy.no_proxy(reqwest::NoProxy::from_string("localhost,127.0.0.1,::1"));

--- a/src/main.ts
+++ b/src/main.ts
@@ -2148,6 +2148,26 @@ function renderIfVisible(): void {
   populatePinnedOptions();
 }
 
+/// First paint from the previous run's snapshots (disk cache): numbers on
+/// screen in milliseconds instead of a blank "Refreshing…" while the
+/// slowest provider answers — at boot that wait ran 30-40 seconds. Cards
+/// arrive marked stale ("Outdated") and the live fetch replaces them.
+async function paintCachedSnapshots(): Promise<void> {
+  // Only when a saved layout exists: on a true first run there is no cache
+  // anyway, and refresh()'s first-launch detection must see the live list.
+  if (config.layout === null) return;
+  try {
+    const cached = await invoke<Snapshot[]>("cached_usage");
+    // The live fetch may have already landed — never paint over it.
+    if (!cached.length || lastSnapshots.length) return;
+    lastSnapshots = cached;
+    ensureLayout();
+    renderIfVisible();
+  } catch {
+    // No cache readable — the live fetch paints, as before.
+  }
+}
+
 async function refresh(force = false): Promise<void> {
   if (refreshing) return;
   if (!force && Date.now() - lastFetch < STALE_MS) return;
@@ -3002,6 +3022,7 @@ window.addEventListener("DOMContentLoaded", () => {
   });
   void initSettings().then(() => {
     scheduleAutoRefresh();
+    void paintCachedSnapshots();
     void refresh(true);
     // Queued, not shown: the window is usually still hidden in the tray at
     // startup — the first popover-shown presents it. Runs after the config


### PR DESCRIPTION
## Problem

After a reboot the window took 30-40 seconds to show any numbers, and the first minute after login felt heavy.

Two mechanisms, verified on a real install (1.6 GB of session logs):
1. The first paint waited for **every** provider's live fetch — and at boot, with the network still coming up, requests rode the full 20 s timeout, several per provider chain.
2. The daily pricing-catalog refresh changes `catalog_stamp()`, which by design discards the persisted spend cache and re-parses every session log (787 MB Codex + 392 MB Claude here). With autostart, that always landed exactly at Windows login.

## Fixes

- **Instant first paint** — new `cached_usage` command returns the previous run's last-good snapshots from `last_snapshots.json` (≤24 h old, disabled providers filtered, same account-swap guard as the live path, everything marked stale). The UI paints them immediately after config load; the live fetch replaces them when it lands. First-run detection is untouched (the cached paint is skipped when no layout exists yet).
- **Boot grace for catalog downloads** — `ensure_fresh()` serves the on-disk catalogs for the first 10 minutes of process uptime, so the discard-and-re-parse happens when the machine is idle, not during login. A first run with no catalogs on disk still fetches immediately. Prices are at most one day + grace stale.
- **5 s connect timeout** on the shared HTTP client — a dead or still-connecting network fails fast instead of holding every request for 20 s.

No numbers change anywhere — only when work happens and what's shown while it happens.

Also removes the changelog credit phrasing per the maintainer's request.

## Testing

- 56/56 Rust unit tests pass; frontend type-checks and builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->