### PR TITLE
Bake in AihubMix DeepSeek V4 pro/flash pricing until catalogs catch up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   catalogs learn the model, so spend from Grok 4.6 sessions shows
   dollars instead of the unpriced ⚠ — including Cursor sessions, whose
   usage export brands the model `cursor-grok-4.6-xhigh`.
+- **DeepSeek V4 spend prices from day one** — AihubMix's rate cards for
+  `deepseek-v4-pro` ($0.464 in / $0.928 out / $0.004 cache read per
+  MTok) and `deepseek-v4-flash` ($0.154 / $0.308 / $0.003) are baked in
+  until public catalogs learn the family, dated snapshots like
+  `-0813` included, so Hermes sessions on these models show dollars
+  instead of the unpriced ⚠.
 
 ## 0.4.33 — 2026-08-12
 

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -166,7 +166,7 @@ pub fn generation() -> u64 {
 /// fingerprinted below — an app update that reprices the same files would
 /// otherwise leave history at the old dollars until upstream happens to
 /// rewrite a catalog.
-const CORRECTIONS_REV: u32 = 4; // 4: grok-4.6 builtin launch pricing
+const CORRECTIONS_REV: u32 = 5; // 5: deepseek-v4 pro/flash builtin prices
 
 /// Stable fingerprint of the effective pricing inputs: the on-disk catalog
 /// files plus this binary's corrections revision. The persistent spend
@@ -669,8 +669,30 @@ fn builtin_price(canonical: &str) -> Option<Price> {
         .strip_prefix("moonshot/")
         .or_else(|| canonical.strip_prefix("moonshot-ai/"))
         .or_else(|| canonical.strip_prefix("xai/"))
+        .or_else(|| canonical.strip_prefix("deepseek/"))
         .unwrap_or(canonical);
+    // DeepSeek ships dated snapshots ("deepseek-v4-pro-0813"); price them as
+    // the base model so a new date doesn't silently go unpriced. Scoped to
+    // deepseek- slugs whose trailing dash-segment is all digits (≥4), so
+    // "deepseek-v4" or version-bearing names elsewhere never lose a tail.
+    let bare = match bare.strip_suffix(|c: char| c.is_ascii_digit()) {
+        Some(_) if bare.starts_with("deepseek-") => bare.rsplit_once('-').map_or(bare, |(h, t)| {
+            if t.chars().all(|c| c.is_ascii_digit()) && t.len() >= 4 { h } else { bare }
+        }),
+        _ => bare,
+    };
     match bare {
+        // AihubMix DeepSeek V4 family — the gateway's OWN rate cards
+        // (aihubmix.com/model/deepseek-v4-pro-0813 and /deepseek-v4-flash
+        // headline pricing, NOT the cheaper Baidu/Tencent provider rows on
+        // the same pages): pro $0.464/$0.928 with $0.004 cache read (yes,
+        // ~1/116 of input — the page really says $0.004), flash
+        // $0.154/$0.308 with $0.003 cache read. No cache-write rate is
+        // published, so writes bill at the input rate. Hermes logs these
+        // bare ("deepseek-v4-flash", "deepseek-v4-pro-0813" — verified
+        // against a real state.db); public catalogs don't carry them yet.
+        "deepseek-v4-pro" => Some(Price::flat(0.464, 0.928, 0.004, 0.464)),
+        "deepseek-v4-flash" => Some(Price::flat(0.154, 0.308, 0.003, 0.154)),
         "kimi-k3" | "kimi-k3-code" => Some(Price::flat(3.0, 15.0, 0.3, 3.0)),
         // Alibaba Model Studio, GA'd 2026-08-03 (USD/MTok): input $2,
         // output $6, implicit cache read $0.25, explicit cache write $2.50.
@@ -787,6 +809,29 @@ mod tests {
         super::apply_supplement(&mut store, &updated);
         let terra = store.supplement.get("gpt-5.6-terra").unwrap();
         assert_eq!((terra.input, terra.output), (1.75, 11.0));
+    }
+
+    #[test]
+    fn deepseek_v4_builtins_price_including_dated_snapshots() {
+        let store = super::Store::default();
+        // Real Hermes slugs: bare flash, dated pro snapshot, and the
+        // deepseek/-prefixed catalog spelling.
+        for slug in ["deepseek-v4-pro", "deepseek-v4-pro-0813", "deepseek/deepseek-v4-pro-0813"] {
+            let p = super::resolve(&store, slug, 0).unwrap_or_else(|| panic!("{slug} unpriced"));
+            assert!((p.input - 0.464).abs() < 1e-9, "{slug}");
+            assert!((p.output - 0.928).abs() < 1e-9, "{slug}");
+            // AihubMix really does list $0.004/M cache read for pro —
+            // ~1/116 of input is the vendor's number, not a typo.
+            assert!((p.cache_read - 0.004).abs() < 1e-9, "{slug}");
+        }
+        for slug in ["deepseek-v4-flash", "deepseek-v4-flash-0731"] {
+            let p = super::resolve(&store, slug, 0).unwrap_or_else(|| panic!("{slug} unpriced"));
+            assert!((p.input - 0.154).abs() < 1e-9, "{slug}");
+            assert!((p.cache_read - 0.003).abs() < 1e-9, "{slug}");
+        }
+        // The trimmer never eats non-date tails or other families.
+        assert!(super::resolve(&store, "deepseek-v4", 0).is_none());
+        assert!(super::resolve(&store, "deepseek-v3.2", 0).is_none());
     }
 
     #[test]

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -624,6 +624,22 @@ fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
     if let Some(p) = builtin_price(&canonical) {
         return Some(p);
     }
+    // DeepSeek ships dated snapshots ("deepseek-v4-pro-0813"): when no
+    // source knows the dated form, retry the base slug through the WHOLE
+    // chain — a catalog that has learned the base model must outrank the
+    // baked table for dated spellings too, or the table would never
+    // self-retire for them. Scoped to deepseek slugs with an all-digit
+    // ≥4-char tail so version-bearing names never lose a real tail.
+    if let Some((head, tail)) = canonical.rsplit_once('-') {
+        if canonical.starts_with("deepseek")
+            && tail.len() >= 4
+            && tail.chars().all(|c| c.is_ascii_digit())
+        {
+            if let Some(p) = resolve(s, head, depth + 1) {
+                return Some(p);
+            }
+        }
+    }
     // Zero-rate entries, reconsidered: nothing anywhere carries real rates
     // for this slug, so a 0/0 catalog row means the model is genuinely
     // free — take it, keeping free models at $0.00 without an unpriced ⚠.
@@ -671,16 +687,6 @@ fn builtin_price(canonical: &str) -> Option<Price> {
         .or_else(|| canonical.strip_prefix("xai/"))
         .or_else(|| canonical.strip_prefix("deepseek/"))
         .unwrap_or(canonical);
-    // DeepSeek ships dated snapshots ("deepseek-v4-pro-0813"); price them as
-    // the base model so a new date doesn't silently go unpriced. Scoped to
-    // deepseek- slugs whose trailing dash-segment is all digits (≥4), so
-    // "deepseek-v4" or version-bearing names elsewhere never lose a tail.
-    let bare = match bare.strip_suffix(|c: char| c.is_ascii_digit()) {
-        Some(_) if bare.starts_with("deepseek-") => bare.rsplit_once('-').map_or(bare, |(h, t)| {
-            if t.chars().all(|c| c.is_ascii_digit()) && t.len() >= 4 { h } else { bare }
-        }),
-        _ => bare,
-    };
     match bare {
         // AihubMix DeepSeek V4 family — the gateway's OWN rate cards
         // (aihubmix.com/model/deepseek-v4-pro-0813 and /deepseek-v4-flash
@@ -691,6 +697,8 @@ fn builtin_price(canonical: &str) -> Option<Price> {
         // published, so writes bill at the input rate. Hermes logs these
         // bare ("deepseek-v4-flash", "deepseek-v4-pro-0813" — verified
         // against a real state.db); public catalogs don't carry them yet.
+        // Dated snapshots reach these arms via resolve()'s date-trim
+        // retry, so a catalog that learns the base slug outranks them.
         "deepseek-v4-pro" => Some(Price::flat(0.464, 0.928, 0.004, 0.464)),
         "deepseek-v4-flash" => Some(Price::flat(0.154, 0.308, 0.003, 0.154)),
         "kimi-k3" | "kimi-k3-code" => Some(Price::flat(3.0, 15.0, 0.3, 3.0)),
@@ -832,6 +840,16 @@ mod tests {
         // The trimmer never eats non-date tails or other families.
         assert!(super::resolve(&store, "deepseek-v4", 0).is_none());
         assert!(super::resolve(&store, "deepseek-v3.2", 0).is_none());
+
+        // Self-retirement holds for dated spellings too: once any catalog
+        // learns the BASE slug, dated snapshots follow the catalog, not
+        // the baked table (Devin's find — the trim must run in resolve,
+        // where the retry passes through every source, not in builtin).
+        let mut store = super::Store::default();
+        store.litellm.insert("deepseek-v4-pro".into(), super::Price::flat(0.5, 1.0, 0.05, 0.5));
+        let p = super::resolve(&store, "deepseek-v4-pro-0813", 0).unwrap();
+        assert!((p.input - 0.5).abs() < 1e-9);
+        assert!((p.cache_read - 0.05).abs() < 1e-9);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Second half of the #129 split (Grok half merged as #130): Hermes sessions on DeepSeek V4 models showed the unpriced ⚠ because no public catalog carries the family yet. Bakes in the vendor rate cards, self-retiring the moment a catalog learns the slugs.

- Rates are AihubMix's **own headline cards** (aihubmix.com/model/deepseek-v4-pro-0813 and /deepseek-v4-flash), not the cheaper Baidu/Tencent provider rows shown on the same pages: pro $0.464 / $0.928 with $0.004 cache read, flash $0.154 / $0.308 with $0.003 cache read. No cache-write rate is published, so writes bill at the input rate.
- On the pro cache read: Devin flagged $0.004 (~1/116 of input) as a possible dropped digit on #129 — verified against the page, which literally lists `Cache Read: $0.004 /M tokens`. It's the vendor's number; a test comment pins this.
- The earlier draft's flash entry ($0.142/$0.284/$0.0284) matched the Baidu/Tencent rows, not AihubMix's route — corrected here.
- Dated snapshots (`deepseek-v4-pro-0813`) strip to the base entry; the trimmer is scoped to `deepseek-` slugs with an all-digit ≥4-char tail so `deepseek-v4` / `deepseek-v3.2` are untouched.
- Slug shapes verified against a real Hermes `state.db`: it logs bare (`deepseek-v4-flash`, `deepseek-v4-pro-0813`), no gateway prefix — which also answers Devin's #129 question about `aihubmix/`-prefixed spellings.
- CORRECTIONS_REV bumped so persisted spend re-prices.

## Testing

New unit test covers bare, dated, and `deepseek/`-prefixed spellings, the corrected flash rates, and trimmer non-targets. Full suite 58/58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->