### PR TITLE
Port OpenUsage 0.7.8/0.7.9 pricing aliases and settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - **Hide tray numbers while screen sharing** — optional Privacy setting
   (off by default). During Presentation Settings, exclusive fullscreen,
   or remote control, the main tray percentage and starred strip numbers
-  hide; the Pane icon stays.
+  hide; the Pane icon and starred provider logos stay.
 - **Reset all settings** — Settings → Advanced restores every preference
   to its default and re-detects installed tools. API keys and usage
   history stay.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
   respected either way.
 - **Hide tray numbers while screen sharing** — optional Privacy setting
   (off by default). During Presentation Settings, exclusive fullscreen,
-  or remote control, starred tray percentages hide; the Pane icon stays.
+  or remote control, the main tray percentage and starred strip numbers
+  hide; the Pane icon stays.
 - **Reset all settings** — Settings → Advanced restores every preference
   to its default and re-detects installed tools. API keys and usage
   history stay.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Daybreak Blue and Cursor Router spend names price correctly** — Pane
+  now loads the full OpenUsage pricing-alias list (it used to keep only
+  the first 64 rules, which dropped Daybreak, GPT-5.3–5.6 effort slugs,
+  and Cursor Router labels like "Opus 5 (Auto Balanced)").
+- **Codex auto-review stays its own row** — reviewer traffic still shows
+  as `codex-auto-review` in the model breakdown; the dollars use that
+  day's GPT rate (gpt-5.5 from April 2026 onward), matching the Mac app.
+- **Reduce animations** — Settings toggle skips card entrance motion and
+  the day/night wipe. Windows' own Animation effects setting is still
+  respected either way.
+- **Hide tray numbers while screen sharing** — optional Privacy setting
+  (off by default). During Presentation Settings, exclusive fullscreen,
+  or remote control, starred tray percentages hide; the Pane icon stays.
+- **Reset all settings** — Settings → Advanced restores every preference
+  to its default and re-detects installed tools. API keys and usage
+  history stay.
+
 ## 0.4.34 — 2026-08-13
 
 ### Added

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -65,9 +65,13 @@ Ground rules that apply to every provider:
   tier (recorded per session in the rollout itself, never inferred from
   `config.toml`) price at each model's Codex priority multiplier, and
   supported GPT-5.4/5.5/5.6 requests above 272k prompt tokens use
-  OpenAI's long-context rates for the whole request. Pi coding agent
-  sessions that drove this Codex account (provider `openai-codex`) fold
-  into this card's spend the same way they do for Claude.
+  OpenAI's long-context rates for the whole request. Auto-review usage
+  keeps the name `codex-auto-review` in the model breakdown; dollars use
+  the dated GPT fallback for that day (gpt-5.5 from April 2026 onward).
+  Daybreak Blue (`gpt-daybreak-blue-latest`) prices as GPT-5.6 Sol.
+  Pi coding agent sessions that drove this Codex account (provider
+  `openai-codex`) fold into this card's spend the same way they do for
+  Claude.
 
 ## Cursor
 

--- a/index.html
+++ b/index.html
@@ -150,6 +150,9 @@
             <label class="toggle" title="Turn off on slower PCs — replaces the glass refraction with a simple solid look"><input id="glass" type="checkbox" /> Liquid glass effects</label>
           </div>
           <div class="setting-row">
+            <label class="toggle" title="Skip card entrance motion and the day/night wipe. Windows' own 'Animation effects' setting is still respected."><input id="reduce-anim" type="checkbox" /> Reduce animations</label>
+          </div>
+          <div class="setting-row">
             <label class="toggle"><input id="show-total-spend" type="checkbox" /> Show Total Spend card</label>
           </div>
           <div class="setting-row">
@@ -188,6 +191,9 @@
           </p>
           <div class="setting-row">
             <label class="toggle"><input id="telemetry" type="checkbox" /> Share anonymous usage statistics</label>
+          </div>
+          <div class="setting-row">
+            <label class="toggle" title="While a meeting share, Presentation Settings, or remote control is on, starred tray percentages hide. The Pane icon stays. Off by default."><input id="hide-while-sharing" type="checkbox" /> Hide tray numbers while screen sharing</label>
           </div>
         </div></div>
       </div>
@@ -265,6 +271,20 @@
             <input id="key-qwen" type="password" placeholder="sk-sp-… (auto-detected from env)" />
             <button data-save="qwen">Save</button>
           </div>
+        </div></div>
+      </div>
+
+      <div class="acc-group">
+        <button class="acc-head">Advanced <span class="chev">&#8964;</span></button>
+        <div class="acc-body"><div class="acc-inner">
+          <p class="settings-note">
+            Restores every preference to its default and re-detects installed
+            tools. API keys and your usage history stay. Proxy changes still
+            need a restart.
+          </p>
+          <button id="reset-all-settings" type="button" class="danger-btn">
+            Reset all settings
+          </button>
         </div></div>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
             <label class="toggle"><input id="telemetry" type="checkbox" /> Share anonymous usage statistics</label>
           </div>
           <div class="setting-row">
-            <label class="toggle" title="While a meeting share, Presentation Settings, or remote control is on, the main tray percentage and starred strip numbers hide. The Pane icon stays. Off by default."><input id="hide-while-sharing" type="checkbox" /> Hide tray numbers while screen sharing</label>
+            <label class="toggle" title="During Presentation Settings, exclusive fullscreen, or remote control, tray percentages hide. The Pane icon and starred provider logos stay. A Teams/Zoom window share is not detected. Off by default."><input id="hide-while-sharing" type="checkbox" /> Hide tray numbers while screen sharing</label>
           </div>
         </div></div>
       </div>

--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
             <label class="toggle"><input id="telemetry" type="checkbox" /> Share anonymous usage statistics</label>
           </div>
           <div class="setting-row">
-            <label class="toggle" title="While a meeting share, Presentation Settings, or remote control is on, starred tray percentages hide. The Pane icon stays. Off by default."><input id="hide-while-sharing" type="checkbox" /> Hide tray numbers while screen sharing</label>
+            <label class="toggle" title="While a meeting share, Presentation Settings, or remote control is on, the main tray percentage and starred strip numbers hide. The Pane icon stays. Off by default."><input id="hide-while-sharing" type="checkbox" /> Hide tray numbers while screen sharing</label>
           </div>
         </div></div>
       </div>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,5 +40,5 @@ toml = "0.8"
 regex = "1"
 webview2-com = "0.38"
 windows-core = "0.61"
-windows = { version = "0.61", features = ["Win32_Foundation", "Win32_Security_Credentials"] }
+windows = { version = "0.61", features = ["Win32_Foundation", "Win32_Security_Credentials", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -483,16 +483,16 @@ fn spawn_share_watcher(app: tauri::AppHandle) {
                 continue;
             }
             was_hidden = hide;
+            let cached = last_strip()
+                .lock()
+                .map(|g| g.clone())
+                .unwrap_or_default();
             if hide {
-                let _ = update_tray_strip(app.clone(), Vec::new());
+                let _ = apply_tray_strip(app.clone(), cached, true);
                 let handle = app.clone();
                 let _ = app.run_on_main_thread(move || set_main_tray_logo(&handle));
             } else {
-                let cached = last_strip()
-                    .lock()
-                    .map(|g| g.clone())
-                    .unwrap_or_default();
-                let _ = update_tray_strip(app.clone(), cached);
+                let _ = apply_tray_strip(app.clone(), cached, false);
                 let handle = app.clone();
                 let _ = app.run_on_main_thread(move || paint_cached_main_tray(&handle));
                 let _ = app.emit("tray-strip-restore", ());
@@ -537,16 +537,17 @@ const STRIP_PROVIDER_IDS: [&str; 19] = [
 
 #[tauri::command]
 fn update_tray_strip(app: tauri::AppHandle, entries: Vec<StripEntry>) -> Result<(), String> {
-    if !HIDE_STRIP.load(Ordering::Relaxed) {
-        if let Ok(mut slot) = last_strip().lock() {
-            *slot = entries.clone();
-        }
+    if let Ok(mut slot) = last_strip().lock() {
+        *slot = entries.clone();
     }
-    let entries = if HIDE_STRIP.load(Ordering::Relaxed) {
-        Vec::new()
-    } else {
-        entries
-    };
+    apply_tray_strip(app, entries, HIDE_STRIP.load(Ordering::Relaxed))
+}
+
+fn apply_tray_strip(
+    app: tauri::AppHandle,
+    entries: Vec<StripEntry>,
+    hide_numbers: bool,
+) -> Result<(), String> {
     let handle = app.clone();
     app.run_on_main_thread(move || {
         // Remove strip icons for providers no longer selected.
@@ -568,14 +569,31 @@ fn update_tray_strip(app: tauri::AppHandle, entries: Vec<StripEntry>) -> Result<
             let logo_id = format!("strip-logo-{}", entry.id);
             let num_id = format!("strip-num-{}", entry.id);
             let logo_icon = tauri::image::Image::new_owned(entry.logo.clone(), 32, 32);
-            let num_icon =
-                tauri::image::Image::new_owned(draw_tray_numbers(&entry.values), 32, 32);
+            let num_icon = tauri::image::Image::new_owned(
+                if hide_numbers {
+                    vec![0u8; 32 * 32 * 4]
+                } else {
+                    draw_tray_numbers(&entry.values)
+                },
+                32,
+                32,
+            );
+            let tooltip = if hide_numbers {
+                entry
+                    .tooltip
+                    .split('\n')
+                    .next()
+                    .unwrap_or("Pane")
+                    .to_string()
+            } else {
+                entry.tooltip.clone()
+            };
 
             if let Some(tray) = handle.tray_by_id(&num_id) {
                 let _ = tray.set_icon(Some(num_icon));
-                let _ = tray.set_tooltip(Some(&entry.tooltip));
+                let _ = tray.set_tooltip(Some(&tooltip));
                 if let Some(logo_tray) = handle.tray_by_id(&logo_id) {
-                    let _ = logo_tray.set_tooltip(Some(&entry.tooltip));
+                    let _ = logo_tray.set_tooltip(Some(&tooltip));
                 }
                 continue;
             }
@@ -586,7 +604,7 @@ fn update_tray_strip(app: tauri::AppHandle, entries: Vec<StripEntry>) -> Result<
             for (tray_id, icon) in [(num_id, num_icon), (logo_id, logo_icon)] {
                 let _ = TrayIconBuilder::with_id(tray_id)
                     .icon(icon)
-                    .tooltip(&entry.tooltip)
+                    .tooltip(&tooltip)
                     .show_menu_on_left_click(false)
                     .on_tray_icon_event(|tray, event| {
                         if let TrayIconEvent::Click {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod telemetry;
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::{json, Value};
@@ -169,6 +170,7 @@ fn set_config(patch: Value) -> Result<Value, String> {
     std::fs::write(&tmp, serde_json::to_string_pretty(&cfg).unwrap_or_default())
         .map_err(|e| format!("write config: {e}"))?;
     std::fs::rename(&tmp, &path).map_err(|e| format!("replace config: {e}"))?;
+    HIDE_WANT.store(hide_usage_flag(&cfg), Ordering::Relaxed);
     Ok(cfg)
 }
 
@@ -321,10 +323,6 @@ fn pick_tray_metrics<'a>(
 }
 
 fn update_tray(app: &tauri::AppHandle, snapshots: &[providers::Snapshot], cfg: &Value) {
-    let Some(tray) = app.tray_by_id("tray") else {
-        return;
-    };
-
     let mut tooltip = String::from("Pane");
     for s in snapshots.iter().filter(|s| s.status == "ok").take(6) {
         if let Some(m) = s.metrics.iter().find(|m| m.kind == "progress") {
@@ -332,7 +330,6 @@ fn update_tray(app: &tauri::AppHandle, snapshots: &[providers::Snapshot], cfg: &
             tooltip.push_str(&format!("\n{} {}: {left:.0}% left", s.name, m.label));
         }
     }
-    let _ = tray.set_tooltip(Some(&tooltip));
 
     // When the Mac-style tray strip is active it carries the numbers, so the
     // main icon stays the app logo (the strip icons are per-provider).
@@ -340,19 +337,35 @@ fn update_tray(app: &tauri::AppHandle, snapshots: &[providers::Snapshot], cfg: &
         .get("trayProviders")
         .and_then(Value::as_array)
         .is_some_and(|a| !a.is_empty());
+    let lefts: Vec<u32> = if strip_active {
+        Vec::new()
+    } else {
+        pick_tray_metrics(snapshots, cfg.get("pinned").unwrap_or(&Value::Null))
+            .iter()
+            .map(|m| (100.0 - m.used_percent.unwrap_or(0.0)).clamp(0.0, 100.0).round() as u32)
+            .collect()
+    };
+    if let Ok(mut slot) = last_main_tray().lock() {
+        slot.lefts = lefts.clone();
+        slot.tooltip = tooltip.clone();
+    }
+
+    if HIDE_STRIP.load(Ordering::Relaxed) {
+        set_main_tray_logo(app);
+        return;
+    }
+
+    let Some(tray) = app.tray_by_id("tray") else {
+        return;
+    };
+    let _ = tray.set_tooltip(Some(&tooltip));
     if strip_active {
         if let Some(default) = app.default_window_icon() {
             let _ = tray.set_icon(Some(default.clone()));
         }
         return;
     }
-
-    let metrics = pick_tray_metrics(snapshots, cfg.get("pinned").unwrap_or(&Value::Null));
-    if !metrics.is_empty() {
-        let lefts: Vec<u32> = metrics
-            .iter()
-            .map(|m| (100.0 - m.used_percent.unwrap_or(0.0)).clamp(0.0, 100.0).round() as u32)
-            .collect();
+    if !lefts.is_empty() {
         let icon = tauri::image::Image::new_owned(draw_tray_numbers(&lefts), 32, 32);
         let _ = tray.set_icon(Some(icon));
     }
@@ -366,7 +379,65 @@ fn update_tray(app: &tauri::AppHandle, snapshots: &[providers::Snapshot], cfg: &
 
 /// Hide starred tray numbers while a screen share / presentation is on
 /// (Settings → Privacy, off by default — Mac parity with OpenUsage #1013).
+static HIDE_WANT: AtomicBool = AtomicBool::new(false);
 static HIDE_STRIP: AtomicBool = AtomicBool::new(false);
+
+struct LastMainTray {
+    lefts: Vec<u32>,
+    tooltip: String,
+}
+
+fn last_main_tray() -> &'static Mutex<LastMainTray> {
+    static S: OnceLock<Mutex<LastMainTray>> = OnceLock::new();
+    S.get_or_init(|| {
+        Mutex::new(LastMainTray {
+            lefts: Vec::new(),
+            tooltip: String::from("Pane"),
+        })
+    })
+}
+
+fn last_strip() -> &'static Mutex<Vec<StripEntry>> {
+    static S: OnceLock<Mutex<Vec<StripEntry>>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn hide_usage_flag(cfg: &Value) -> bool {
+    cfg.get("hideUsageWhileSharing").and_then(Value::as_bool) == Some(true)
+}
+
+fn set_main_tray_logo(app: &tauri::AppHandle) {
+    let Some(tray) = app.tray_by_id("tray") else {
+        return;
+    };
+    if let Some(default) = app.default_window_icon() {
+        let _ = tray.set_icon(Some(default.clone()));
+    }
+    let _ = tray.set_tooltip(Some("Pane"));
+}
+
+fn paint_cached_main_tray(app: &tauri::AppHandle) {
+    if HIDE_STRIP.load(Ordering::Relaxed) {
+        set_main_tray_logo(app);
+        return;
+    }
+    let cached = last_main_tray()
+        .lock()
+        .map(|g| (g.lefts.clone(), g.tooltip.clone()))
+        .unwrap_or_else(|_| (Vec::new(), String::from("Pane")));
+    let Some(tray) = app.tray_by_id("tray") else {
+        return;
+    };
+    let _ = tray.set_tooltip(Some(&cached.1));
+    if cached.0.is_empty() {
+        if let Some(default) = app.default_window_icon() {
+            let _ = tray.set_icon(Some(default.clone()));
+        }
+        return;
+    }
+    let icon = tauri::image::Image::new_owned(draw_tray_numbers(&cached.0), 32, 32);
+    let _ = tray.set_icon(Some(icon));
+}
 
 fn screen_is_being_shared() -> bool {
     #[cfg(windows)]
@@ -398,15 +469,15 @@ fn screen_is_being_shared() -> bool {
 }
 
 fn spawn_share_watcher(app: tauri::AppHandle) {
+    HIDE_WANT.store(
+        hide_usage_flag(&config_with_defaults(load_config())),
+        Ordering::Relaxed,
+    );
     tauri::async_runtime::spawn(async move {
         let mut was_hidden = false;
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-            let enabled = config_with_defaults(load_config())
-                .get("hideUsageWhileSharing")
-                .and_then(Value::as_bool)
-                == Some(true);
-            let hide = enabled && screen_is_being_shared();
+            let hide = HIDE_WANT.load(Ordering::Relaxed) && screen_is_being_shared();
             HIDE_STRIP.store(hide, Ordering::Relaxed);
             if hide == was_hidden {
                 continue;
@@ -414,14 +485,23 @@ fn spawn_share_watcher(app: tauri::AppHandle) {
             was_hidden = hide;
             if hide {
                 let _ = update_tray_strip(app.clone(), Vec::new());
+                let handle = app.clone();
+                let _ = app.run_on_main_thread(move || set_main_tray_logo(&handle));
             } else {
+                let cached = last_strip()
+                    .lock()
+                    .map(|g| g.clone())
+                    .unwrap_or_default();
+                let _ = update_tray_strip(app.clone(), cached);
+                let handle = app.clone();
+                let _ = app.run_on_main_thread(move || paint_cached_main_tray(&handle));
                 let _ = app.emit("tray-strip-restore", ());
             }
         }
     });
 }
 
-#[derive(serde::Deserialize)]
+#[derive(Clone, serde::Deserialize)]
 struct StripEntry {
     id: String,
     logo: Vec<u8>, // 32x32 RGBA
@@ -457,6 +537,11 @@ const STRIP_PROVIDER_IDS: [&str; 19] = [
 
 #[tauri::command]
 fn update_tray_strip(app: tauri::AppHandle, entries: Vec<StripEntry>) -> Result<(), String> {
+    if !HIDE_STRIP.load(Ordering::Relaxed) {
+        if let Ok(mut slot) = last_strip().lock() {
+            *slot = entries.clone();
+        }
+    }
     let entries = if HIDE_STRIP.load(Ordering::Relaxed) {
         Vec::new()
     } else {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ mod spend;
 mod telemetry;
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::{json, Value};
@@ -100,6 +100,8 @@ fn config_with_defaults(mut cfg: Value) -> Value {
     // own default kept transmitting — a switch that displays off while
     // data flows is the one state a privacy control must never be in.
     obj.entry("telemetry").or_insert(json!(true));
+    obj.entry("reduceAnimations").or_insert(json!(false));
+    obj.entry("hideUsageWhileSharing").or_insert(json!(false));
     cfg
 }
 
@@ -139,6 +141,8 @@ const CONFIG_KEYS: &[&str] = &[
     "welcomeDismissed",
     "lastSeenVersion",
     "telemetry",
+    "reduceAnimations",
+    "hideUsageWhileSharing",
 ];
 
 #[tauri::command]
@@ -360,6 +364,63 @@ fn update_tray(app: &tauri::AppHandle, snapshots: &[providers::Snapshot], cfg: &
 // webview already has the icons) and sends the pixels here.
 // ---------------------------------------------------------------------------
 
+/// Hide starred tray numbers while a screen share / presentation is on
+/// (Settings → Privacy, off by default — Mac parity with OpenUsage #1013).
+static HIDE_STRIP: AtomicBool = AtomicBool::new(false);
+
+fn screen_is_being_shared() -> bool {
+    #[cfg(windows)]
+    {
+        use windows::Win32::UI::Shell::{
+            SHQueryUserNotificationState, QUNS_PRESENTATION_MODE, QUNS_RUNNING_D3D_FULL_SCREEN,
+        };
+        use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_REMOTECONTROL};
+
+        // Someone is remotely controlling this session (Quick Assist, etc.).
+        if unsafe { GetSystemMetrics(SM_REMOTECONTROL) } != 0 {
+            return true;
+        }
+        if let Ok(state) = unsafe { SHQueryUserNotificationState() } {
+            // Presentation Settings / exclusive fullscreen — the closest
+            // public Windows equivalent of macOS's screen-watcher flag.
+            // QUNS_BUSY is skipped: a fullscreen YouTube tab would hide
+            // numbers all evening.
+            if state == QUNS_PRESENTATION_MODE || state == QUNS_RUNNING_D3D_FULL_SCREEN {
+                return true;
+            }
+        }
+        false
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+fn spawn_share_watcher(app: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let mut was_hidden = false;
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+            let enabled = config_with_defaults(load_config())
+                .get("hideUsageWhileSharing")
+                .and_then(Value::as_bool)
+                == Some(true);
+            let hide = enabled && screen_is_being_shared();
+            HIDE_STRIP.store(hide, Ordering::Relaxed);
+            if hide == was_hidden {
+                continue;
+            }
+            was_hidden = hide;
+            if hide {
+                let _ = update_tray_strip(app.clone(), Vec::new());
+            } else {
+                let _ = app.emit("tray-strip-restore", ());
+            }
+        }
+    });
+}
+
 #[derive(serde::Deserialize)]
 struct StripEntry {
     id: String,
@@ -396,6 +457,11 @@ const STRIP_PROVIDER_IDS: [&str; 19] = [
 
 #[tauri::command]
 fn update_tray_strip(app: tauri::AppHandle, entries: Vec<StripEntry>) -> Result<(), String> {
+    let entries = if HIDE_STRIP.load(Ordering::Relaxed) {
+        Vec::new()
+    } else {
+        entries
+    };
     let handle = app.clone();
     app.run_on_main_thread(move || {
         // Remove strip icons for providers no longer selected.
@@ -1237,6 +1303,7 @@ pub fn run() {
         ])
         .setup(|app| {
             spawn_update_checker(app.handle());
+            spawn_share_watcher(app.handle().clone());
             let quit = MenuItem::with_id(app, "quit", "Quit Pane", true, None::<&str>)?;
             let menu = Menu::with_items(app, &[&quit])?;
 

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -166,7 +166,11 @@ pub fn generation() -> u64 {
 /// fingerprinted below — an app update that reprices the same files would
 /// otherwise leave history at the old dollars until upstream happens to
 /// rewrite a catalog.
-const CORRECTIONS_REV: u32 = 5; // 5: deepseek-v4 pro/flash builtin prices
+const CORRECTIONS_REV: u32 = 6; // 6: ingest the live supplement's 100+ alias rules
+/// The live OpenUsage supplement is ~105 alias rules (Daybreak, Cursor
+/// Router prose names, GPT-5.3–5.6 effort slugs). 64 silently dropped
+/// everything after `gpt-5.2`. Per-rule caps below still bound memory.
+const MAX_ALIAS_RULES: usize = 256;
 
 /// Stable fingerprint of the effective pricing inputs: the on-disk catalog
 /// files plus this binary's corrections revision. The persistent spend
@@ -326,12 +330,12 @@ fn apply_supplement(store: &mut Store, doc: &Value) {
     }
 
     // The supplement is fetched from a third-party URL, so cap what it can
-    // feed us: at most 64 alias rules of at most 256 chars each, compiled
+    // feed us: at most MAX_ALIAS_RULES of at most 256 chars each, compiled
     // with a bounded size. (Rust's regex engine is linear-time by design,
     // so ReDoS-style backtracking blowups aren't possible; the caps bound
     // memory and compile cost.)
     if let Some(rules) = doc.get("alias_rules").and_then(Value::as_array) {
-        for rule in rules.iter().take(64) {
+        for rule in rules.iter().take(MAX_ALIAS_RULES) {
             let (Some(pattern), Some(canonical)) = (
                 rule.get("pattern").and_then(Value::as_str),
                 rule.get("canonical").and_then(Value::as_str),
@@ -933,6 +937,27 @@ mod tests {
         let mut p = p;
         p.cache_write_1h = Some(9.0);
         assert!((request_cost(&p, &u, true) - 9.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn supplement_keeps_more_than_64_alias_rules() {
+        // The live feed is past 100 rules; a 64-cap dropped Daybreak and
+        // every Cursor Router "Auto Balanced" prose name.
+        let mut rules = Vec::new();
+        for i in 0..70 {
+            rules.push(serde_json::json!({
+                "pattern": format!("^dummy-{i}$"),
+                "canonical": "auto"
+            }));
+        }
+        rules.push(serde_json::json!({
+            "pattern": "^(?:gpt-)?daybreak-blue-latest$",
+            "canonical": "gpt-5.6-sol"
+        }));
+        let mut store = super::Store::default();
+        super::apply_supplement(&mut store, &serde_json::json!({ "alias_rules": rules }));
+        assert_eq!(store.alias_rules.len(), 71);
+        assert!(store.alias_rules.iter().any(|(_, c)| c == "gpt-5.6-sol"));
     }
 
     /// Live probe: fetches the three catalogs and resolves a few real slugs.

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -97,7 +97,7 @@ fn cache() -> &'static Mutex<HashMap<PathBuf, FileEntry>> {
 // stale-price cache is worse than a slow first scan.
 // ---------------------------------------------------------------------------
 
-const PERSIST_VERSION: u32 = 1;
+const PERSIST_VERSION: u32 = 2;
 
 /// Set when any file was (re)parsed this run — nothing changed, nothing saved.
 static CACHE_DIRTY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
@@ -1045,14 +1045,21 @@ fn codex_line(st: &mut CodexFileState, line: &str, data: &mut FileData) {
     // `-fast` slug resolves through its unscaled base rates and the Codex
     // multiplier applies exactly once. A fast-only third-party slug with no
     // base entry keeps its already-scaled rate, no second multiplier.
-    let (rate_model, alias_fast) = match model.strip_suffix("-fast") {
-        Some(base) if !base.is_empty() => (base.to_string(), true),
-        _ => (model.clone(), false),
+    // Auto-review keeps its own name in the breakdown; only the dollar math
+    // uses the dated GPT fallback (Mac parity with OpenUsage #1085).
+    let rate_source = if model.eq_ignore_ascii_case("codex-auto-review") {
+        auto_review_fallback(ts)
+    } else {
+        model.clone()
     };
-    let lower = model.to_lowercase();
+    let (rate_model, alias_fast) = match rate_source.strip_suffix("-fast") {
+        Some(base) if !base.is_empty() => (base.to_string(), true),
+        _ => (rate_source.clone(), false),
+    };
+    let lower = rate_source.to_lowercase();
     let base_price = pricing::lookup(&rate_model);
     let price = base_price
-        .or_else(|| if alias_fast { pricing::lookup(&model) } else { None })
+        .or_else(|| if alias_fast { pricing::lookup(&rate_source) } else { None })
         .or_else(|| {
             // The static gpt-5 table only for recognizably Codex-family
             // models; anything else is excluded.
@@ -1092,6 +1099,40 @@ fn codex_line(st: &mut CodexFileState, line: &str, data: &mut FileData) {
         cache_write_1h: 0.0,
     };
     add_event(data, ts, &model, pricing::request_cost_at(&p, &u, threshold) * mult, tokens);
+}
+
+/// `codex-auto-review` release timeline (newest first), from ccusage's
+/// embedded snapshot: a line dated on/after a release prices as that model.
+fn auto_review_fallback_date(date: &str) -> &'static str {
+    if date.len() != 10
+        || !date.as_bytes().iter().enumerate().all(|(i, b)| {
+            if i == 4 || i == 7 {
+                *b == b'-'
+            } else {
+                b.is_ascii_digit()
+            }
+        })
+    {
+        return "gpt-5";
+    }
+    const FALLBACKS: &[(&str, &str)] = &[
+        ("2026-04-23", "gpt-5.5"),
+        ("2026-03-05", "gpt-5.4"),
+        ("2026-02-05", "gpt-5.3-codex"),
+        ("2025-12-11", "gpt-5.2-codex"),
+        ("2025-11-13", "gpt-5.1-codex"),
+        ("2025-09-15", "gpt-5-codex"),
+        ("2025-08-07", "gpt-5"),
+    ];
+    FALLBACKS
+        .iter()
+        .find(|(released, _)| date >= *released)
+        .map(|(_, model)| *model)
+        .unwrap_or("gpt-5")
+}
+
+fn auto_review_fallback(ts: DateTime<Utc>) -> String {
+    auto_review_fallback_date(&ts.format("%Y-%m-%d").to_string()).to_string()
 }
 
 /// Codex rollout files log a token_count event per turn; the model rides in
@@ -1830,6 +1871,30 @@ mod tests {
             token_count_line("2026-07-10T10:00:01Z", Some((1_000.0, 100.0)), (1_000.0, 100.0)),
         ];
         assert_eq!(tokens_sum(&codex_run(&lines)), 1_100.0);
+    }
+
+    #[test]
+    fn auto_review_fallback_follows_ccusage_timeline() {
+        assert_eq!(auto_review_fallback_date("2026-08-13"), "gpt-5.5");
+        assert_eq!(auto_review_fallback_date("2026-04-23"), "gpt-5.5");
+        assert_eq!(auto_review_fallback_date("2026-04-22"), "gpt-5.4");
+        assert_eq!(auto_review_fallback_date("2025-08-01"), "gpt-5");
+        assert_eq!(auto_review_fallback_date("nope"), "gpt-5");
+    }
+
+    #[test]
+    fn codex_auto_review_keeps_its_name_in_the_breakdown() {
+        let lines = vec![
+            json!({"timestamp": "2026-08-13T10:00:00Z", "type": "turn_context",
+                   "payload": {"model": "codex-auto-review"}})
+            .to_string(),
+            token_count_line("2026-08-13T10:00:01Z", Some((1_000.0, 100.0)), (1_000.0, 100.0)),
+        ];
+        let data = codex_run(&lines);
+        let models: Vec<&str> = data.days.keys().map(|(_, m)| m.as_str()).collect();
+        assert_eq!(models, vec!["codex-auto-review"]);
+        assert!(cost_sum(&data) > 0.0);
+        assert!(data.unpriced.is_empty());
     }
 
     #[test]

--- a/src/main.ts
+++ b/src/main.ts
@@ -181,6 +181,8 @@ interface Config {
   showTotalSpend: boolean;
   welcomeDismissed: boolean;
   lastSeenVersion: string;
+  reduceAnimations: boolean;
+  hideUsageWhileSharing: boolean;
 }
 
 const ALL_PROVIDERS: [string, string][] = [
@@ -314,6 +316,8 @@ let config: Config = {
   showTotalSpend: true,
   welcomeDismissed: false,
   lastSeenVersion: "",
+  reduceAnimations: false,
+  hideUsageWhileSharing: false,
 };
 let lastFetch = 0;
 let refreshing = false;
@@ -329,6 +333,7 @@ let animateExpandId: string | null = null;
 /// One pass of entrance animations (cards slide in, bars fill) — played when
 /// the popover opens or the first data lands, never on background re-renders.
 function playReveal(): void {
+  if (reduceMotion()) return;
   const el = document.querySelector<HTMLElement>("#providers");
   if (!el) return;
   el.classList.remove("reveal");
@@ -1659,6 +1664,17 @@ function applyGlass(): void {
   if (config.glassEffects !== false && !lensReady) initLiquidLens();
 }
 
+function reduceMotion(): boolean {
+  return (
+    config.reduceAnimations === true ||
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+function applyReduceMotion(): void {
+  document.body.classList.toggle("reduce-anim", config.reduceAnimations === true);
+}
+
 let lensReady = false;
 
 function initLiquidLens(): void {
@@ -1830,7 +1846,7 @@ function toggleTheme(e: Event): void {
   );
 
   const doc = document as Document & { startViewTransition?: (cb: () => void) => { ready: Promise<void> } };
-  if (doc.startViewTransition) {
+  if (!reduceMotion() && doc.startViewTransition) {
     const transition = doc.startViewTransition(apply);
     transition.ready
       .then(() => {
@@ -2674,6 +2690,19 @@ async function initSettings(): Promise<void> {
   });
   applyGlass();
 
+  const reduceAnim = document.querySelector<HTMLInputElement>("#reduce-anim")!;
+  reduceAnim.checked = config.reduceAnimations === true;
+  reduceAnim.addEventListener("change", () => {
+    void patchConfig({ reduceAnimations: reduceAnim.checked }).then(applyReduceMotion);
+  });
+  applyReduceMotion();
+
+  const hideShare = document.querySelector<HTMLInputElement>("#hide-while-sharing")!;
+  hideShare.checked = config.hideUsageWhileSharing === true;
+  hideShare.addEventListener("change", () => {
+    void patchConfig({ hideUsageWhileSharing: hideShare.checked }).then(() => void updateTrayStrip());
+  });
+
   const shortcut = document.querySelector<HTMLInputElement>("#shortcut")!;
   shortcut.value = config.shortcut;
   shortcut.addEventListener("change", async () => {
@@ -2701,6 +2730,100 @@ async function initSettings(): Promise<void> {
   proxyEnabled.addEventListener("change", saveProxy);
   proxyUrl.addEventListener("change", saveProxy);
 
+  populatePinnedOptions();
+
+  document.querySelector("#reset-all-settings")!.addEventListener("click", () => {
+    void resetAllSettings();
+  });
+}
+
+/// Restore every preference to the same defaults a fresh install gets.
+/// API keys, lastSeenVersion, and welcomeDismissed stay (keys are not
+/// "settings"; What's-new shouldn't pop again).
+async function resetAllSettings(): Promise<void> {
+  const ok = await appConfirm({
+    title: "Reset all settings?",
+    message:
+      "Theme, density, notifications, shortcut, proxy, pacing, tray stars, and card layouts go back to defaults. Installed tools are re-detected. API keys and usage history stay. A proxy change still needs a restart.",
+    confirmLabel: "Reset all",
+    danger: true,
+  });
+  if (!ok) return;
+  try {
+    await invoke("set_autostart", { enabled: true });
+  } catch {
+    // Dev builds skip autostart; the preference is still saved below.
+  }
+  try {
+    await invoke("set_shortcut", { shortcut: "" });
+  } catch {
+    // Invalid leftover shortcut shouldn't block the rest of the reset.
+  }
+  await patchConfig({
+    refreshMinutes: 1,
+    disabled: [],
+    pinned: null,
+    trayProviders: [],
+    pacingAlways: true,
+    telemetry: true,
+    notifyAlmostOut: true,
+    notifyCuttingClose: true,
+    notifyWillRunOut: true,
+    spendTab: "today",
+    spendMetric: "cost",
+    showUsed: false,
+    resetExact: false,
+    timeFormat: "auto",
+    layout: null,
+    appearance: "dark",
+    density: "compact",
+    glassEffects: true,
+    shortcut: "",
+    proxy: { enabled: false, url: "" },
+    showTotalSpend: true,
+    reduceAnimations: false,
+    hideUsageWhileSharing: false,
+  });
+  syncSettingsControls();
+  applyAppearance();
+  applyGlass();
+  applyReduceMotion();
+  document.body.classList.remove("settings-open");
+  document.querySelector("#settings-btn")?.classList.remove("active");
+  void refresh(true).then(() => void updateTrayStrip());
+}
+
+function syncSettingsControls(): void {
+  const setNum = (sel: string, v: string) => {
+    const el = document.querySelector<HTMLInputElement>(sel);
+    if (el) el.value = v;
+  };
+  const setCheck = (sel: string, v: boolean) => {
+    const el = document.querySelector<HTMLInputElement>(sel);
+    if (el) el.checked = v;
+  };
+  const setSelect = (sel: string, v: string) => {
+    const el = document.querySelector<HTMLSelectElement>(sel);
+    if (el) el.value = v;
+  };
+  setNum("#interval", String(config.refreshMinutes));
+  setCheck("#pacing", config.pacingAlways);
+  setSelect("#timeformat", config.timeFormat);
+  setCheck("#notify-almost", config.notifyAlmostOut);
+  setCheck("#notify-close", config.notifyCuttingClose);
+  setCheck("#notify-runout", config.notifyWillRunOut);
+  setCheck("#telemetry", config.telemetry);
+  setCheck("#hide-while-sharing", config.hideUsageWhileSharing === true);
+  setCheck("#show-total-spend", config.showTotalSpend);
+  setSelect("#appearance", config.appearance);
+  setCheck("#density", config.density === "compact");
+  setCheck("#glass", config.glassEffects !== false);
+  setCheck("#reduce-anim", config.reduceAnimations === true);
+  setNum("#shortcut", config.shortcut);
+  setCheck("#proxy-enabled", config.proxy?.enabled ?? false);
+  setNum("#proxy-url", config.proxy?.url ?? "");
+  const autostart = document.querySelector<HTMLInputElement>("#autostart");
+  if (autostart) autostart.checked = true;
   populatePinnedOptions();
 }
 
@@ -2986,13 +3109,17 @@ window.addEventListener("DOMContentLoaded", () => {
     const tick = (e.target as HTMLElement).closest<HTMLElement>("[data-trail]");
     if (!tick) return;
     const card = trailCards()[Number(tick.dataset.trail)];
-    card?.scrollIntoView({ behavior: "smooth", block: "start" });
+    card?.scrollIntoView({ behavior: reduceMotion() ? "auto" : "smooth", block: "start" });
   });
 
   // The 4-hourly background checker feeds the same footer button.
   void listen<string>("update-available", (e) => {
     updateVersion = e.payload;
     renderBuildInfo();
+  });
+
+  void listen("tray-strip-restore", () => {
+    void updateTrayStrip();
   });
 
   void listen("popover-shown", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2784,6 +2784,7 @@ async function resetAllSettings(): Promise<void> {
     reduceAnimations: false,
     hideUsageWhileSharing: false,
   });
+  spendTab = "today";
   syncSettingsControls();
   scheduleAutoRefresh();
   applyAppearance();

--- a/src/main.ts
+++ b/src/main.ts
@@ -2785,6 +2785,7 @@ async function resetAllSettings(): Promise<void> {
     hideUsageWhileSharing: false,
   });
   syncSettingsControls();
+  scheduleAutoRefresh();
   applyAppearance();
   applyGlass();
   applyReduceMotion();

--- a/src/styles.css
+++ b/src/styles.css
@@ -1316,6 +1316,14 @@ footer {
   }
 }
 
+body.reduce-anim *,
+body.reduce-anim *::before,
+body.reduce-anim *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+}
+
 /* -------------------------------------------------------- customize drawer */
 
 #drawer {
@@ -2069,6 +2077,25 @@ body.no-glass .cust-dock {
 
 #changelog-btn:hover {
   background: var(--accent);
+}
+
+#reset-all-settings {
+  display: block;
+  width: 100%;
+  margin-top: 4px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 6px 14px;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--destructive, #ef4444) 55%, var(--border));
+  color: var(--destructive, #ef4444);
+}
+
+#reset-all-settings:hover {
+  background: color-mix(in srgb, var(--destructive, #ef4444) 12%, transparent);
 }
 
 /* Light theme: white glass, same as the sidebar's light recipe. */


### PR DESCRIPTION
## Summary

OpenUsage 0.7.8/0.7.9 shipped a few things Pane was still missing. This ports the ones that matter on Windows (Claude Desktop login is skipped — it needs a real install, and we never decrypt DPAPI).

- **Pricing alias-rule cap 64 → 256.** The live OpenUsage `pricing_supplement.json` has 105 `alias_rules`; Pane's `.take(64)` dropped Daybreak (`gpt-daybreak-blue-latest` → gpt-5.6-sol), GPT-5.3–5.6 effort slugs, and Cursor Router labels like `Opus 5 (Auto Balanced)`. `CORRECTIONS_REV` 5 → 6 so the spend cache reprices.
- **Codex auto-review stays its own row.** Display name stays `codex-auto-review`; dollars use the dated GPT fallback (gpt-5.5 from 2026-04-23), matching ccusage's timeline. `PERSIST_VERSION` 1 → 2.
- **Reduce animations** — Settings → General. Also still honors Windows `prefers-reduced-motion`.
- **Hide tray numbers while screen sharing** — Settings → Privacy, off by default. Uses `SHQueryUserNotificationState` (Presentation Settings / exclusive fullscreen) plus `SM_REMOTECONTROL`. Skips `QUNS_BUSY` so a fullscreen YouTube tab does not hide numbers.
- **Reset all settings** — Settings → Advanced. Restores Rust `config_with_defaults` (refresh 1 min, dark+compact, notifies on, telemetry on, layout null so first-launch re-detects). Keeps API keys, `lastSeenVersion`, and `welcomeDismissed`.

## Testing

New unit tests for the alias-rule cap and Codex auto-review fallback. `cargo test --lib` 62 passed. Built and installed locally; UI settings and spend names look good.

Made with Cursor

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->