### PR TITLE
Release 0.4.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.36 — 2026-08-14
+
 ### Added
 - **Hermes desktop card** — Nous Research's Hermes app now has a provider
   card like the others: last model used, which backend billed it, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.35",
+  "version": "0.4.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.35",
+      "version": "0.4.36",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.35",
+  "version": "0.4.36",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.35"
+version = "0.4.36"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.35",
+  "version": "0.4.36",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Version bump to 0.4.36 and changelog roll.
- Ships the Hermes desktop card and GLM-5.3 AihubMix preview pricing from #138 (MiniMax/OpenRouter-routed Hermes sessions still join those cards; AihubMix stays on Hermes).

After merge: push the `v0.4.36` tag to build and publish the signed release. Do not tag until the merge commit is on main.

## Test plan
- [x] Local install `Pane_0.4.36_x64-setup.exe /S /UPDATE` — ProductVersion is 0.4.36
- [x] Opened Pane; `127.0.0.1:6736/v1/usage/hermes` shows Last used `coding-glm-5.3`, Via AihubMix, Sessions 7

Made with Cursor

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->