### PR TITLE
Release 0.4.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.38 — 2026-08-15
+
 ### Fixed
 - **Refreshes are fast again — sorry 0.4.37 made Pane laggy and slow.**
   That release's bounded log walk resolved every directory it visited to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.37",
+  "version": "0.4.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.37",
+      "version": "0.4.38",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.37",
+  "version": "0.4.38",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.37"
+version = "0.4.38"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.37"
+version = "0.4.38"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.37",
+  "version": "0.4.38",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
Version bump to 0.4.38 (`package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`) plus the CHANGELOG roll. No code changes.

Hotfix release for the 0.4.37 slowdown, out the same day:
- #144 — the bounded log walk no longer canonicalizes every directory (a per-directory handle open + antivirus round-trip on Windows made opening Pane and every refresh crawl). Only symlinks/junctions pay that cost now, aliased subtrees dedupe by canonical identity, and all 0.4.37 protections hold.
- The changelog entry apologizes to everyone who installed 0.4.37 and hit the lag.

After merge: tag `v0.4.38` on the merge commit to build and publish the signed release.

## Test plan
- [x] 24 spend tests pass (including the new junction alias test, which exercises on CI's Windows runners)
- [x] Fixed build installed on the affected machine: Pane opens instantly, local API answers in 166 ms

Made with Cursor

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->