### PR TITLE
Mirror Cursor's Plan & Usage page on bucket-era plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@
   is honest there: Cursor itself reports three contradictory total
   numbers). Pre-bucket accounts keep the classic included bar, computed
   as spend ÷ plan limit when Cursor reports spend (the API's own percent
-  otherwise — never a fabricated one). Saved layouts migrate the renamed
-  rows automatically: stars, pins, hidden flags, and order carry over
-  from "Auto usage" / "API usage" to the new labels.
+  otherwise — never a fabricated one). Team accounts keep their bucket
+  bars alongside the dollar Total meter. Saved layouts migrate
+  automatically: stars, pins, hidden flags, and order carry over from
+  "Auto usage" / "API usage" to the new labels, and a star or tray pin
+  on a Total row that became text repoints to Cursor Models instead of
+  silently vanishing from the tray.
 
 ## 0.4.34 — 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Cursor's Total usage bar matches its own caption** — Cursor's API
+  now reports `totalPercentUsed` against included *plus free bonus*
+  pools (a ~$345 denominator on live accounts), so the bar sat at 0%
+  while the caption said "$2.37 of $20.00 included". The bar now shows
+  the included-pool percent (spend ÷ plan limit, matching Cursor's own
+  dashboard message); the API's field remains the fallback when no
+  limit is reported.
+
 ## 0.4.34 — 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@
   Cursor shows, plus dollars spent this cycle as a text row (no percent
   is honest there: Cursor itself reports three contradictory total
   numbers). Pre-bucket accounts keep the classic included bar, computed
-  as spend ÷ plan limit so it always matches its own caption.
+  as spend ÷ plan limit when Cursor reports spend (the API's own percent
+  otherwise — never a fabricated one). Saved layouts migrate the renamed
+  rows automatically: stars, pins, hidden flags, and order carry over
+  from "Auto usage" / "API usage" to the new labels.
 
 ## 0.4.34 — 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,17 @@
 ## Unreleased
 
 ### Fixed
-- **Cursor's Total usage bar matches its own caption** — Cursor's API
-  now reports `totalPercentUsed` against included *plus free bonus*
-  pools (a ~$345 denominator on live accounts), so the bar sat at 0%
-  while the caption said "$2.37 of $20.00 included". The bar now shows
-  the included-pool percent (spend ÷ plan limit, matching Cursor's own
-  dashboard message); the API's field remains the fallback when no
-  limit is reported.
+- **The Cursor card mirrors Cursor's Plan & Usage page** — Cursor's new
+  bucket-era plans show two bars ("Cursor Models" and "Other Models")
+  and no total bar, but Pane's Total usage meter trusted the API's
+  `totalPercentUsed`, which now measures against included *plus free
+  bonus* pools (~$345 on live accounts) — so the bar sat at 0% while
+  the caption said "$2.37 of $20.00 included". Bucket-era cards now
+  show the same two bars as the dashboard, with the exact percentages
+  Cursor shows, plus dollars spent this cycle as a text row (no percent
+  is honest there: Cursor itself reports three contradictory total
+  numbers). Pre-bucket accounts keep the classic included bar, computed
+  as spend ÷ plan limit so it always matches its own caption.
 
 ## 0.4.34 — 2026-08-13
 

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -384,9 +384,18 @@ async fn fetch() -> Result<Snapshot, String> {
         || spend_type.as_deref() == Some("team")
         || pooled_limit > 0.0;
 
-    let used_cents = num(plan_usage.get("totalSpend"))
-        .or_else(|| limit.map(|l| l - num(plan_usage.get("remaining")).unwrap_or(0.0)))
-        .unwrap_or(0.0);
+    // Spend is only KNOWN when Cursor actually reports it: totalSpend,
+    // else limit-remaining when BOTH exist. Defaulting a missing
+    // `remaining` to 0 made used == limit — a 100% bar, "Limit reached",
+    // and run-out notifications for an account whose planUsage carries
+    // only the limit (Devin's find on the untestable pre-bucket path).
+    let used_cents_opt = num(plan_usage.get("totalSpend")).or_else(|| {
+        match (limit, num(plan_usage.get("remaining"))) {
+            (Some(l), Some(r)) => Some((l - r).max(0.0)),
+            _ => None,
+        }
+    });
+    let used_cents = used_cents_opt.unwrap_or(0.0);
 
     if is_team {
         // Team-shaped accounts sometimes omit the plan limit (or report
@@ -428,19 +437,27 @@ async fn fetch() -> Result<Snapshot, String> {
                     .with_reset(resets_at, Some(period_ms)),
             );
         }
-        metrics.push(
-            Metric::text("Total usage", format!("{} this cycle", dollars(used_cents)))
-                .with_reset(resets_at, Some(period_ms)),
-        );
+        // The cycle reset stays visible on the two bars above; the text
+        // row's with_reset rides along for local-API consumers only.
+        if let Some(u) = used_cents_opt {
+            metrics.push(
+                Metric::text("Total usage", format!("{} this cycle", dollars(u)))
+                    .with_reset(resets_at, Some(period_ms)),
+            );
+        }
     } else {
-        // Pre-bucket accounts: the classic included-pool bar. Computed
-        // spend/limit (matching the caption); the API's totalPercentUsed
-        // only when no limit is reported.
-        let pct = match limit {
-            Some(l) if l > 0.0 => used_cents / l * 100.0,
+        // Pre-bucket accounts: the classic included-pool bar — computed
+        // spend/limit so the bar always matches its own caption, but ONLY
+        // when spend is actually reported; otherwise fall back to the
+        // API's own percent rather than fabricating one.
+        let pct = match (used_cents_opt, limit) {
+            (Some(u), Some(l)) if l > 0.0 => u / l * 100.0,
             _ => total_pct.unwrap_or(0.0),
         };
-        let detail = limit.map(|l| format!("{} of {} included", dollars(used_cents), dollars(l)));
+        let detail = match (used_cents_opt, limit) {
+            (Some(u), Some(l)) => Some(format!("{} of {} included", dollars(u), dollars(l))),
+            _ => None,
+        };
         metrics.push(
             Metric::progress("Total usage", pct.clamp(0.0, 100.0), detail)
                 .with_reset(resets_at, Some(period_ms)),

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -404,14 +404,38 @@ async fn fetch() -> Result<Snapshot, String> {
             )
             .with_reset(resets_at, Some(period_ms)),
         );
+    } else if plan_usage.get("autoPercentUsed").is_some()
+        || plan_usage.get("apiPercentUsed").is_some()
+    {
+        // Bucket-era plans: mirror Cursor's own Plan & Usage page, which
+        // shows exactly two bars — "Cursor Models" (the auto bucket:
+        // Composer, Cursor Grok, …) and "Other Models" — and NO total
+        // bar. There is no honest total percent on these plans: the $20
+        // "limit" is only the Other-Models/API floor, totalPercentUsed
+        // measures against included+bonus pools (~$345 live), and the
+        // API's own displayMessage does spend/$20 math — three Cursor
+        // numbers that all contradict the dashboard. Dollars spent stay
+        // visible as a text row; only the misleading percent is gone.
+        if let Some(auto) = num(plan_usage.get("autoPercentUsed")) {
+            metrics.push(
+                Metric::progress("Cursor Models", auto.clamp(0.0, 100.0), None)
+                    .with_reset(resets_at, Some(period_ms)),
+            );
+        }
+        if let Some(api) = num(plan_usage.get("apiPercentUsed")) {
+            metrics.push(
+                Metric::progress("Other Models", api.clamp(0.0, 100.0), None)
+                    .with_reset(resets_at, Some(period_ms)),
+            );
+        }
+        metrics.push(
+            Metric::text("Total usage", format!("{} this cycle", dollars(used_cents)))
+                .with_reset(resets_at, Some(period_ms)),
+        );
     } else {
-        // Cursor's totalPercentUsed measures spend against included PLUS
-        // free bonus pools (live probe 2026-08-13: $2.37 of the $20 plan
-        // reported 0.69% — a ~$345 denominator — while Cursor's own
-        // displayMessage said "12% of your included usage"). The bar must
-        // agree with its own "$X of $Y included" caption, so compute the
-        // included-pool percent ourselves; the API field is only the
-        // fallback when no limit is reported.
+        // Pre-bucket accounts: the classic included-pool bar. Computed
+        // spend/limit (matching the caption); the API's totalPercentUsed
+        // only when no limit is reported.
         let pct = match limit {
             Some(l) if l > 0.0 => used_cents / l * 100.0,
             _ => total_pct.unwrap_or(0.0),
@@ -419,19 +443,6 @@ async fn fetch() -> Result<Snapshot, String> {
         let detail = limit.map(|l| format!("{} of {} included", dollars(used_cents), dollars(l)));
         metrics.push(
             Metric::progress("Total usage", pct.clamp(0.0, 100.0), detail)
-                .with_reset(resets_at, Some(period_ms)),
-        );
-    }
-
-    if let Some(auto) = num(plan_usage.get("autoPercentUsed")) {
-        metrics.push(
-            Metric::progress("Auto usage", auto.clamp(0.0, 100.0), None)
-                .with_reset(resets_at, Some(period_ms)),
-        );
-    }
-    if let Some(api) = num(plan_usage.get("apiPercentUsed")) {
-        metrics.push(
-            Metric::progress("API usage", api.clamp(0.0, 100.0), None)
                 .with_reset(resets_at, Some(period_ms)),
         );
     }

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -397,6 +397,26 @@ async fn fetch() -> Result<Snapshot, String> {
     });
     let used_cents = used_cents_opt.unwrap_or(0.0);
 
+    // The per-bucket bars mirror Cursor's own Plan & Usage page — "Cursor
+    // Models" (the auto bucket: Composer, Cursor Grok, …) and "Other
+    // Models" — and render for EVERY account shape that reports them,
+    // team included (they always did; a restructure briefly scoped them
+    // to non-team accounts and Devin caught the regression).
+    let auto_pct = num(plan_usage.get("autoPercentUsed"));
+    let api_pct = num(plan_usage.get("apiPercentUsed"));
+    if let Some(auto) = auto_pct {
+        metrics.push(
+            Metric::progress("Cursor Models", auto.clamp(0.0, 100.0), None)
+                .with_reset(resets_at, Some(period_ms)),
+        );
+    }
+    if let Some(api) = api_pct {
+        metrics.push(
+            Metric::progress("Other Models", api.clamp(0.0, 100.0), None)
+                .with_reset(resets_at, Some(period_ms)),
+        );
+    }
+
     if is_team {
         // Team-shaped accounts sometimes omit the plan limit (or report
         // zero, which would divide to NaN); the legacy request endpoint
@@ -413,32 +433,16 @@ async fn fetch() -> Result<Snapshot, String> {
             )
             .with_reset(resets_at, Some(period_ms)),
         );
-    } else if plan_usage.get("autoPercentUsed").is_some()
-        || plan_usage.get("apiPercentUsed").is_some()
-    {
-        // Bucket-era plans: mirror Cursor's own Plan & Usage page, which
-        // shows exactly two bars — "Cursor Models" (the auto bucket:
-        // Composer, Cursor Grok, …) and "Other Models" — and NO total
-        // bar. There is no honest total percent on these plans: the $20
+    } else if auto_pct.is_some() || api_pct.is_some() {
+        // Bucket-era personal plans: Cursor's page shows the two bars and
+        // NO total bar. There is no honest total percent here: the $20
         // "limit" is only the Other-Models/API floor, totalPercentUsed
         // measures against included+bonus pools (~$345 live), and the
         // API's own displayMessage does spend/$20 math — three Cursor
         // numbers that all contradict the dashboard. Dollars spent stay
         // visible as a text row; only the misleading percent is gone.
-        if let Some(auto) = num(plan_usage.get("autoPercentUsed")) {
-            metrics.push(
-                Metric::progress("Cursor Models", auto.clamp(0.0, 100.0), None)
-                    .with_reset(resets_at, Some(period_ms)),
-            );
-        }
-        if let Some(api) = num(plan_usage.get("apiPercentUsed")) {
-            metrics.push(
-                Metric::progress("Other Models", api.clamp(0.0, 100.0), None)
-                    .with_reset(resets_at, Some(period_ms)),
-            );
-        }
-        // The cycle reset stays visible on the two bars above; the text
-        // row's with_reset rides along for local-API consumers only.
+        // The cycle reset stays visible on the bars above; the text row's
+        // with_reset rides along for local-API consumers only.
         if let Some(u) = used_cents_opt {
             metrics.push(
                 Metric::text("Total usage", format!("{} this cycle", dollars(u)))

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -405,10 +405,17 @@ async fn fetch() -> Result<Snapshot, String> {
             .with_reset(resets_at, Some(period_ms)),
         );
     } else {
-        let pct = total_pct.unwrap_or_else(|| match limit {
+        // Cursor's totalPercentUsed measures spend against included PLUS
+        // free bonus pools (live probe 2026-08-13: $2.37 of the $20 plan
+        // reported 0.69% — a ~$345 denominator — while Cursor's own
+        // displayMessage said "12% of your included usage"). The bar must
+        // agree with its own "$X of $Y included" caption, so compute the
+        // included-pool percent ourselves; the API field is only the
+        // fallback when no limit is reported.
+        let pct = match limit {
             Some(l) if l > 0.0 => used_cents / l * 100.0,
-            _ => 0.0,
-        });
+            _ => total_pct.unwrap_or(0.0),
+        };
         let detail = limit.map(|l| format!("{} of {} included", dollars(used_cents), dollars(l)));
         metrics.push(
             Metric::progress("Total usage", pct.clamp(0.0, 100.0), detail)

--- a/src/main.ts
+++ b/src/main.ts
@@ -452,6 +452,35 @@ function ensureLayout(): void {
     changed = true;
   }
 
+  // One-time label migration (Cursor bucket-era rename, 0.4.35): "Auto
+  // usage" → "Cursor Models", "API usage" → "Other Models". Stars, pins,
+  // hidden/on-demand flags and row order carry over — without this, a
+  // starred/pinned old row silently loses its setting and the stale label
+  // rots in metricOrder forever (no rename migration existed before).
+  const CURSOR_RENAMES: Record<string, string> = {
+    "Auto usage": "Cursor Models",
+    "API usage": "Other Models",
+  };
+  for (const [pid, L] of Object.entries(layout.providers)) {
+    if (providerFamily(pid) !== "cursor") continue;
+    for (const list of [L.metricOrder, L.hidden, L.starred, L.onDemand]) {
+      for (const [oldLabel, newLabel] of Object.entries(CURSOR_RENAMES)) {
+        const at = list.indexOf(oldLabel);
+        if (at < 0) continue;
+        if (list.includes(newLabel)) list.splice(at, 1);
+        else list[at] = newLabel;
+        changed = true;
+      }
+    }
+  }
+  if (config.pinned && providerFamily(config.pinned.provider) === "cursor") {
+    const to = CURSOR_RENAMES[config.pinned.label];
+    if (to) {
+      config.pinned = { ...config.pinned, label: to };
+      void patchConfig({ pinned: config.pinned }).catch(() => {});
+    }
+  }
+
   for (const s of lastSnapshots) {
     if (!layout.providerOrder.includes(s.id)) {
       layout.providerOrder.push(s.id);

--- a/src/main.ts
+++ b/src/main.ts
@@ -473,8 +473,28 @@ function ensureLayout(): void {
       }
     }
   }
+  // On bucket-era accounts "Total usage" became a text row — the tray
+  // strip and pinned tray number only accept progress metrics, so a
+  // star/pin on it would silently vanish. Repoint both to the nearest
+  // equivalent meter, "Cursor Models" (only when the live snapshot
+  // confirms the row is text; pre-bucket accounts keep their bar).
+  const cursorSnap = lastSnapshots.find((s) => providerFamily(s.id) === "cursor");
+  const totalIsText =
+    cursorSnap?.metrics.find((m) => m.label === "Total usage")?.kind === "text";
+  if (totalIsText) {
+    for (const [pid, L] of Object.entries(layout.providers)) {
+      if (providerFamily(pid) !== "cursor") continue;
+      const at = L.starred.indexOf("Total usage");
+      if (at >= 0) {
+        if (L.starred.includes("Cursor Models")) L.starred.splice(at, 1);
+        else L.starred[at] = "Cursor Models";
+        changed = true;
+      }
+    }
+  }
   if (config.pinned && providerFamily(config.pinned.provider) === "cursor") {
-    const to = CURSOR_RENAMES[config.pinned.label];
+    const renamed = CURSOR_RENAMES[config.pinned.label];
+    const to = renamed ?? (totalIsText && config.pinned.label === "Total usage" ? "Cursor Models" : null);
     if (to) {
       config.pinned = { ...config.pinned, label: to };
       void patchConfig({ pinned: config.pinned }).catch(() => {});


### PR DESCRIPTION
## Summary

jazii's Cursor card showed "0% used" next to "$1.66 of $20.00 included" while the account was actively burning tokens. Live probe of `GetCurrentPeriodUsage` found Cursor's `totalPercentUsed` now measures spend against included **plus free bonus** pools (a ~$345 denominator on a live Pro account: $2.37 spent reported 0.69%), while the API's own `displayMessage` said "12% of your included usage" — and Cursor's actual Plan & Usage dashboard shows neither number: it renders exactly two bars (**Cursor Models** and **Other Models**) and **no total bar at all**.

What ships:

- **Bucket-era plans** (accounts reporting `autoPercentUsed`/`apiPercentUsed`): mirror the dashboard exactly — **Cursor Models** and **Other Models** bars with Cursor's own percentages (both carry the billing-cycle reset), plus **Total usage** as a text row ("$7.94 this cycle"), rendered only when Cursor reports spend. No total *percent* is shown because no honest one exists: Cursor reports three contradictory totals (bonus-pool field ~0.7%, displayMessage 12%, dashboard none). The text row's `with_reset` is for local-API consumers; the card shows the reset on the bars.
- **Pre-bucket accounts** keep the classic "$X of $Y included" bar — computed spend ÷ limit *only when Cursor actually reports spend* (`totalSpend`, or `limit` **and** `remaining`); otherwise the API's own percent. Never fabricated: the earlier draft's `remaining → 0` default could read `used == limit` and fire a false "Limit reached" (Devin round-1 find).
- **One-time layout migration** for the renames: stars, tray pins, hidden/on-demand flags, and row order carry from "Auto usage"/"API usage" to the new labels instead of rotting as stale entries (Devin round-1 find).
- Team accounts unchanged.

## Testing

- Verified live on a real bucket-era Pro account: card renders Cursor Models 2.65% / Other Models 0% / "$7.94 this cycle", matching the Cursor dashboard side-by-side; frontend type-checks and builds.
- ⚠ The pre-bucket fallback path can't be tested live (no such account available) — Devin is the only reviewer for that path, and its round-1 finding there was real and is fixed.
- Note: upstream OpenUsage still trusts `totalPercentUsed`, so the Mac app likely has this same 0% bug on bucket-era accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)