### PR TITLE
OpenCode meters read the official account-wide usage API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ build-latest.log
 
 # Session tooling
 .claude/
+pane.md
 
 # Editor directories and files
 .vscode/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+- **OpenCode meters are account-wide now** — OpenCode shipped the
+  official usage API we'd been waiting on
+  ([anomalyco/opencode#16513](https://github.com/anomalyco/opencode/pull/16513)),
+  and the card now reads Session / Weekly / Monthly percentages and
+  resets straight from OpenCode's servers: the same numbers as the Zen
+  dashboard, including your other devices and anyone sharing the
+  subscription. The old this-PC-only computation from `opencode.db`
+  remains as the offline fallback, and dollar spend stays local.
+
 ### Fixed
 - **Grok 4.6 prices from day one** — xAI's launch-day rates
   ($2 in / $0.50 cached / $6 out per MTok, doubling for ≥200k-token

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ success/failure counts — never amounts or error text) — see
 | Claude (Claude Code) | `%USERPROFILE%\.claude\.credentials.json` + Anthropic usage API; multi-account — every discovered config-dir login gets its own card |
 | Codex (Codex CLI) | `%USERPROFILE%\.codex\auth.json` + ChatGPT usage API, incl. reset-credit redemption; multi-account like Claude |
 | Cursor | Cursor's local state database + cursor.com API |
-| OpenCode (Go plan) | Local `opencode.db` spend vs documented plan limits* |
+| OpenCode (Go plan) | Official account-wide usage API (Go key from `auth.json`); local `opencode.db` for spend* |
 | GitHub Copilot | Copilot editor login or GitHub CLI (Credential Manager) + GitHub API |
 | Grok (Grok CLI) | `%USERPROFILE%\.grok\auth.json` + Grok billing/subscription APIs |
 | Devin (Devin CLI) | `%APPDATA%\devin\credentials.toml` + GetUserStatus RPC; local CLI session store for spend |
@@ -170,10 +170,13 @@ success/failure counts — never amounts or error text) — see
 | AihubMix | API key (Settings or auto-detected from OpenCode) → usage vs spending limit |
 | Qwen Code | Coding Plan key (Settings or env) → 5h/weekly/monthly request quotas + local spend |
 
-*OpenCode has no public usage API yet
-([anomalyco/opencode#10448](https://github.com/anomalyco/opencode/issues/10448));
-usage is computed locally from this machine's OpenCode history, the same
-data `opencode stats` uses.
+*OpenCode's meters use the official usage API that shipped in
+[anomalyco/opencode#16513](https://github.com/anomalyco/opencode/pull/16513)
+— the same account-wide numbers as the Zen dashboard, so usage from your
+other devices (or other people on a shared subscription) finally counts.
+If the API is unreachable, Pane falls back to computing this machine's
+usage locally from `opencode.db`, the same data `opencode stats` uses;
+dollar spend figures are always local.
 
 More on the way: IDE-database providers (Windsurf, JetBrains AI…) and
 whatever the community asks for loudest.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -80,18 +80,20 @@ Ground rules that apply to every provider:
 
 ## OpenCode (Go plan)
 
-- **Reads:** `%USERPROFILE%\.local\share\opencode\opencode.db` (copied
-  before reading) — message costs your own OpenCode history already
+- **Reads:** the Go key from
+  `%USERPROFILE%\.local\share\opencode\auth.json`;
+  `%USERPROFILE%\.local\share\opencode\opencode.db` (copied before
+  reading) for spend — message costs your own OpenCode history already
   contains.
-- **Calls:** nothing — OpenCode has no public usage API (the gateway
-  exposes only inference routes); usage is computed locally against
-  documented plan limits using OpenCode's real windows: a rolling
-  5-hour session (resets as the oldest in-window spend ages out), a UTC
-  Monday-start week, and a monthly cycle anchored to your first-ever Go
-  usage. **Note the meters count this PC only:** Go quotas are counted
-  account-wide on OpenCode's servers, so usage from your other devices
-  or from other participants on a shared subscription can't appear
-  here. The Console quick-link shows the account-wide truth.
+- **Calls:** `opencode.ai/zen/go/v1/usage` (the official account-wide
+  usage API, shipped in anomalyco/opencode#16513) — Session / Weekly /
+  Monthly percentages and resets counted on OpenCode's servers, the
+  same numbers the Zen dashboard shows, so usage from your other
+  devices and shared-subscription participants is included. If the API
+  is unreachable, meters fall back to the old local computation from
+  `opencode.db` (rolling 5-hour session, UTC Monday-start week, monthly
+  cycle anchored to your first-ever Go usage) — the fallback counts
+  this PC only. Dollar spend rows are always computed locally.
 
 ## GitHub Copilot
 

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -96,14 +96,18 @@ async fn fetch() -> Result<Snapshot, String> {
     };
 
     // Account-wide truth first; the local windows only when it fails
-    // (offline, revoked key, or a gateway hiccup).
+    // (offline, revoked key, or a gateway hiccup). The fallback names its
+    // narrower scope in the plan label — the card must never silently
+    // flip between account-wide and this-PC-only numbers looking the same.
     match fetch_official(&key).await {
-        Ok(metrics) => return Ok(Snapshot::ok(ID, NAME, Some("Go".into()), metrics)),
+        Ok(metrics) => Ok(Snapshot::ok(ID, NAME, Some("Go".into()), metrics)),
         Err(e) => {
             eprintln!("[pane] opencode: usage API failed ({e}) — using local windows");
+            let mut snap = local_windows_snapshot()?;
+            snap.plan = Some("Go — this PC only".into());
+            Ok(snap)
         }
     }
-    local_windows_snapshot()
 }
 
 /// GET /zen/go/v1/usage with the Go key. The response is served by
@@ -132,9 +136,13 @@ fn parse_official(doc: &Value) -> Option<Vec<Metric>> {
     let usage = doc.get("usage")?;
     let mut metrics = Vec::new();
     for (field, label, period_ms) in [
-        ("rolling", "Session", SESSION_MS as i64),
-        ("weekly", "Weekly", WEEK_MS as i64),
-        ("monthly", "Monthly", 30 * 86_400_000_i64),
+        ("rolling", "Session", Some(SESSION_MS as i64)),
+        ("weekly", "Weekly", Some(WEEK_MS as i64)),
+        // Monthly cycles run 28-31 days anchored to the subscription
+        // date — a fixed period would skew the pace projection (and go
+        // NEGATIVE-fraction right after a 31-day cycle starts), so the
+        // real length is derived from the server's own reset boundary.
+        ("monthly", "Monthly", None),
     ] {
         let Some(w) = usage.get(field) else { continue };
         let Some(percent) = w.get("percent").and_then(Value::as_f64) else { continue };
@@ -146,9 +154,32 @@ fn parse_official(doc: &Value) -> Option<Vec<Metric>> {
             .and_then(Value::as_str)
             .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
             .map(|d| d.timestamp_millis());
-        metrics.push(Metric::progress(label, used, None).with_reset(resets_at, Some(period_ms)));
+        let period_ms = period_ms.or_else(|| resets_at.map(month_period_ending));
+        metrics.push(Metric::progress(label, used, None).with_reset(resets_at, period_ms));
     }
     (!metrics.is_empty()).then_some(metrics)
+}
+
+/// Length of the anchored monthly cycle that ENDS at the server's
+/// resetsAt: one month back on the same day-of-month (clamped to short
+/// months) at the same time-of-day — the true 28-31-day window.
+fn month_period_ending(resets_ms: i64) -> i64 {
+    use chrono::{Datelike, TimeZone, Timelike, Utc};
+    let Some(end) = Utc.timestamp_millis_opt(resets_ms).single() else {
+        return 30 * 86_400_000;
+    };
+    let (py, pm) = shift_month(end.year(), end.month(), -1);
+    let day = end.day().min(days_in_month(py, pm));
+    let start = utc_date(
+        py,
+        pm,
+        day,
+        end.hour(),
+        end.minute(),
+        end.second(),
+        end.timestamp_subsec_millis(),
+    );
+    ((resets_ms as f64 - start) as i64).max(1)
 }
 
 /// Fallback: the pre-API local computation from opencode.db — this PC's
@@ -405,6 +436,16 @@ mod tests {
         assert_eq!((m[1].label.as_str(), m[1].used_percent), ("Weekly", Some(6.0)));
         assert_eq!(m[1].resets_at, Some(ms("2026-08-17T00:00:00.302Z") as i64));
         assert_eq!((m[2].label.as_str(), m[2].used_percent), ("Monthly", Some(3.0)));
+        // Monthly period is the REAL cycle length ending at the server's
+        // reset (Aug 5 → Sep 5 = 31 days), never a fixed 30 days — a fixed
+        // window skewed the pace projection (Devin's find).
+        assert_eq!(m[2].period_ms, Some(31 * 86_400_000_i64));
+        // Clamped short-month edge: a reset on Mar 31 looks back to
+        // Feb 28 in a non-leap year.
+        let mar31 = chrono::DateTime::parse_from_rfc3339("2026-03-31T10:00:00Z")
+            .unwrap()
+            .timestamp_millis();
+        assert_eq!(month_period_ending(mar31), 31 * 86_400_000_i64);
 
         // Rate-limited windows render as full; a missing window is skipped
         // without sinking the card; junk yields None (→ local fallback).

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -160,17 +160,27 @@ fn parse_official(doc: &Value) -> Option<Vec<Metric>> {
         ("monthly", "Monthly", None),
     ] {
         let Some(w) = usage.get(field) else { continue };
-        let Some(percent) = w.get("percent").and_then(Value::as_f64) else { continue };
-        // Guard the empirically-captured contract: the server sends
-        // integer 0-100 USED percentages (it floors server-side; the
-        // shape already changed once between the upstream PR and deploy).
-        // A fractional 0-1 encoding or an out-of-range value means the
-        // shape changed again — fail the whole parse (→ labeled local
-        // fallback) instead of rendering silently wrong meters.
-        if !(0.0..=100.0).contains(&percent) || (percent > 0.0 && percent < 1.0) {
-            return None;
-        }
-        let used = percent;
+        // "rate-limited" IS the answer (100%), independent of the percent
+        // field — a blocked window must never vanish from the card just
+        // because the server omitted or lagged its percent.
+        let rate_limited = w.get("status").and_then(Value::as_str) == Some("rate-limited");
+        let percent = w.get("percent").and_then(Value::as_f64);
+        let used = if rate_limited {
+            100.0
+        } else {
+            let Some(percent) = percent else { continue };
+            // Guard the empirically-captured contract: the server sends
+            // integer 0-100 USED percentages (it floors server-side; the
+            // shape already changed once between the upstream PR and
+            // deploy). A fractional 0-1 encoding or an out-of-range value
+            // means the shape changed again — fail the whole parse (→
+            // labeled local fallback) instead of rendering silently wrong
+            // meters.
+            if !(0.0..=100.0).contains(&percent) || (percent > 0.0 && percent < 1.0) {
+                return None;
+            }
+            percent
+        };
         let resets_at = w
             .get("resetsAt")
             .and_then(Value::as_str)
@@ -476,6 +486,13 @@ mod tests {
         }});
         let m = parse_official(&limited).expect("parses");
         assert_eq!(m.len(), 1);
+        assert_eq!(m[0].used_percent, Some(100.0));
+        // rate-limited stays a full meter even if the server omits (or
+        // lags) the percent — the status alone is the answer.
+        let no_percent = serde_json::json!({ "usage": {
+            "rolling": { "status": "rate-limited", "resetsAt": "2026-08-13T15:33:33Z" },
+        }});
+        let m = parse_official(&no_percent).expect("parses");
         assert_eq!(m[0].used_percent, Some(100.0));
         assert!(parse_official(&serde_json::json!({"error": "nope"})).is_none());
 

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -99,11 +99,26 @@ async fn fetch() -> Result<Snapshot, String> {
     // (offline, revoked key, or a gateway hiccup). The fallback names its
     // narrower scope in the plan label — the card must never silently
     // flip between account-wide and this-PC-only numbers looking the same.
+    static FALLBACK_ACTIVE: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
     match fetch_official(&key).await {
-        Ok(metrics) => Ok(Snapshot::ok(ID, NAME, Some("Go".into()), metrics)),
+        Ok(metrics) => {
+            FALLBACK_ACTIVE.store(false, std::sync::atomic::Ordering::Relaxed);
+            Ok(Snapshot::ok(ID, NAME, Some("Go".into()), metrics))
+        }
         Err(e) => {
-            eprintln!("[pane] opencode: usage API failed ({e}) — using local windows");
-            let mut snap = local_windows_snapshot()?;
+            // Log the TRANSITION into fallback, not every refresh — an
+            // offline machine would otherwise print this once a minute
+            // for the app's lifetime.
+            if !FALLBACK_ACTIVE.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                eprintln!("[pane] opencode: usage API failed ({e}) — using local windows");
+            }
+            // If the fallback ALSO fails (fresh device with no local
+            // history), the card must carry both causes — surfacing only
+            // "opencode.db not found" would send someone troubleshooting
+            // an offline/revoked-key card after the wrong problem.
+            let mut snap = local_windows_snapshot()
+                .map_err(|db| format!("usage API failed ({e}); local fallback: {db}"))?;
             snap.plan = Some("Go — this PC only".into());
             Ok(snap)
         }
@@ -146,9 +161,16 @@ fn parse_official(doc: &Value) -> Option<Vec<Metric>> {
     ] {
         let Some(w) = usage.get(field) else { continue };
         let Some(percent) = w.get("percent").and_then(Value::as_f64) else { continue };
-        // "rate-limited" arrives with percent already at 100; clamp guards
-        // both directions anyway.
-        let used = percent.clamp(0.0, 100.0);
+        // Guard the empirically-captured contract: the server sends
+        // integer 0-100 USED percentages (it floors server-side; the
+        // shape already changed once between the upstream PR and deploy).
+        // A fractional 0-1 encoding or an out-of-range value means the
+        // shape changed again — fail the whole parse (→ labeled local
+        // fallback) instead of rendering silently wrong meters.
+        if !(0.0..=100.0).contains(&percent) || (percent > 0.0 && percent < 1.0) {
+            return None;
+        }
+        let used = percent;
         let resets_at = w
             .get("resetsAt")
             .and_then(Value::as_str)
@@ -456,6 +478,17 @@ mod tests {
         assert_eq!(m.len(), 1);
         assert_eq!(m[0].used_percent, Some(100.0));
         assert!(parse_official(&serde_json::json!({"error": "nope"})).is_none());
+
+        // Contract guards: a fractional (0-1) or out-of-range percent
+        // means the wire shape changed — the parse must fail loudly (→
+        // labeled local fallback), never render wrong meters. Zero and
+        // exact integers stay valid.
+        for bad in [0.06, 150.0, -3.0] {
+            let doc = serde_json::json!({ "usage": {
+                "weekly": { "status": "ok", "percent": bad, "resetsAt": "2026-08-17T00:00:00Z" },
+            }});
+            assert!(parse_official(&doc).is_none(), "percent {bad} must reject");
+        }
     }
 
     #[test]

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -6,10 +6,16 @@ use std::sync::atomic::{AtomicU64, Ordering};
 const ID: &str = "opencode";
 const NAME: &str = "OpenCode";
 
-// OpenCode Go plan limits from https://opencode.ai/docs/go/ (dollars).
-// There is no public usage API yet (anomalyco/opencode#10448), so we compute
-// spend locally from opencode's own message database — the same data
-// `opencode stats` uses. Swap to the official API once it ships.
+// Primary source: the official account-wide usage API that shipped in
+// anomalyco/opencode#16513 (2026-08-11) — GET /zen/go/v1/usage with the Go
+// key returns per-window percentages and resets counted on OpenCode's
+// servers, so other devices and shared-subscription participants finally
+// show up. The local computation below survives as the FALLBACK when the
+// API is unreachable, and its plan limits still label the local path.
+const USAGE_URL: &str = "https://opencode.ai/zen/go/v1/usage";
+
+// OpenCode Go plan limits from https://opencode.ai/docs/go/ (dollars) —
+// fallback path only.
 const SESSION_LIMIT: f64 = 12.0; // rolling 5 hours
 const WEEKLY_LIMIT: f64 = 30.0; // UTC ISO week (Monday start)
 const MONTHLY_LIMIT: f64 = 60.0; // month anchored to earliest-ever Go usage
@@ -66,13 +72,13 @@ fn with_db_copy<T>(f: impl FnOnce(&Path) -> Result<T, String>) -> Result<T, Stri
 }
 
 pub async fn snapshot() -> Snapshot {
-    match fetch() {
+    match fetch().await {
         Ok(s) => s,
         Err(e) => Snapshot::error(ID, NAME, e),
     }
 }
 
-fn fetch() -> Result<Snapshot, String> {
+async fn fetch() -> Result<Snapshot, String> {
     let auth_path = data_dir().join("auth.json");
     if !auth_path.exists() {
         return Ok(Snapshot::no_credentials(
@@ -81,14 +87,73 @@ fn fetch() -> Result<Snapshot, String> {
             "OpenCode sign-in not found. Run `opencode` and log in.",
         ));
     }
-    if auth_entry_key("opencode-go").is_none() {
+    let Some(key) = auth_entry_key("opencode-go") else {
         return Ok(Snapshot::no_credentials(
             ID,
             NAME,
             "No OpenCode Go subscription found in auth.json.",
         ));
-    }
+    };
 
+    // Account-wide truth first; the local windows only when it fails
+    // (offline, revoked key, or a gateway hiccup).
+    match fetch_official(&key).await {
+        Ok(metrics) => return Ok(Snapshot::ok(ID, NAME, Some("Go".into()), metrics)),
+        Err(e) => {
+            eprintln!("[pane] opencode: usage API failed ({e}) — using local windows");
+        }
+    }
+    local_windows_snapshot()
+}
+
+/// GET /zen/go/v1/usage with the Go key. The response is served by
+/// OpenCode's console — the same numbers the Zen dashboard shows.
+async fn fetch_official(key: &str) -> Result<Vec<Metric>, String> {
+    let resp = super::http()
+        .get(USAGE_URL)
+        .bearer_auth(key)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(|e| format!("usage request: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("usage endpoint: HTTP {}", resp.status()));
+    }
+    let doc: Value = resp.json().await.map_err(|e| format!("usage parse: {e}"))?;
+    parse_official(&doc).ok_or_else(|| "no recognizable usage windows in response".into())
+}
+
+/// Live wire shape (verified against the deployed endpoint, which differs
+/// from the merged PR's draft): { "usage": { "rolling"|"weekly"|"monthly":
+/// { "status": "ok"|"rate-limited", "percent": int, "resetsAt": RFC3339 } } }.
+/// Percentages and resets are the server's own; a window the response
+/// doesn't carry is simply skipped rather than failing the card.
+fn parse_official(doc: &Value) -> Option<Vec<Metric>> {
+    let usage = doc.get("usage")?;
+    let mut metrics = Vec::new();
+    for (field, label, period_ms) in [
+        ("rolling", "Session", SESSION_MS as i64),
+        ("weekly", "Weekly", WEEK_MS as i64),
+        ("monthly", "Monthly", 30 * 86_400_000_i64),
+    ] {
+        let Some(w) = usage.get(field) else { continue };
+        let Some(percent) = w.get("percent").and_then(Value::as_f64) else { continue };
+        // "rate-limited" arrives with percent already at 100; clamp guards
+        // both directions anyway.
+        let used = percent.clamp(0.0, 100.0);
+        let resets_at = w
+            .get("resetsAt")
+            .and_then(Value::as_str)
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|d| d.timestamp_millis());
+        metrics.push(Metric::progress(label, used, None).with_reset(resets_at, Some(period_ms)));
+    }
+    (!metrics.is_empty()).then_some(metrics)
+}
+
+/// Fallback: the pre-API local computation from opencode.db — this PC's
+/// rows only, so shared subscriptions under-count here.
+fn local_windows_snapshot() -> Result<Snapshot, String> {
     let w = with_db_copy(|db| {
         let rows: Vec<(f64, f64)> = read_messages(db)?
             .into_iter()
@@ -323,6 +388,33 @@ mod tests {
 
     fn ms(iso: &str) -> f64 {
         chrono::DateTime::parse_from_rfc3339(iso).unwrap().timestamp_millis() as f64
+    }
+
+    #[test]
+    fn official_usage_parses_the_live_wire_shape() {
+        // Captured verbatim from the deployed endpoint (2026-08-13) — note
+        // it does NOT match the merged PR's draft shape.
+        let doc = serde_json::json!({ "usage": {
+            "rolling": { "status": "ok", "percent": 0, "resetsAt": "2026-08-13T15:33:33.302Z" },
+            "weekly":  { "status": "ok", "percent": 6, "resetsAt": "2026-08-17T00:00:00.302Z" },
+            "monthly": { "status": "ok", "percent": 3, "resetsAt": "2026-09-05T08:48:51.302Z" },
+        }});
+        let m = parse_official(&doc).expect("parses");
+        assert_eq!(m.len(), 3);
+        assert_eq!((m[0].label.as_str(), m[0].used_percent), ("Session", Some(0.0)));
+        assert_eq!((m[1].label.as_str(), m[1].used_percent), ("Weekly", Some(6.0)));
+        assert_eq!(m[1].resets_at, Some(ms("2026-08-17T00:00:00.302Z") as i64));
+        assert_eq!((m[2].label.as_str(), m[2].used_percent), ("Monthly", Some(3.0)));
+
+        // Rate-limited windows render as full; a missing window is skipped
+        // without sinking the card; junk yields None (→ local fallback).
+        let limited = serde_json::json!({ "usage": {
+            "rolling": { "status": "rate-limited", "percent": 100, "resetsAt": "2026-08-13T15:33:33Z" },
+        }});
+        let m = parse_official(&limited).expect("parses");
+        assert_eq!(m.len(), 1);
+        assert_eq!(m[0].used_percent, Some(100.0));
+        assert!(parse_official(&serde_json::json!({"error": "nope"})).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

OpenCode finally shipped a public usage API — [anomalyco/opencode#16513](https://github.com/anomalyco/opencode/pull/16513), merged 2026-08-11 — the endpoint this codebase has been waiting on since July (the old comment literally said "swap to the official API once it ships"). This swaps to it.

- `GET https://opencode.ai/zen/go/v1/usage`, Bearer-authenticated with the Go key Pane already reads from `auth.json` (no new credential surface).
- The card's Session / Weekly / Monthly meters now show **account-wide** percentages and resets counted on OpenCode's servers — the same numbers as the Zen dashboard, so usage from other devices and shared-subscription participants is finally included (the long-standing "this PC only" caveat).
- **Wire shape verified live**: the deployed response (`usage.{rolling,weekly,monthly}.{status,percent,resetsAt}`) differs from the merged PR's draft code — parsing targets the deployed shape, pinned in a unit test with a verbatim capture.
- `rate-limited` windows render at 100%; a missing window is skipped rather than failing the card; unparseable responses fall through.
- The pre-API local computation from `opencode.db` survives as the fallback when the API is unreachable (offline, revoked key), clearly labeled this-PC-only. Dollar spend rows are unchanged — always local.
- README and docs/providers.md updated: the "no public usage API yet (#10448)" story is gone. (#10448 itself — a *balance* endpoint — is still open; percentages are what the meters need.)

## Testing

New unit test pins the live wire shape (verbatim capture from the deployed endpoint queried with a real Go key: rolling 0% / weekly 6% / monthly 3%), the rate-limited case, and the junk-response fallback. Full suite 59/59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->