### PR TITLE
Release 0.4.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.33 — 2026-08-12
 
 ### Fixed
 - **Launch shows your numbers instantly** — the window now paints the

--- a/README.md
+++ b/README.md
@@ -212,8 +212,9 @@ whatever the community asks for loudest.
 - **Quick links** — Status / Dashboard shortcuts on every card.
 - **[Local HTTP API](docs/local-http-api.md)** — `GET
   http://127.0.0.1:6736/v1/usage` for scripts, Rainmeter widgets, stream
-  overlays; same wire format as the Mac app, but with no CORS headers so
-  web pages can't read it through your browser.
+  overlays; same wire format as the Mac app, but with no CORS headers
+  and a loopback-only Host check so web pages can't read it through
+  your browser (not even via DNS rebinding).
 - **Appearance** — System / Light / Dark, compact density, global shortcut
   (e.g. `Ctrl+Shift+U`), optional outbound proxy.
 
@@ -240,7 +241,8 @@ treats them — verify it:
 The short version: tokens are sent only to their own vendor's API over
 HTTPS; pasted keys live in `%APPDATA%\Pane`, readable only by your
 Windows user; spend accounting parses your local logs locally; the HTTP
-API is loopback-only with no CORS; updates are signature-verified.
+API is loopback-only with no CORS and a Host check; updates are
+signature-verified.
 
 ## Settings (gear icon)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,8 +31,11 @@ All of this is auditable in the source — links go to the exact code.
   directory and `~\.config` for Claude/Codex-shaped credential files —
   the places those official mechanisms put them. A discovered credential
   follows the exact same lane rule (its own vendor's API only, token
-  refresh written back beside it), and a file that cannot name its
-  account is never used at all.
+  refresh written back beside it), a file that cannot name its account
+  is never used at all, and a broadly-discovered Codex candidate must
+  additionally *prove* it's an OpenAI login (OpenAI's own claim
+  namespace in its `id_token`) before any request — a look-alike
+  credential file from another app never enters the lane.
 - **No analytics SDK, no crash reporter, no event streams.** Pane's
   entire self-reporting surface is two anonymous channels, both
   documented field-by-field in [docs/privacy.md](docs/privacy.md): the
@@ -43,10 +46,12 @@ All of this is auditable in the source — links go to the exact code.
   the statistic off is a hard stop and deletes the stored ID. The full
   list of network calls Pane can make is in
   [docs/privacy.md](docs/privacy.md).
-- **The local HTTP API is loopback-only and CORS-locked.** It binds
-  `127.0.0.1:6736`, serves usage numbers (never credentials), and sends no
-  `Access-Control-Allow-Origin` header — so web pages you visit cannot
-  read it from a browser ([`src-tauri/src/httpapi.rs`](src-tauri/src/httpapi.rs)).
+- **The local HTTP API is loopback-only, CORS-locked, and Host-checked.**
+  It binds `127.0.0.1:6736`, serves usage numbers (never credentials),
+  sends no `Access-Control-Allow-Origin` header, and refuses requests
+  whose `Host` header isn't a loopback spelling — so web pages you visit
+  cannot read it from a browser, not even via DNS rebinding
+  ([`src-tauri/src/httpapi.rs`](src-tauri/src/httpapi.rs)).
 - **Updates are cryptographically verified.** The auto-updater accepts
   only releases signed by the project's minisign key — passphrase-protected,
   master copy held offline; the public key is baked into the app. The

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -100,8 +100,9 @@ manifest first.
 `http://127.0.0.1:6736/v1/usage` exists so your own scripts and widgets
 can read your usage. It is loopback-only (nothing on your network can
 reach it), serves usage numbers only (never credentials or keys), and
-sends **no CORS headers** — so websites you visit cannot read it through
-your browser. Details: [local-http-api.md](local-http-api.md).
+sends **no CORS headers**, and refuses non-loopback `Host` headers — so
+websites you visit cannot read it through your browser, not even via
+DNS rebinding. Details: [local-http-api.md](local-http-api.md).
 
 ## Verifying all of this
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -46,10 +46,13 @@ Ground rules that apply to every provider:
 
 - **Reads:** `%USERPROFILE%\.codex\auth.json` (honors `CODEX_HOME`).
   **Multi-account:** same discovery as Claude — dot-folders and
-  `~\.config` dirs holding a Codex-shaped `auth.json` each become their
-  own card, identified by `tokens.account_id` (or the id_token's ChatGPT
-  account claim) and named by the account email; a dir that can't name
-  its account is skipped. Reset-credit redemption always uses the
+  `~\.config` dirs each become their own card, but only when their
+  `auth.json` *proves* it's an OpenAI login (its `id_token` carries
+  OpenAI's own claim namespace) — another app's credential file that
+  merely looks similar is never picked up. Cards are identified by
+  `tokens.account_id` (or the id_token's ChatGPT account claim) and
+  named by the account email; a dir that can't name its account is
+  skipped. Reset-credit redemption always uses the
   account whose card offered the credit.
 - **Calls:** `chatgpt.com/backend-api/wham/usage` (limits, Spark windows,
   credits); `.../wham/rate-limit-reset-credits` (reset credits, and
@@ -93,7 +96,9 @@ Ground rules that apply to every provider:
 ## GitHub Copilot
 
 - **Reads:** gh CLI / Copilot tokens from Windows Credential Manager
-  (`gh:github.com:<user>`) or legacy `hosts.yml` files.
+  (`gh:github.com:<user>`) or legacy `hosts.yml` files — in every source,
+  only the `github.com` entry; a GitHub Enterprise token sharing the
+  file is never selected (this card only ever talks to api.github.com).
 - **Calls:** `api.github.com/copilot_internal/user`.
 - **Shows:** credits/quota and plan.
 
@@ -122,7 +127,9 @@ Ground rules that apply to every provider:
 ## MiniMax
 
 - **Reads:** pasted key (Settings), `MINIMAX_API_KEY`, or
-  `%USERPROFILE%\.minimax\config.yaml`; local spend from
+  `%USERPROFILE%\.minimax\config.yaml` (exactly
+  `provider.minimax.options.apiKey` — a same-named key under another
+  provider's section is never used); local spend from
   `%USERPROFILE%\.minimax\sqlite.db` (the Agent CLI's per-turn
   token_usage table, snapshotted via SQLite's backup API — never
   modified) and from Claude Code sessions that ran against MiniMax's

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.32",
+  "version": "0.4.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.32",
+      "version": "0.4.33",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.32",
+  "version": "0.4.33",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.32"
+version = "0.4.33"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.32"
+version = "0.4.33"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.32",
+  "version": "0.4.33",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to 0.4.33 and changelog roll. Ships everything merged since 0.4.32:

**Security** (external report, all 8 items):
- Credential provenance hardening: Codex OpenAI-claim proof, Copilot github.com scoping, MiniMax exact-path key lookup
- Disabled Cursor makes no network requests
- Local API rejects non-loopback Host headers (DNS-rebinding guard)
- Release workflows pin actions to commit SHAs
- Pricing catalogs download under a 32 MB cap
- README documents an inspect-first install path

**Performance:**
- Instant first paint from cached snapshots (was 30-40 s blank at boot)
- Daily pricing refresh deferred past the first 10 minutes (per source)
- 5 s connect timeout so dead networks fail fast

After merge: push the `v0.4.33` tag to build and publish the signed release. Note this is the first release built with the SHA-pinned workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->