### PR TITLE
Release 0.4.35

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ pane.md
 *.njsproj
 *.sln
 *.sw?
+
+# Per-chair agent config (Cursor rules) — local like pane.md
+.cursor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.35 — 2026-08-13
 
 ### Added
 - **Daybreak Blue and Cursor Router spend names price correctly** — Pane

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.34",
+      "version": "0.4.35",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.34",
+  "version": "0.4.35",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.34"
+version = "0.4.35"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to 0.4.35 and changelog roll. Ships everything merged since 0.4.34:

**From #135 (OpenUsage 0.7.8/0.7.9 parity):**
- Full pricing-alias list (Daybreak Blue, GPT-5.3–5.6 effort slugs, Cursor Router names)
- codex-auto-review keeps its own breakdown row with dated GPT pricing
- Reduce animations setting
- Hide tray numbers while screen sharing (Privacy, off by default)
- Reset all settings (Settings → Advanced)

**From #136 (Cursor bucket-era card):**
- The Cursor card mirrors Cursor's own Plan & Usage page: Cursor Models / Other Models bars, dollars-this-cycle text row, layout/star/pin migration; pre-bucket and team accounts keep their meters

Also adds `.cursor/` to .gitignore (per-chair agent config stays local, like pane.md).

After merge: push the `v0.4.35` tag to build and publish the signed release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->