### PR TITLE
Grok 4.6 launch pricing, Cursor slug handling, DeepSeek v4 builtins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Grok 4.6 prices from day one** — xAI's launch-day rates
+  ($2 in / $0.50 cached / $6 out per MTok, doubling for ≥200k-token
+  prompts; the fast variant at 2x) are baked in until the public
+  catalogs learn the model, so spend from Grok 4.6 sessions shows
+  dollars instead of the unpriced ⚠.
+
 ## 0.4.33 — 2026-08-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 ### Fixed
+- **DeepSeek V4 pro/flash now price** — DeepSeek's V4 pro and flash
+  models (including dated snapshots like `deepseek-v4-pro-0813` and
+  `deepseek-v4-flash-0731`) weren't in any public catalog, so usage
+  through Hermes/AihubMix counted tokens but showed $0 and folded out of
+  the spend ring. Their AihubMix rates are baked in until the catalogs
+  learn them (self-retiring), and cached history repricies.
 - **Grok 4.6 prices from day one** — xAI's launch-day rates
   ($2 in / $0.50 cached / $6 out per MTok, doubling for ≥200k-token
   prompts; the fast variant at 2x) are baked in until the public

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -668,6 +668,7 @@ fn builtin_price(canonical: &str) -> Option<Price> {
     let bare = canonical
         .strip_prefix("moonshot/")
         .or_else(|| canonical.strip_prefix("moonshot-ai/"))
+        .or_else(|| canonical.strip_prefix("xai/"))
         .unwrap_or(canonical);
     match bare {
         "kimi-k3" | "kimi-k3-code" => Some(Price::flat(3.0, 15.0, 0.3, 3.0)),
@@ -675,6 +676,21 @@ fn builtin_price(canonical: &str) -> Option<Price> {
         // output $6, implicit cache read $0.25, explicit cache write $2.50.
         // Public catalogs still carry 0/0 placeholders for these slugs.
         "qwen3.8-max" | "qwen3.8-max-preview" => Some(Price::flat(2.0, 6.0, 0.25, 2.5)),
+        // Grok 4.6, released 2026-08-12 — docs.x.ai/docs/pricing (USD/MTok):
+        // $2 in / $0.50 cached / $6 out; prompts ≥200k bill $4 / $1 / $12
+        // for the WHOLE request (xAI's long-context rule matches
+        // request_cost's tiering, and Grok spend passes the default 200k
+        // threshold). xAI bills no separate cache-write rate — writes are
+        // plain input. The announced 2x "-fast" variant needs no entry:
+        // the -fast resolution path applies the default 2x multiplier to
+        // this rate card. Public catalogs don't carry 4.6 yet.
+        "grok-4.6" | "grok-4-6" => Some(Price {
+            input_200k: Some(4.0),
+            output_200k: Some(12.0),
+            cache_read_200k: Some(1.0),
+            cache_write_200k: Some(4.0),
+            ..Price::flat(2.0, 6.0, 0.5, 2.0)
+        }),
         _ => None,
     }
 }
@@ -766,6 +782,29 @@ mod tests {
         super::apply_supplement(&mut store, &updated);
         let terra = store.supplement.get("gpt-5.6-terra").unwrap();
         assert_eq!((terra.input, terra.output), (1.75, 11.0));
+    }
+
+    #[test]
+    fn grok_46_builtin_prices_with_long_context_tier() {
+        // Vendor rates (docs.x.ai/docs/pricing): $2/$0.50/$6, doubling for
+        // ≥200k prompts — resolvable in every spelling before the public
+        // catalogs learn the model. Empty store = builtin only.
+        let store = super::Store::default();
+        for slug in ["grok-4.6", "grok-4-6", "xai/grok-4.6", "grok-4.6-high"] {
+            let p = super::resolve(&store, slug, 0)
+                .unwrap_or_else(|| panic!("{slug} did not price"));
+            assert_eq!((p.input, p.output, p.cache_read, p.cache_write), (2.0, 6.0, 0.5, 2.0), "{slug}");
+            assert_eq!(
+                (p.input_200k, p.output_200k, p.cache_read_200k),
+                (Some(4.0), Some(12.0), Some(1.0)),
+                "{slug}"
+            );
+        }
+        // The fast variant is "twice the price" (launch post): the -fast
+        // path scales the whole rate card, long-context tier included.
+        let fast = super::resolve(&store, "grok-4.6-fast", 0).unwrap();
+        assert_eq!((fast.input, fast.output, fast.cache_read), (4.0, 12.0, 1.0));
+        assert_eq!(fast.input_200k, Some(8.0));
     }
 
     #[test]

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -166,7 +166,7 @@ pub fn generation() -> u64 {
 /// fingerprinted below — an app update that reprices the same files would
 /// otherwise leave history at the old dollars until upstream happens to
 /// rewrite a catalog.
-const CORRECTIONS_REV: u32 = 3; // 3: zero-rate catalog placeholders no longer price at $0.00
+const CORRECTIONS_REV: u32 = 4; // 4: deepseek-v4 pro/flash builtin prices
 
 /// Stable fingerprint of the effective pricing inputs: the on-disk catalog
 /// files plus this binary's corrections revision. The persistent spend
@@ -669,8 +669,28 @@ fn builtin_price(canonical: &str) -> Option<Price> {
         .strip_prefix("moonshot/")
         .or_else(|| canonical.strip_prefix("moonshot-ai/"))
         .or_else(|| canonical.strip_prefix("xai/"))
+        .or_else(|| canonical.strip_prefix("deepseek/"))
+        // Cursor's CSV brands third-party slugs ("cursor-grok-4.6-xhigh");
+        // the supplement's alias rules normally translate these, but a
+        // launch-day model needs the baked rates before the supplement
+        // learns the new slug.
+        .or_else(|| canonical.strip_prefix("cursor-"))
         .unwrap_or(canonical);
+    // DeepSeek ships dated snapshots ("deepseek-v4-pro-0813"); price them as
+    // the base model so a new date doesn't silently go unpriced.
+    let bare = match bare.strip_suffix(|c: char| c.is_ascii_digit()) {
+        Some(_) if bare.starts_with("deepseek-") => bare.rsplit_once('-').map_or(bare, |(h, t)| {
+            if t.chars().all(|c| c.is_ascii_digit()) && t.len() >= 4 { h } else { bare }
+        }),
+        _ => bare,
+    };
     match bare {
+        // AihubMix DeepSeek V4 family (USD/MTok, aihubmix.com/model/…): no
+        // cache-write rate published, so writes bill at the input rate.
+        // Used through Hermes/AihubMix; public catalogs don't carry these
+        // slugs yet. pro: /deepseek-v4-pro-0813 · flash: /deepseek-v4-flash.
+        "deepseek-v4-pro" => Some(Price::flat(0.464, 0.928, 0.004, 0.464)),
+        "deepseek-v4-flash" => Some(Price::flat(0.142, 0.284, 0.0284, 0.142)),
         "kimi-k3" | "kimi-k3-code" => Some(Price::flat(3.0, 15.0, 0.3, 3.0)),
         // Alibaba Model Studio, GA'd 2026-08-03 (USD/MTok): input $2,
         // output $6, implicit cache read $0.25, explicit cache write $2.50.
@@ -742,6 +762,25 @@ mod tests {
     }
 
     #[test]
+    fn deepseek_v4_pro_is_priced_including_dated_snapshots() {
+        let store = super::Store::default();
+        // Bare slug and the AihubMix dated snapshot both price identically.
+        for slug in ["deepseek-v4-pro", "deepseek-v4-pro-0813", "deepseek/deepseek-v4-pro-0813"] {
+            let p = super::resolve(&store, slug, 0).unwrap_or_else(|| panic!("{slug} unpriced"));
+            assert!((p.input - 0.464).abs() < 1e-9, "{slug}");
+            assert!((p.output - 0.928).abs() < 1e-9, "{slug}");
+            assert!((p.cache_read - 0.004).abs() < 1e-9, "{slug}");
+        }
+        // The flash sibling is priced too (both are Hermes-logged slugs),
+        // including its dated snapshot.
+        let flash = super::resolve(&store, "deepseek-v4-flash-0731", 0).unwrap();
+        assert!((flash.input - 0.142).abs() < 1e-9);
+        assert!((flash.output - 0.284).abs() < 1e-9);
+        // A slug outside the family stays unpriced (no over-broad match).
+        assert!(super::resolve(&store, "deepseek-v9-imaginary", 0).is_none());
+    }
+
+    #[test]
     fn priority_slugs_price_at_base_times_priority_multiplier() {
         let mut store = super::Store::default();
         store
@@ -790,7 +829,11 @@ mod tests {
         // ≥200k prompts — resolvable in every spelling before the public
         // catalogs learn the model. Empty store = builtin only.
         let store = super::Store::default();
-        for slug in ["grok-4.6", "grok-4-6", "xai/grok-4.6", "grok-4.6-high"] {
+        // cursor-grok-4.6-xhigh is the exact slug Cursor's CSV logged on
+        // launch day — 20.6M real tokens showed $0.00 until it resolved.
+        for slug in
+            ["grok-4.6", "grok-4-6", "xai/grok-4.6", "grok-4.6-high", "cursor-grok-4.6-xhigh"]
+        {
             let p = super::resolve(&store, slug, 0)
                 .unwrap_or_else(|| panic!("{slug} did not price"));
             assert_eq!((p.input, p.output, p.cache_read, p.cache_write), (2.0, 6.0, 0.5, 2.0), "{slug}");

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -413,7 +413,18 @@ fn codex_price(model: &str) -> (f64, f64, f64) {
 
 fn grok_price(model: &str) -> (f64, f64) {
     let m = model.to_lowercase();
-    if m.contains("code") || m.contains("fast") {
+    // Grok 4.6's "fast" is a 2x PREMIUM speed tier (launch post: "twice
+    // the price"), the opposite of the older grok-4-fast/grok-code-fast
+    // line where "fast" meant a smaller, cheaper model — 4.6 slugs must
+    // never fall into that cheap branch. (Normally unreachable: the
+    // baked-in catalog entry resolves 4.6 before this backstop.)
+    if m.contains("4.6") || m.contains("4-6") {
+        if m.contains("fast") {
+            (4.0, 12.0)
+        } else {
+            (2.0, 6.0)
+        }
+    } else if m.contains("code") || m.contains("fast") {
         (0.2, 1.5)
     } else {
         (3.0, 15.0)


### PR DESCRIPTION
## Summary

Grok 4.6 shipped 2026-08-12 and no public catalog carries it yet, so its spend showed the unpriced ⚠. This bakes in the vendor rates until catalogs catch up (same self-retiring pattern as kimi-k3 / qwen3.8-max — a real catalog entry outranks these the moment one ships). Verified working on a live install against real launch-day Cursor usage.

**Grok 4.6** (docs.x.ai/docs/pricing):
- $2 input / $0.50 cached / $6 output per MTok; ≥200k-token prompts bill $4 / $1 / $12 for the whole request (xAI's long-context rule matches `request_cost`'s tiering at the default 200k threshold)
- Cache writes bill as plain input (xAI publishes no write rate)
- The 2× fast variant resolves through the existing `-fast` multiplier path — no separate entry
- `builtin_price` now also strips Cursor's `cursor-` branding: Cursor's CSV logs the model as `cursor-grok-4.6-xhigh`, which stayed unpriced (20.6M real tokens at $0.00) until stripped
- `grok_price` backstop in spend.rs: 4.6's "fast" is a 2× premium tier, never the old cheap `grok-4-fast` branch (kept consistent even though the backstop is normally unreachable for 4.6)

**DeepSeek v4** (aihubmix.com): `deepseek-v4-pro` builtin at $0.464 / $0.928 / $0.004 cached, with dated-snapshot stripping (`deepseek-v4-pro-0813` → base) so new dates don't silently go unpriced. `CORRECTIONS_REV` bumped to 4 so cached spend reprices.

## Testing

- 58/58 unit tests pass, including new coverage for every Grok 4.6 spelling (`grok-4.6`, `grok-4-6`, `xai/`-prefixed, effort suffixes, `cursor-grok-4.6-xhigh`, fast/long-context scaling) and DeepSeek dated snapshots
- Confirmed on a local install: the launch-day Cursor session that showed `$0.00 · 20.6M tokens · estimated` prices correctly after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->