### PR TITLE
Docs: align privacy network-call list and roadmap with 0.4.34

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,8 +85,10 @@ wave ends with a shipped, installed build.
 - [x] GitHub release, auto-updater, winget submission (in review).
 
 All waves shipped 2026-07-07 as v0.2.0; public launch followed as v0.4.0.
-Remaining backlog: OpenCode official balance API when it ships,
-long-context pricing tiers.
+Remaining backlog: OpenCode official *balance* API when it ships
+(anomalyco/opencode#10448 — the account-wide *usage* API landed in Pane
+0.4.34; balance would add dollar amounts to the account-wide view).
+Long-context pricing tiers shipped in 0.4.9.
 
 ## Deliberately not ported
 - PostHog SDK telemetry — reconsidered 2026-07-27: Pane ships its own

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -11,7 +11,7 @@ This is the complete list. Anything not listed here does not happen.
 
 | Destination | When | What is sent |
 |---|---|---|
-| Each provider's own API (Anthropic, OpenAI/ChatGPT, cursor.com, GitHub, x.ai, Devin, MiniMax, OpenRouter, Z.ai, Google, DeepSeek, Moonshot, ElevenLabs, Codebuff, Kilo, AihubMix, Alibaba Model Studio…) | Every refresh (default 1 min), only for providers you have enabled | That provider's own token/key, exactly as its official tool would send it. Full per-provider detail: [providers.md](providers.md) |
+| Each provider's own API (Anthropic, OpenAI/ChatGPT, cursor.com, GitHub, x.ai, opencode.ai, Devin, MiniMax, OpenRouter, Z.ai, Google, DeepSeek, Moonshot, ElevenLabs, Codebuff, Kilo, AihubMix, Alibaba Model Studio…) | Every refresh (default 1 min), only for providers you have enabled | That provider's own token/key, exactly as its official tool would send it. Full per-provider detail: [providers.md](providers.md) |
 | `raw.githubusercontent.com` (LiteLLM), `models.dev`, `robinebers.github.io` | ~Daily | Anonymous GET for public model price tables (no identifying data) |
 | `pane.jazii.dev/api/update` (falls back to `github.com/ItsJazii/pane/releases`) | On launch + every 4 h | Anonymous GET for the update manifest, carrying the app version. See "The update check" below for exactly what this counts. |
 | `us.i.posthog.com` | Once per day (unless switched off) | The two anonymous daily-statistic events described in "Anonymous usage statistics" below — a random ID, version, enabled-provider list, and per-provider success/failure counts. Never usage amounts, spend, keys, or error text. |


### PR DESCRIPTION
Docs-only follow-up to the 0.4.34 release:

- **docs/privacy.md** — `opencode.ai` joins the "every network call Pane can make" provider list; until the official usage API shipped, the OpenCode provider made no network calls, so it was correctly absent before and misleadingly absent now.
- **ROADMAP.md** — the backlog line now distinguishes the shipped account-wide *usage* API (in 0.4.34) from the still-open *balance* endpoint (anomalyco/opencode#10448), and dates the long-context pricing tiers to 0.4.9 (verified against the changelog).

README and docs/providers.md were already updated inside #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->