### PR TITLE
Give Hermes a provider card and price GLM-5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,16 @@
   (per-model breakdown on hover) sit behind Show more. MiniMax- and
   OpenRouter-routed sessions still join those slices; AihubMix
   (including a custom URL pointed at aihubmix.com) stays on the Hermes
-  card. No network calls — Pane reads the local ledger at
+  card; a custom URL pointed at MiniMax or OpenRouter joins those slices.
+  No network calls — Pane reads the local ledger at
   `%LOCALAPPDATA%\hermes\state.db`.
 - **GLM-5.3 spend prices from day one** — AihubMix's preview rate card
   for `coding-glm-5.3` ($0.060 in / $0.220 out per MTok; unpublished
   cache bills at the input rate) is baked in until public catalogs learn
-  the model. Hermes logs both `coding-glm-5.3` and `glm-5.3` against the
-  same gateway, so both spellings price. Gateway-prefixed DeepSeek V4
-  slugs (`accounts/fireworks/models/deepseek-v4-pro-0813`) also resolve.
+  the model. Hermes AihubMix rows logged as `glm-5.3` use that SKU;
+  the generic name stays unpriced for other vendors. Gateway-prefixed
+  DeepSeek V4 slugs (`accounts/fireworks/models/deepseek-v4-pro-0813`)
+  also resolve.
 
 ## 0.4.35 — 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Hermes desktop card** — Nous Research's Hermes app now has a provider
+  card like the others: last model used, which backend billed it, and
+  session count on the face; Today / Yesterday / Last 30 Days spend
+  (per-model breakdown on hover) sit behind Show more. MiniMax- and
+  OpenRouter-routed sessions still join those slices; AihubMix
+  (including a custom URL pointed at aihubmix.com) stays on the Hermes
+  card. No network calls — Pane reads the local ledger at
+  `%LOCALAPPDATA%\hermes\state.db`.
+- **GLM-5.3 spend prices from day one** — AihubMix's preview rate card
+  for `coding-glm-5.3` ($0.060 in / $0.220 out per MTok; unpublished
+  cache bills at the input rate) is baked in until public catalogs learn
+  the model. Hermes logs both `coding-glm-5.3` and `glm-5.3` against the
+  same gateway, so both spellings price. Gateway-prefixed DeepSeek V4
+  slugs (`accounts/fireworks/models/deepseek-v4-pro-0813`) also resolve.
+
 ## 0.4.35 — 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ statistic (random ID, version, which providers are enabled, provider
 success/failure counts — never amounts or error text) — see
 [Privacy](#privacy--security) for the full contract and the off switch.
 
-## Providers (19 and counting)
+## Providers (20 and counting)
 
 | Provider | How Pane connects |
 |---|---|
@@ -169,6 +169,7 @@ success/failure counts — never amounts or error text) — see
 | Kilo | Kilo CLI login file or API key → credit blocks + Kilo Pass |
 | AihubMix | API key (Settings or auto-detected from OpenCode) → usage vs spending limit |
 | Qwen Code | Coding Plan key (Settings or env) → 5h/weekly/monthly request quotas + local spend |
+| Hermes | Local ledger `%LOCALAPPDATA%\hermes\state.db` — last model, route, and catalog-priced spend |
 
 *OpenCode's meters use the official usage API that shipped in
 [anomalyco/opencode#16513](https://github.com/anomalyco/opencode/pull/16513)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -183,16 +183,21 @@ Ground rules that apply to every provider:
   notification); Moonshot adds Today / Yesterday / 30-day spend, model
   breakdown, and the usage trend from Kimi Code sessions.
 
-## Hermes (spend only — no card)
+## Hermes (Nous Research desktop)
 
 - **Reads:** the Hermes desktop app's local ledger
   (`%LOCALAPPDATA%\hermes\state.db`, `session_model_usage` table — model,
   billing route, token buckets, and the app's own cost per session).
-- **Calls:** nothing. This is a purely local spend source.
-- **Shows:** each session's tokens/cost in the Total Spend donut under
-  the backend that billed it — MiniMax-routed sessions join the MiniMax
-  slice, OpenRouter-routed join OpenRouter, anything else appears as a
-  Hermes slice.
+  Detected when that file exists; no API key.
+- **Calls:** nothing. This is a purely local source — Hermes records
+  ZERO cost itself, so dollars are priced from Pane's shared catalog.
+- **Shows:** a card with last-used model, which backend billed it
+  (AihubMix, MiniMax, a custom URL, …), and session count. Today /
+  Yesterday / Last 30 Days spend (with a per-model breakdown on hover)
+  sit behind Show more, same as other cards.
+  MiniMax-routed sessions still join the MiniMax spend slice, OpenRouter-
+  routed join OpenRouter; AihubMix and custom OpenAI-compatible URLs
+  (including a custom URL that points at aihubmix.com) stay on this card.
 
 ## Ollama
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -196,7 +196,8 @@ Ground rules that apply to every provider:
   Yesterday / Last 30 Days spend (with a per-model breakdown on hover)
   sit behind Show more, same as other cards.
   MiniMax-routed sessions still join the MiniMax spend slice, OpenRouter-
-  routed join OpenRouter; AihubMix and custom OpenAI-compatible URLs
+  routed join OpenRouter (including a custom URL pointed at those hosts);
+  AihubMix and other custom OpenAI-compatible URLs
   (including a custom URL that points at aihubmix.com) stay on this card.
 
 ## Ollama

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -513,7 +513,7 @@ struct StripEntry {
 /// allowlist for update_tray_strip: ids from the frontend are validated
 /// against this before being spliced into tray icon ids, and stale strip
 /// icons are removed for exactly this set.
-const STRIP_PROVIDER_IDS: [&str; 19] = [
+const STRIP_PROVIDER_IDS: [&str; 20] = [
     "claude",
     "codex",
     "cursor",
@@ -533,6 +533,7 @@ const STRIP_PROVIDER_IDS: [&str; 19] = [
     "kilo",
     "aihubmix",
     "qwen",
+    "hermes",
 ];
 
 #[tauri::command]
@@ -746,6 +747,7 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
         ("kilo", Box::pin(guarded("kilo".into(), "Kilo".into(), providers::kilo::snapshot()))),
         ("aihubmix", Box::pin(guarded("aihubmix".into(), "AihubMix".into(), providers::aihubmix::snapshot()))),
         ("qwen", Box::pin(guarded("qwen".into(), "Qwen Code".into(), providers::qwen::snapshot()))),
+        ("hermes", Box::pin(guarded("hermes".into(), "Hermes".into(), providers::hermes::snapshot()))),
     ];
     let mut futs: Vec<(String, BoxedSnap)> =
         base.into_iter().map(|(id, fut)| (id.to_string(), fut)).collect();

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -710,12 +710,12 @@ fn builtin_price(canonical: &str) -> Option<Price> {
         "deepseek-v4-flash" => Some(Price::flat(0.154, 0.308, 0.003, 0.154)),
         // AihubMix GLM-5.3 preview (aihubmix.com/model/coding-glm-5.3):
         // $0.060 in / $0.220 out per MTok. No cache rate is published, so
-        // reads/writes bill at the input rate. Official commercial glm-5.3
-        // has no public rate card yet (the /model/glm-5.3 page 404s);
-        // Hermes logs both `coding-glm-5.3` and `glm-5.3` against the same
-        // aihubmix.com/v1 gateway, so they share this preview card until a
-        // catalog learns a real entry.
-        "coding-glm-5.3" | "glm-5.3" => Some(Price::flat(0.06, 0.22, 0.06, 0.06)),
+        // reads/writes bill at the input rate. Only this gateway SKU is
+        // baked — the generic vendor name `glm-5.3` is left unpriced so
+        // Z.ai / OpenRouter / other scanners don't inherit the discount.
+        // Hermes still prices its AihubMix `glm-5.3` rows by looking up
+        // this SKU (see providers::hermes::price_lookup_slug).
+        "coding-glm-5.3" => Some(Price::flat(0.06, 0.22, 0.06, 0.06)),
         "kimi-k3" | "kimi-k3-code" => Some(Price::flat(3.0, 15.0, 0.3, 3.0)),
         // Alibaba Model Studio, GA'd 2026-08-03 (USD/MTok): input $2,
         // output $6, implicit cache read $0.25, explicit cache write $2.50.
@@ -877,13 +877,17 @@ mod tests {
     #[test]
     fn glm_53_aihubmix_preview_prices() {
         let store = super::Store::default();
-        for slug in ["coding-glm-5.3", "glm-5.3", "aihubmix/coding-glm-5.3"] {
+        for slug in ["coding-glm-5.3", "aihubmix/coding-glm-5.3"] {
             let p = super::resolve(&store, slug, 0).unwrap_or_else(|| panic!("{slug} unpriced"));
             assert!((p.input - 0.06).abs() < 1e-9, "{slug}");
             assert!((p.output - 0.22).abs() < 1e-9, "{slug}");
             // No cache rate on the vendor page — unpublished → input rate.
             assert!((p.cache_read - 0.06).abs() < 1e-9, "{slug}");
         }
+        // Generic vendor name (and gateway prefixes that peel to it) stay
+        // unpriced until a catalog learns an official rate.
+        assert!(super::resolve(&store, "glm-5.3", 0).is_none());
+        assert!(super::resolve(&store, "z-ai/glm-5.3", 0).is_none());
         // A catalog that learns the official commercial slug outranks the
         // preview card (self-retirement).
         let mut store = super::Store::default();

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -166,7 +166,7 @@ pub fn generation() -> u64 {
 /// fingerprinted below — an app update that reprices the same files would
 /// otherwise leave history at the old dollars until upstream happens to
 /// rewrite a catalog.
-const CORRECTIONS_REV: u32 = 6; // 6: ingest the live supplement's 100+ alias rules
+const CORRECTIONS_REV: u32 = 7; // 7: GLM-5.3 AihubMix preview rates + last-segment dated DeepSeek
 /// The live OpenUsage supplement is ~105 alias rules (Daybreak, Cursor
 /// Router prose names, GPT-5.3–5.6 effort slugs). 64 silently dropped
 /// everything after `gpt-5.2`. Per-rule caps below still bound memory.
@@ -634,8 +634,12 @@ fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
     // baked table for dated spellings too, or the table would never
     // self-retire for them. Scoped to deepseek slugs with an all-digit
     // ≥4-char tail so version-bearing names never lose a real tail.
-    if let Some((head, tail)) = canonical.rsplit_once('-') {
-        if canonical.starts_with("deepseek")
+    // Last path segment so gateway prefixes (Fireworks, AihubMix, …)
+    // still date-trim: Hermes logs
+    // `accounts/fireworks/models/deepseek-v4-pro-0813`.
+    let slug = canonical.rsplit('/').next().unwrap_or(canonical.as_str());
+    if let Some((head, tail)) = slug.rsplit_once('-') {
+        if slug.starts_with("deepseek")
             && tail.len() >= 4
             && tail.chars().all(|c| c.is_ascii_digit())
         {
@@ -685,12 +689,11 @@ fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
 /// (the supplement priced k2.7 and k2.7-code identically); "moonshot/" and
 /// "moonshot-ai/" prefixed spellings match how the CLIs log it.
 fn builtin_price(canonical: &str) -> Option<Price> {
-    let bare = canonical
-        .strip_prefix("moonshot/")
-        .or_else(|| canonical.strip_prefix("moonshot-ai/"))
-        .or_else(|| canonical.strip_prefix("xai/"))
-        .or_else(|| canonical.strip_prefix("deepseek/"))
-        .unwrap_or(canonical);
+    // Gateways prefix the vendor slug (`xai/grok-4.6`, `deepseek/…`,
+    // `accounts/fireworks/models/deepseek-v4-pro`). Peel to the last
+    // path segment so one arm covers every spelling; catalogs still
+    // outrank this table because resolve() consults them first.
+    let bare = canonical.rsplit('/').next().unwrap_or(canonical);
     match bare {
         // AihubMix DeepSeek V4 family — the gateway's OWN rate cards
         // (aihubmix.com/model/deepseek-v4-pro-0813 and /deepseek-v4-flash
@@ -705,6 +708,14 @@ fn builtin_price(canonical: &str) -> Option<Price> {
         // retry, so a catalog that learns the base slug outranks them.
         "deepseek-v4-pro" => Some(Price::flat(0.464, 0.928, 0.004, 0.464)),
         "deepseek-v4-flash" => Some(Price::flat(0.154, 0.308, 0.003, 0.154)),
+        // AihubMix GLM-5.3 preview (aihubmix.com/model/coding-glm-5.3):
+        // $0.060 in / $0.220 out per MTok. No cache rate is published, so
+        // reads/writes bill at the input rate. Official commercial glm-5.3
+        // has no public rate card yet (the /model/glm-5.3 page 404s);
+        // Hermes logs both `coding-glm-5.3` and `glm-5.3` against the same
+        // aihubmix.com/v1 gateway, so they share this preview card until a
+        // catalog learns a real entry.
+        "coding-glm-5.3" | "glm-5.3" => Some(Price::flat(0.06, 0.22, 0.06, 0.06)),
         "kimi-k3" | "kimi-k3-code" => Some(Price::flat(3.0, 15.0, 0.3, 3.0)),
         // Alibaba Model Studio, GA'd 2026-08-03 (USD/MTok): input $2,
         // output $6, implicit cache read $0.25, explicit cache write $2.50.
@@ -828,7 +839,12 @@ mod tests {
         let store = super::Store::default();
         // Real Hermes slugs: bare flash, dated pro snapshot, and the
         // deepseek/-prefixed catalog spelling.
-        for slug in ["deepseek-v4-pro", "deepseek-v4-pro-0813", "deepseek/deepseek-v4-pro-0813"] {
+        for slug in [
+            "deepseek-v4-pro",
+            "deepseek-v4-pro-0813",
+            "deepseek/deepseek-v4-pro-0813",
+            "accounts/fireworks/models/deepseek-v4-pro-0813",
+        ] {
             let p = super::resolve(&store, slug, 0).unwrap_or_else(|| panic!("{slug} unpriced"));
             assert!((p.input - 0.464).abs() < 1e-9, "{slug}");
             assert!((p.output - 0.928).abs() < 1e-9, "{slug}");
@@ -854,6 +870,26 @@ mod tests {
         let p = super::resolve(&store, "deepseek-v4-pro-0813", 0).unwrap();
         assert!((p.input - 0.5).abs() < 1e-9);
         assert!((p.cache_read - 0.05).abs() < 1e-9);
+        let p = super::resolve(&store, "accounts/fireworks/models/deepseek-v4-pro-0813", 0).unwrap();
+        assert!((p.input - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn glm_53_aihubmix_preview_prices() {
+        let store = super::Store::default();
+        for slug in ["coding-glm-5.3", "glm-5.3", "aihubmix/coding-glm-5.3"] {
+            let p = super::resolve(&store, slug, 0).unwrap_or_else(|| panic!("{slug} unpriced"));
+            assert!((p.input - 0.06).abs() < 1e-9, "{slug}");
+            assert!((p.output - 0.22).abs() < 1e-9, "{slug}");
+            // No cache rate on the vendor page — unpublished → input rate.
+            assert!((p.cache_read - 0.06).abs() < 1e-9, "{slug}");
+        }
+        // A catalog that learns the official commercial slug outranks the
+        // preview card (self-retirement).
+        let mut store = super::Store::default();
+        store.litellm.insert("glm-5.3".into(), super::Price::flat(1.0, 3.0, 0.25, 1.0));
+        let p = super::resolve(&store, "glm-5.3", 0).unwrap();
+        assert!((p.input - 1.0).abs() < 1e-9);
     }
 
     #[test]

--- a/src-tauri/src/providers/hermes.rs
+++ b/src-tauri/src/providers/hermes.rs
@@ -1,20 +1,29 @@
-//! Hermes desktop (Nous Research) — spend source only, no provider card.
+//! Hermes desktop (Nous Research) — local ledger card + spend source.
 //!
 //! Hermes keeps a local ledger at %LOCALAPPDATA%\hermes\state.db: the
 //! `session_model_usage` table has one row per (session, model, billing
 //! route) with cumulative token buckets, the app's own cost fields, and
 //! first/last-seen stamps. Hermes can route the same chat through several
-//! backends (MiniMax OAuth, OpenRouter, …), so each row carries the
-//! billing provider — the spend scanner uses it to file tokens under the
-//! provider that actually served them.
+//! backends (MiniMax OAuth, OpenRouter, AihubMix, a custom OpenAI-compatible
+//! URL, …). The spend scanner files MiniMax/OpenRouter rows under those
+//! slices; everything else — including AihubMix, whether Hermes labeled
+//! it `aihubmix` or `custom` pointed at aihubmix.com — stays on the
+//! Hermes card. Hermes records ZERO cost itself, so dollars come from
+//! the shared pricing catalog.
 
 use super::minimax::{file_stamp, snapshot_db, FileStamp};
+use super::{Metric, Snapshot};
+
+const ID: &str = "hermes";
+const NAME: &str = "Hermes";
 
 #[derive(Clone)]
 pub struct HermesUsage {
     pub ts_ms: i64,
     pub model: String,
     pub billing_provider: String,
+    pub billing_base_url: String,
+    pub session_id: String,
     pub input: f64,
     pub output: f64,
     pub reasoning: f64,
@@ -29,13 +38,112 @@ fn state_db_path() -> Option<std::path::PathBuf> {
     dirs::data_local_dir().map(|d| d.join("hermes").join("state.db"))
 }
 
+pub async fn snapshot() -> Snapshot {
+    fetch()
+}
+
+fn fetch() -> Snapshot {
+    let Some(db_path) = state_db_path() else {
+        return Snapshot::no_credentials(
+            ID,
+            NAME,
+            "Install the Hermes desktop app (Nous Research) — Pane reads its local ledger.",
+        );
+    };
+    if !db_path.exists() {
+        return Snapshot::no_credentials(
+            ID,
+            NAME,
+            "Install the Hermes desktop app (Nous Research) — Pane reads its local ledger.",
+        );
+    }
+    let events = collect_usage_events();
+    Snapshot::ok(
+        ID,
+        NAME,
+        Some("Desktop".into()),
+        metrics_from_events(&events),
+    )
+}
+
+/// Card face: last model, which backend billed it, how many sessions.
+/// Dollar totals live on the spend rows (Today / Yesterday / Last 30 Days)
+/// so these labels must not collide with those names.
+fn metrics_from_events(events: &[HermesUsage]) -> Vec<Metric> {
+    let mut metrics = Vec::new();
+    let last = events.iter().max_by_key(|e| e.ts_ms);
+    match last {
+        Some(ev) if !ev.model.is_empty() => {
+            metrics.push(Metric::text(
+                "Last used",
+                display_model(&ev.model).to_string(),
+            ));
+            metrics.push(Metric::text(
+                "Via",
+                route_label(&ev.billing_provider, &ev.billing_base_url),
+            ));
+        }
+        _ => metrics.push(Metric::text("Last used", "None yet".into())),
+    }
+    let sessions = unique_sessions(events);
+    if sessions > 0 {
+        metrics.push(Metric::text("Sessions", sessions.to_string()));
+    }
+    metrics
+}
+
+fn unique_sessions(events: &[HermesUsage]) -> usize {
+    let mut seen = std::collections::HashSet::new();
+    for e in events {
+        if !e.session_id.is_empty() {
+            seen.insert(e.session_id.as_str());
+        }
+    }
+    if seen.is_empty() {
+        events.len()
+    } else {
+        seen.len()
+    }
+}
+
+/// Last path segment so gateway-prefixed slugs stay readable on the card.
+fn display_model(model: &str) -> &str {
+    model
+        .rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(model)
+}
+
+/// Human name for the backend that billed the row. A `custom` OpenAI-
+/// compatible URL that points at a known gateway still shows that gateway
+/// (Hermes labels AihubMix as `custom` when you paste the URL yourself).
+fn route_label(provider: &str, base_url: &str) -> String {
+    let blob = format!("{} {}", provider, base_url).to_lowercase();
+    if blob.contains("aihubmix") {
+        "AihubMix".into()
+    } else if blob.contains("minimax") {
+        "MiniMax".into()
+    } else if blob.contains("openrouter") {
+        "OpenRouter".into()
+    } else if blob.contains("nous") {
+        "Nous API".into()
+    } else if provider.is_empty() || provider.eq_ignore_ascii_case("custom") {
+        "Custom API".into()
+    } else {
+        provider.to_string()
+    }
+}
+
 /// Per-session-per-model usage from Hermes's local store. Cached on the
 /// (db, WAL) stamps; a busy/locked db serves the last good events.
 pub fn collect_usage_events() -> Vec<HermesUsage> {
     use std::sync::Mutex;
     static CACHE: Mutex<Option<(FileStamp, FileStamp, Vec<HermesUsage>)>> = Mutex::new(None);
 
-    let Some(db_path) = state_db_path() else { return Vec::new() };
+    let Some(db_path) = state_db_path() else {
+        return Vec::new();
+    };
     if !db_path.exists() {
         return Vec::new();
     }
@@ -80,7 +188,8 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<HermesUsage>, String> {
             "SELECT last_seen, model, billing_provider,
                     input_tokens, output_tokens, reasoning_tokens,
                     cache_read_tokens, cache_write_tokens,
-                    COALESCE(actual_cost_usd, 0.0), COALESCE(estimated_cost_usd, 0.0)
+                    COALESCE(actual_cost_usd, 0.0), COALESCE(estimated_cost_usd, 0.0),
+                    COALESCE(session_id, ''), COALESCE(billing_base_url, '')
              FROM session_model_usage",
         )
         .map_err(|e| format!("query session_model_usage: {e}"))?;
@@ -98,8 +207,86 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<HermesUsage>, String> {
                 cache_read: row.get::<_, f64>(6).unwrap_or(0.0),
                 cache_write: row.get::<_, f64>(7).unwrap_or(0.0),
                 cost_usd: if actual > 0.0 { actual } else { estimated },
+                session_id: row.get::<_, String>(10).unwrap_or_default(),
+                billing_base_url: row.get::<_, String>(11).unwrap_or_default(),
             })
         })
         .map_err(|e| format!("read session_model_usage: {e}"))?;
     Ok(rows.flatten().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(ts: i64, model: &str, provider: &str, url: &str, session: &str) -> HermesUsage {
+        HermesUsage {
+            ts_ms: ts,
+            model: model.into(),
+            billing_provider: provider.into(),
+            billing_base_url: url.into(),
+            session_id: session.into(),
+            input: 1.0,
+            output: 1.0,
+            reasoning: 0.0,
+            cache_read: 0.0,
+            cache_write: 0.0,
+            cost_usd: 0.0,
+        }
+    }
+
+    #[test]
+    fn empty_ledger_still_has_a_last_used_row() {
+        let m = metrics_from_events(&[]);
+        assert_eq!(m[0].label, "Last used");
+        assert_eq!(m[0].value.as_deref(), Some("None yet"));
+        assert_eq!(m.len(), 1);
+    }
+
+    #[test]
+    fn card_shows_latest_model_gateway_and_session_count() {
+        let events = [
+            ev(1, "glm-5.3", "aihubmix", "https://aihubmix.com/v1", "s1"),
+            ev(
+                9,
+                "accounts/fireworks/models/deepseek-v4-pro-0813",
+                "custom",
+                "https://aihubmix.com/v1/",
+                "s2",
+            ),
+            ev(
+                5,
+                "coding-glm-5.3",
+                "custom",
+                "https://aihubmix.com/v1",
+                "s1",
+            ),
+        ];
+        let m = metrics_from_events(&events);
+        assert_eq!(m[0].value.as_deref(), Some("deepseek-v4-pro-0813"));
+        assert_eq!(m[1].label, "Via");
+        assert_eq!(m[1].value.as_deref(), Some("AihubMix"));
+        assert_eq!(m[2].label, "Sessions");
+        assert_eq!(m[2].value.as_deref(), Some("2"));
+    }
+
+    #[test]
+    fn custom_url_without_a_known_host_stays_custom() {
+        assert_eq!(
+            route_label("custom", "https://example.com/v1"),
+            "Custom API"
+        );
+        assert_eq!(route_label("aihubmix", ""), "AihubMix");
+        assert_eq!(route_label("minimax-oauth", ""), "MiniMax");
+        assert_eq!(route_label("nous-api", ""), "Nous API");
+    }
+
+    #[test]
+    fn display_model_peels_gateway_prefixes() {
+        assert_eq!(display_model("coding-glm-5.3"), "coding-glm-5.3");
+        assert_eq!(
+            display_model("accounts/fireworks/models/deepseek-v4-pro-0813"),
+            "deepseek-v4-pro-0813"
+        );
+    }
 }

--- a/src-tauri/src/providers/hermes.rs
+++ b/src-tauri/src/providers/hermes.rs
@@ -120,11 +120,15 @@ fn display_model(model: &str) -> &str {
         .unwrap_or(model)
 }
 
+fn route_blob(provider: &str, base_url: &str) -> String {
+    format!("{} {}", provider, base_url).to_lowercase()
+}
+
 /// Human name for the backend that billed the row. A `custom` OpenAI-
 /// compatible URL that points at a known gateway still shows that gateway
 /// (Hermes labels AihubMix as `custom` when you paste the URL yourself).
 fn route_label(provider: &str, base_url: &str) -> String {
-    let blob = format!("{} {}", provider, base_url).to_lowercase();
+    let blob = route_blob(provider, base_url);
     if blob.contains("aihubmix") {
         "AihubMix".into()
     } else if blob.contains("minimax") {
@@ -137,6 +141,31 @@ fn route_label(provider: &str, base_url: &str) -> String {
         "Custom API".into()
     } else {
         provider.to_string()
+    }
+}
+
+/// Which spend slice a Hermes row belongs to. MiniMax / OpenRouter —
+/// including a custom URL pointed at those hosts — join those cards.
+/// AihubMix (named or custom URL) stays on Hermes.
+pub fn spend_slice(provider: &str, base_url: &str) -> (&'static str, &'static str) {
+    let blob = route_blob(provider, base_url);
+    if blob.contains("minimax") {
+        ("minimax", "MiniMax")
+    } else if blob.contains("openrouter") {
+        ("openrouter", "OpenRouter")
+    } else {
+        ("hermes", "Hermes")
+    }
+}
+
+/// Catalog key for this Hermes row. Bare `glm-5.3` is unpriced globally
+/// (other vendors' rates aren't AihubMix's preview); when this row went
+/// through AihubMix, look up the gateway SKU instead.
+pub fn price_lookup_slug(model: &str, provider: &str, base_url: &str) -> String {
+    if display_model(model) == "glm-5.3" && route_blob(provider, base_url).contains("aihubmix") {
+        "coding-glm-5.3".into()
+    } else {
+        model.into()
     }
 }
 
@@ -309,6 +338,44 @@ mod tests {
         assert_eq!(route_label("aihubmix", ""), "AihubMix");
         assert_eq!(route_label("minimax-oauth", ""), "MiniMax");
         assert_eq!(route_label("nous-api", ""), "Nous API");
+    }
+
+    #[test]
+    fn spend_slice_follows_custom_minimax_and_openrouter_urls() {
+        assert_eq!(spend_slice("minimax-oauth", "").0, "minimax");
+        assert_eq!(spend_slice("openrouter", "").0, "openrouter");
+        assert_eq!(spend_slice("aihubmix", "").0, "hermes");
+        assert_eq!(spend_slice("custom", "https://aihubmix.com/v1").0, "hermes");
+        assert_eq!(
+            spend_slice("custom", "https://api.minimax.io/v1").0,
+            "minimax"
+        );
+        assert_eq!(
+            spend_slice("custom", "https://openrouter.ai/api/v1").0,
+            "openrouter"
+        );
+        assert_eq!(spend_slice("custom", "https://example.com/v1").0, "hermes");
+        assert_eq!(spend_slice("nous-api", "").0, "hermes");
+        assert_eq!(spend_slice("", "").0, "hermes");
+    }
+
+    #[test]
+    fn aihubmix_glm53_looks_up_the_gateway_sku() {
+        assert_eq!(
+            price_lookup_slug("glm-5.3", "aihubmix", ""),
+            "coding-glm-5.3"
+        );
+        assert_eq!(
+            price_lookup_slug("glm-5.3", "custom", "https://aihubmix.com/v1"),
+            "coding-glm-5.3"
+        );
+        // Other routes keep the generic name (unpriced until a catalog
+        // learns it) so Z.ai / OpenRouter dollars aren't guessed.
+        assert_eq!(price_lookup_slug("glm-5.3", "nous-api", ""), "glm-5.3");
+        assert_eq!(
+            price_lookup_slug("coding-glm-5.3", "aihubmix", ""),
+            "coding-glm-5.3"
+        );
     }
 
     #[test]

--- a/src-tauri/src/providers/hermes.rs
+++ b/src-tauri/src/providers/hermes.rs
@@ -13,9 +13,14 @@
 
 use super::minimax::{file_stamp, snapshot_db, FileStamp};
 use super::{Metric, Snapshot};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 const ID: &str = "hermes";
 const NAME: &str = "Hermes";
+
+/// Concurrent card refresh + spend scan each copy the ledger; a per-call
+/// counter keeps their temp files from colliding (same pattern as OpenCode).
+static COPY_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone)]
 pub struct HermesUsage {
@@ -158,7 +163,8 @@ pub fn collect_usage_events() -> Vec<HermesUsage> {
         }
     }
 
-    let tmp_base = std::env::temp_dir().join(format!("pane-hermes-{}", std::process::id()));
+    let n = COPY_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let tmp_base = std::env::temp_dir().join(format!("pane-hermes-{}-{n}", std::process::id()));
     let tmp_db = tmp_base.with_extension("db");
     let events = snapshot_db(&db_path, &tmp_db).and_then(|()| read_usage_events(&tmp_db));
     for suffix in ["db", "db-wal", "db-shm"] {
@@ -182,16 +188,30 @@ pub fn collect_usage_events() -> Vec<HermesUsage> {
 
 fn read_usage_events(db: &std::path::Path) -> Result<Vec<HermesUsage>, String> {
     let conn = rusqlite::Connection::open(db).map_err(|e| format!("open db copy: {e}"))?;
+    // Optional columns (session_id, billing_base_url) were added as Hermes
+    // grew; a ledger from an older build must still yield tokens/cost.
+    let cols = table_columns(&conn)?;
+    let session_expr = if cols.iter().any(|c| c == "session_id") {
+        "COALESCE(session_id, '')"
+    } else {
+        "''"
+    };
+    let url_expr = if cols.iter().any(|c| c == "billing_base_url") {
+        "COALESCE(billing_base_url, '')"
+    } else {
+        "''"
+    };
     // last_seen/first_seen are epoch seconds as REAL; costs may be NULL.
+    let sql = format!(
+        "SELECT last_seen, model, billing_provider,
+                input_tokens, output_tokens, reasoning_tokens,
+                cache_read_tokens, cache_write_tokens,
+                COALESCE(actual_cost_usd, 0.0), COALESCE(estimated_cost_usd, 0.0),
+                {session_expr}, {url_expr}
+         FROM session_model_usage"
+    );
     let mut stmt = conn
-        .prepare(
-            "SELECT last_seen, model, billing_provider,
-                    input_tokens, output_tokens, reasoning_tokens,
-                    cache_read_tokens, cache_write_tokens,
-                    COALESCE(actual_cost_usd, 0.0), COALESCE(estimated_cost_usd, 0.0),
-                    COALESCE(session_id, ''), COALESCE(billing_base_url, '')
-             FROM session_model_usage",
-        )
+        .prepare(&sql)
         .map_err(|e| format!("query session_model_usage: {e}"))?;
     let rows = stmt
         .query_map([], |row| {
@@ -212,6 +232,16 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<HermesUsage>, String> {
             })
         })
         .map_err(|e| format!("read session_model_usage: {e}"))?;
+    Ok(rows.flatten().collect())
+}
+
+fn table_columns(conn: &rusqlite::Connection) -> Result<Vec<String>, String> {
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(session_model_usage)")
+        .map_err(|e| format!("pragma table_info: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|e| format!("pragma table_info rows: {e}"))?;
     Ok(rows.flatten().collect())
 }
 
@@ -288,5 +318,32 @@ mod tests {
             display_model("accounts/fireworks/models/deepseek-v4-pro-0813"),
             "deepseek-v4-pro-0813"
         );
+    }
+
+    #[test]
+    fn older_ledger_without_optional_columns_still_reads_tokens() {
+        let path =
+            std::env::temp_dir().join(format!("pane-hermes-narrow-test-{}.db", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session_model_usage (
+                last_seen REAL, model TEXT, billing_provider TEXT,
+                input_tokens REAL, output_tokens REAL, reasoning_tokens REAL,
+                cache_read_tokens REAL, cache_write_tokens REAL,
+                actual_cost_usd REAL, estimated_cost_usd REAL
+             );
+             INSERT INTO session_model_usage VALUES
+                (1.0, 'glm-5.3', 'aihubmix', 10, 5, 0, 0, 0, 0, 0);",
+        )
+        .unwrap();
+        drop(conn);
+        let events = read_usage_events(&path).expect("narrow schema should still parse");
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].model, "glm-5.3");
+        assert_eq!(events[0].input, 10.0);
+        assert!(events[0].session_id.is_empty());
+        assert!(events[0].billing_base_url.is_empty());
     }
 }

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -734,18 +734,11 @@ fn minimax(extra: FileData) -> ProviderSpend {
 }
 
 /// Which spend slice a Hermes row belongs to. MiniMax- and OpenRouter-routed
-/// sessions join those providers' slices (they already have cards). Every
-/// other route — AihubMix, a custom OpenAI-compatible URL, Nous API — stays
-/// on the Hermes card.
-fn hermes_bucket(billing_provider: &str) -> (&'static str, &'static str) {
-    let lower = billing_provider.to_lowercase();
-    if lower.contains("minimax") {
-        ("minimax", "MiniMax")
-    } else if lower.contains("openrouter") {
-        ("openrouter", "OpenRouter")
-    } else {
-        ("hermes", "Hermes")
-    }
+/// sessions join those providers' slices (they already have cards), including
+/// a custom URL pointed at those hosts. Every other route — AihubMix, a
+/// custom OpenAI-compatible URL, Nous API — stays on the Hermes card.
+fn hermes_bucket(billing_provider: &str, billing_base_url: &str) -> (&'static str, &'static str) {
+    providers::hermes::spend_slice(billing_provider, billing_base_url)
 }
 
 /// Hermes spend, grouped per target slice. Rows are cumulative per
@@ -760,7 +753,7 @@ fn hermes() -> Vec<(&'static str, &'static str, FileData)> {
         if tokens <= 0.0 && ev.cost_usd <= 0.0 {
             continue;
         }
-        let (id, name) = hermes_bucket(&ev.billing_provider);
+        let (id, name) = hermes_bucket(&ev.billing_provider, &ev.billing_base_url);
         let data = match buckets.iter_mut().find(|(bid, _, _)| *bid == id) {
             Some((_, _, data)) => data,
             None => {
@@ -772,7 +765,11 @@ fn hermes() -> Vec<(&'static str, &'static str, FileData)> {
             add_event(data, ts, &ev.model, ev.cost_usd, tokens);
             continue;
         }
-        match pricing::lookup(&ev.model) {
+        match pricing::lookup(&providers::hermes::price_lookup_slug(
+            &ev.model,
+            &ev.billing_provider,
+            &ev.billing_base_url,
+        )) {
             Some(p) => {
                 let u = pricing::Usage {
                     input: ev.input,
@@ -1781,13 +1778,18 @@ mod tests {
 
     #[test]
     fn hermes_routes_land_in_the_right_slice() {
-        assert_eq!(hermes_bucket("minimax-oauth").0, "minimax");
-        assert_eq!(hermes_bucket("MiniMax").0, "minimax");
-        assert_eq!(hermes_bucket("openrouter").0, "openrouter");
-        assert_eq!(hermes_bucket("nous-api").0, "hermes");
-        assert_eq!(hermes_bucket("aihubmix").0, "hermes");
-        assert_eq!(hermes_bucket("custom").0, "hermes");
-        assert_eq!(hermes_bucket("").0, "hermes");
+        assert_eq!(hermes_bucket("minimax-oauth", "").0, "minimax");
+        assert_eq!(hermes_bucket("MiniMax", "").0, "minimax");
+        assert_eq!(hermes_bucket("openrouter", "").0, "openrouter");
+        assert_eq!(hermes_bucket("nous-api", "").0, "hermes");
+        assert_eq!(hermes_bucket("aihubmix", "").0, "hermes");
+        assert_eq!(hermes_bucket("custom", "").0, "hermes");
+        assert_eq!(hermes_bucket("custom", "https://aihubmix.com/v1").0, "hermes");
+        assert_eq!(
+            hermes_bucket("custom", "https://api.minimax.io/v1").0,
+            "minimax"
+        );
+        assert_eq!(hermes_bucket("", "").0, "hermes");
     }
 
     // ---- Codex: child-session replay gate --------------------------------

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -733,10 +733,10 @@ fn minimax(extra: FileData) -> ProviderSpend {
     build_spend("minimax", "MiniMax", data)
 }
 
-/// Which spend slice a Hermes row belongs to. Hermes (Nous Research's
-/// desktop agent) routes chats through whichever backend the user connected,
-/// so its ledger rows are filed under the provider that actually billed
-/// them; routes Pane has no slice for stay under Hermes's own name.
+/// Which spend slice a Hermes row belongs to. MiniMax- and OpenRouter-routed
+/// sessions join those providers' slices (they already have cards). Every
+/// other route — AihubMix, a custom OpenAI-compatible URL, Nous API — stays
+/// on the Hermes card.
 fn hermes_bucket(billing_provider: &str) -> (&'static str, &'static str) {
     let lower = billing_provider.to_lowercase();
     if lower.contains("minimax") {
@@ -1785,6 +1785,8 @@ mod tests {
         assert_eq!(hermes_bucket("MiniMax").0, "minimax");
         assert_eq!(hermes_bucket("openrouter").0, "openrouter");
         assert_eq!(hermes_bucket("nous-api").0, "hermes");
+        assert_eq!(hermes_bucket("aihubmix").0, "hermes");
+        assert_eq!(hermes_bucket("custom").0, "hermes");
         assert_eq!(hermes_bucket("").0, "hermes");
     }
 

--- a/src/assets/providers/hermes.svg
+++ b/src/assets/providers/hermes.svg
@@ -1,0 +1,5 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" d="M47 8h6v84h-6z"/>
+  <path fill="currentColor" d="M50 14L14 36l7 9 29-18 29 18 7-9z"/>
+  <path fill="currentColor" d="M22 48c10 6 18 10 28 8 10 2 18-2 28-8-8 14-18 22-28 22S30 62 22 48z"/>
+</svg>

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import copilotIcon from "./assets/providers/copilot.svg?raw";
 import cursorIcon from "./assets/providers/cursor.svg?raw";
 import devinIcon from "./assets/providers/devin.svg?raw";
 import grokIcon from "./assets/providers/grok.svg?raw";
+import hermesIcon from "./assets/providers/hermes.svg?raw";
 import minimaxIcon from "./assets/providers/minimax.svg?raw";
 import opencodeIcon from "./assets/providers/opencode.svg?raw";
 import openrouterIcon from "./assets/providers/openrouter.svg?raw";
@@ -36,6 +37,7 @@ const PROVIDER_ICONS: Record<string, string> = {
   cursor: cursorIcon,
   devin: devinIcon,
   grok: grokIcon,
+  hermes: hermesIcon,
   minimax: minimaxIcon,
   opencode: opencodeIcon,
   openrouter: openrouterIcon,
@@ -101,6 +103,7 @@ const RELOGIN: Record<string, string> = {
   opencode: "run `opencode auth login` in a terminal",
   antigravity: "open Antigravity and sign in again",
   ollama: "make sure Ollama is running",
+  hermes: "open the Hermes desktop app once so it writes its local ledger",
 };
 
 /// The ⚠ Outdated tooltip: what went wrong, what fixes it, and the
@@ -205,6 +208,7 @@ const ALL_PROVIDERS: [string, string][] = [
   ["kilo", "Kilo"],
   ["aihubmix", "AihubMix"],
   ["qwen", "Qwen Code"],
+  ["hermes", "Hermes"],
 ];
 
 // Same quick links the Mac app ships (status pages + vendor dashboards).
@@ -253,6 +257,7 @@ const PROVIDER_LINKS: Record<string, { label: string; url: string }[]> = {
   ollama: [{ label: "Library", url: "https://ollama.com/library" }],
   codebuff: [{ label: "Dashboard", url: "https://www.codebuff.com/profile" }],
   kilo: [{ label: "Dashboard", url: "https://app.kilo.ai/" }],
+  hermes: [{ label: "Site", url: "https://hermes-agent.com/" }],
 };
 
 // Brand palette for the Total Spend ring (Mac parity); unknown providers
@@ -497,6 +502,23 @@ function ensureLayout(): void {
       }
     }
   }
+  // Hermes's first local build left Today / Yesterday / Last 30 Days on
+  // the card face. Tuck them behind Show more like every other card;
+  // Last used / Via / Sessions stay visible.
+  const hermesL = layout.providers.hermes;
+  if (hermesL) {
+    for (const [label] of SPEND_KEYS) {
+      if (
+        hermesL.metricOrder.includes(label) &&
+        !hermesL.onDemand.includes(label) &&
+        !hermesL.hidden.includes(label)
+      ) {
+        hermesL.onDemand.push(label);
+        changed = true;
+      }
+    }
+  }
+
   if (config.pinned && providerFamily(config.pinned.provider) === "cursor") {
     const renamed = CURSOR_RENAMES[config.pinned.label];
     const to = renamed ?? (totalIsText && config.pinned.label === "Total usage" ? "Cursor Models" : null);
@@ -2317,6 +2339,7 @@ async function refresh(force = false): Promise<void> {
   const spend = await spendPromise;
   spendLoaded = true;
   if (spend) lastSpend = spend;
+  if (lastSnapshots.length) ensureLayout();
   if (!customizeOpen && lastSnapshots.length) renderIfVisible();
   refreshing = false;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -502,22 +502,6 @@ function ensureLayout(): void {
       }
     }
   }
-  // Hermes's first local build left Today / Yesterday / Last 30 Days on
-  // the card face. Tuck them behind Show more like every other card;
-  // Last used / Via / Sessions stay visible.
-  const hermesL = layout.providers.hermes;
-  if (hermesL) {
-    for (const [label] of SPEND_KEYS) {
-      if (
-        hermesL.metricOrder.includes(label) &&
-        !hermesL.onDemand.includes(label) &&
-        !hermesL.hidden.includes(label)
-      ) {
-        hermesL.onDemand.push(label);
-        changed = true;
-      }
-    }
-  }
 
   if (config.pinned && providerFamily(config.pinned.provider) === "cursor") {
     const renamed = CURSOR_RENAMES[config.pinned.label];


### PR DESCRIPTION
## Summary
- Hermes desktop gets a real card: last model, which backend billed it, and session count on the face; Today / Yesterday / Last 30 Days sit behind Show more with a per-model hover, like the other cards.
- GLM-5.3 via AihubMix now prices from the gateway's preview rate card (`coding-glm-5.3` / `glm-5.3` at $0.06 / $0.22 per MTok). Hermes records $0 itself, so those sessions were missing from Total Spend.
- Gateway-prefixed DeepSeek V4 slugs (`accounts/fireworks/models/deepseek-v4-pro-0813`) also resolve.

## Test plan
- [x] Local install: Hermes card shows Last used `coding-glm-5.3`, Via AihubMix, Sessions
- [x] Show more reveals Today / Yesterday / Last 30 Days; hover lists models and cost
- [ ] Confirm MiniMax/OpenRouter-routed Hermes sessions still join those cards
- [ ] PC without Hermes: card stays in Customize (not signed in)

Made with Cursor

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->