### PR TITLE
Add a Kimi Code plan card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
   Switching Moonshot off in Customize still stops the wallet fetch — no
   API bar and no Moonshot network calls. If the Kimi card itself is
   off, session spend stays on Moonshot so the dollars don't vanish. A
-  starred Moonshot "Credits used" pin moves to the Kimi API bar.
+  starred Moonshot "Credits used" pin moves to the Kimi API bar only
+  when that bar is actually on the card.
 
 ## 0.4.38 — 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
   joins them; plan-only installs stay at two bars. Local session spend
   that used to sit on the Moonshot card lives here. The leftover
   Moonshot card hides while Kimi Code is connected (and comes back if
-  that login goes away); it still appears for API-only installs.
+  that login goes away); it still appears for API-only installs. If the
+  Kimi card loads without a wallet bar, a successful Moonshot fetch is
+  kept so the balance doesn't vanish for one cycle.
   Switching Moonshot off in Customize still stops the wallet fetch — no
   API bar and no Moonshot network calls. If the Kimi card itself is
   off, session spend stays on Moonshot so the dollars don't vanish. A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+- **Kimi Code plan card** — one card like OpenCode: Session and Weekly
+  request bars from the official Kimi Code CLI login. If a Moonshot
+  wallet key is saved, an **API** bar (same high-water credits meter)
+  joins them; plan-only installs stay at two bars. Local session spend
+  that used to sit on the Moonshot card lives here. The leftover
+  Moonshot card hides while Kimi Code is connected; it still appears
+  for API-only installs.
+
 ## 0.4.38 — 2026-08-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
   joins them; plan-only installs stay at two bars. Local session spend
   that used to sit on the Moonshot card lives here. The leftover
   Moonshot card hides while Kimi Code is connected (and comes back if
-  that login goes away); it still appears for API-only installs. A
+  that login goes away); it still appears for API-only installs.
+  Switching Moonshot off in Customize still stops the wallet fetch — no
+  API bar and no Moonshot network calls. If the Kimi card itself is
+  off, session spend stays on Moonshot so the dollars don't vanish. A
   starred Moonshot "Credits used" pin moves to the Kimi API bar.
 
 ## 0.4.38 — 2026-08-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
   wallet key is saved, an **API** bar (same high-water credits meter)
   joins them; plan-only installs stay at two bars. Local session spend
   that used to sit on the Moonshot card lives here. The leftover
-  Moonshot card hides while Kimi Code is connected; it still appears
-  for API-only installs.
+  Moonshot card hides while Kimi Code is connected (and comes back if
+  that login goes away); it still appears for API-only installs. A
+  starred Moonshot "Credits used" pin moves to the Kimi API bar.
 
 ## 0.4.38 — 2026-08-15
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ success/failure counts — never amounts or error text) — see
 | Z.ai | API key (Settings), CLI key file, or env var |
 | Antigravity | Local language server, or Google Cloud Code API via Credential Manager |
 | DeepSeek | API key (Settings) → balance |
-| Moonshot (Kimi) | API key (Settings) → balance (global + CN endpoints) |
+| Moonshot (Kimi API) | API key (Settings) → balance (global + CN endpoints) |
+| Kimi Code | Official CLI login (`kimi login`) → Session + Weekly plan bars; Moonshot API key → API wallet bar; local session spend |
 | ElevenLabs | API key (Settings) → character quota with reset pacing |
 | Ollama | Local server on :11434 — installed + loaded models, no key |
 | Codebuff | `codebuff login` credentials file or API key → credits + weekly limit |

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -11,7 +11,7 @@ This is the complete list. Anything not listed here does not happen.
 
 | Destination | When | What is sent |
 |---|---|---|
-| Each provider's own API (Anthropic, OpenAI/ChatGPT, cursor.com, GitHub, x.ai, opencode.ai, Devin, MiniMax, OpenRouter, Z.ai, Google, DeepSeek, Moonshot, ElevenLabs, Codebuff, Kilo, AihubMix, Alibaba Model Studio…) | Every refresh (default 1 min), only for providers you have enabled | That provider's own token/key, exactly as its official tool would send it. Full per-provider detail: [providers.md](providers.md) |
+| Each provider's own API (Anthropic, OpenAI/ChatGPT, cursor.com, GitHub, x.ai, opencode.ai, Devin, MiniMax, OpenRouter, Z.ai, Google, DeepSeek, Moonshot, Kimi Code, ElevenLabs, Codebuff, Kilo, AihubMix, Alibaba Model Studio…) | Every refresh (default 1 min), only for providers you have enabled | That provider's own token/key, exactly as its official tool would send it. Full per-provider detail: [providers.md](providers.md) |
 | `raw.githubusercontent.com` (LiteLLM), `models.dev`, `robinebers.github.io` | ~Daily | Anonymous GET for public model price tables (no identifying data) |
 | `pane.jazii.dev/api/update` (falls back to `github.com/ItsJazii/pane/releases`) | On launch + every 4 h | Anonymous GET for the update manifest, carrying the app version. See "The update check" below for exactly what this counts. |
 | `us.i.posthog.com` | Once per day (unless switched off) | The two anonymous daily-statistic events described in "Anonymous usage statistics" below — a random ID, version, enabled-provider list, and per-provider success/failure counts. Never usage amounts, spend, keys, or error text. |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -199,6 +199,9 @@ Ground rules that apply to every provider:
   Show more on that bar. Local spend from
   `~\.kimi-code\sessions\**\wire.jsonl` (one usage.record per turn).
   The separate Moonshot card is hidden while this card is connected.
+  Switching Moonshot off in Customize still skips the wallet fetch (no
+  API bar, no `api.moonshot.ai|cn` call). If the Kimi card is off,
+  local session spend stays on Moonshot.
 
 ## Hermes (Nous Research desktop)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -170,18 +170,35 @@ Ground rules that apply to every provider:
 ## DeepSeek / Moonshot / ElevenLabs / Venice-class key providers
 
 - **Reads:** pasted key or env var only (`DEEPSEEK_API_KEY`,
-  `MOONSHOT_API_KEY`/`KIMI_API_KEY`, `ELEVENLABS_API_KEY`). Moonshot
-  additionally reads local spend from the Kimi Code CLI's session logs
-  (`%USERPROFILE%\.kimi-code\sessions\**\wire.jsonl` — one usage.record
-  per turn with model and token buckets).
+  `MOONSHOT_API_KEY`/`KIMI_API_KEY`, `ELEVENLABS_API_KEY`).
 - **Calls:** `api.deepseek.com/user/balance`;
   `api.moonshot.ai|cn/v1/users/me/balance`;
   `api.elevenlabs.io/v1/user/subscription`.
 - **Shows:** balances / character quota with reset pacing; Moonshot and
   DeepSeek add a "Credits used" percent bar metered against the highest
   balance Pane has seen locally (top-ups raise it; feeds the Almost Out
-  notification); Moonshot adds Today / Yesterday / 30-day spend, model
-  breakdown, and the usage trend from Kimi Code sessions.
+  notification).
+
+## Kimi Code
+
+- **Reads:** `%USERPROFILE%\.kimi-code\credentials\kimi-code.json` (honors
+  `KIMI_CODE_HOME`; falls back to `~\.kimi\credentials\kimi-code.json`).
+  That is the official CLI's OAuth login — Pane never asks you to paste
+  the plan token. Refresh tokens rotate on use and are written back
+  beside the CLI's file (`*.pane-bak` first), same as Claude/Codex.
+- **Calls:** `api.kimi.com/coding/v1/usages` (Session + Weekly request
+  windows); `auth.kimi.com/api/oauth/token` (refresh); and, when a
+  Moonshot/Kimi API key is saved, `api.moonshot.ai|cn/v1/users/me/balance`
+  for the API bar. This is the Kimi Code *subscription* plus the
+  pay-as-you-go wallet on the same card.
+- **Shows:** Session (5-hour) and Weekly bars with reset pacing, plan
+  name (Andante / Moderato / Allegretto when the weekly quota matches).
+  The **API** bar (credits used vs the highest balance Pane has seen)
+  only appears when a Moonshot/Kimi API key is saved — plan-only
+  installs never get a third quota row. Balance/Vouchers sit behind
+  Show more on that bar. Local spend from
+  `~\.kimi-code\sessions\**\wire.jsonl` (one usage.record per turn).
+  The separate Moonshot card is hidden while this card is connected.
 
 ## Hermes (Nous Research desktop)
 

--- a/src-tauri/src/alerts.rs
+++ b/src-tauri/src/alerts.rs
@@ -94,6 +94,14 @@ pub fn evaluate(snapshots: &[Snapshot], cfg: &Value) -> Vec<Alert> {
 
     for snapshot in snapshots.iter().filter(|s| s.status == "ok") {
         for metric in snapshot.metrics.iter().filter(|m| m.kind == "progress") {
+            // Restored Kimi API rows are last-known, not live — don't
+            // fire Almost Out off a wallet timeout.
+            if snapshot.id == "kimi"
+                && snapshot.warning.is_some()
+                && matches!(metric.label.as_str(), "API" | "Credits used")
+            {
+                continue;
+            }
             let Some(used) = metric.used_percent else { continue };
             let key = format!("{}:{}", snapshot.id, metric.label);
             let entry = map.entry(key).or_default();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -739,7 +739,17 @@ fn cached_kimi_ok_from(doc: &Value, now_ms: i64) -> bool {
 }
 
 fn fold_moonshot_into_kimi(all: &mut Vec<providers::Snapshot>) {
-    if all.iter().any(|s| s.id == "kimi" && s.status == "ok") {
+    let Some(kimi) = all.iter().find(|s| s.id == "kimi" && s.status == "ok") else {
+        return;
+    };
+    // Don't throw away a freshly fetched wallet just because the plan
+    // card loaded. Fold only when Kimi already carries those rows, or
+    // when Moonshot has nothing to show (plan-only / no_credentials).
+    let kimi_has_wallet = kimi.metrics.iter().any(|m| is_kimi_wallet_label(&m.label));
+    let moonshot_has_rows = all
+        .iter()
+        .any(|s| s.id == "moonshot" && !s.metrics.is_empty());
+    if kimi_has_wallet || !moonshot_has_rows {
         all.retain(|s| s.id != "moonshot");
     }
 }
@@ -1620,7 +1630,10 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use super::{cached_kimi_ok_from, is_kimi_wallet_label, restore_kimi_wallet_rows, SNAPSHOT_CACHE_MS};
+    use super::{
+        cached_kimi_ok_from, fold_moonshot_into_kimi, is_kimi_wallet_label, restore_kimi_wallet_rows,
+        SNAPSHOT_CACHE_MS,
+    };
     use crate::providers::{Metric, Snapshot};
     use serde_json::json;
 
@@ -1688,5 +1701,60 @@ mod tests {
         let err = json!({"kimi": {"at": now, "snap": {"status": "error"}}});
         assert!(!cached_kimi_ok_from(&err, now));
         assert!(!cached_kimi_ok_from(&json!({}), now));
+    }
+
+    #[test]
+    fn fold_keeps_moonshot_when_kimi_has_no_wallet() {
+        let mut all = vec![
+            Snapshot::ok(
+                "kimi",
+                "Kimi Code",
+                None,
+                vec![Metric::progress("Session", 0.0, None)],
+            ),
+            Snapshot::ok(
+                "moonshot",
+                "Moonshot",
+                None,
+                vec![Metric::progress("Credits used", 24.0, None)],
+            ),
+        ];
+        fold_moonshot_into_kimi(&mut all);
+        assert!(all.iter().any(|s| s.id == "moonshot"));
+    }
+
+    #[test]
+    fn fold_hides_moonshot_when_kimi_has_wallet_or_moonshot_is_empty() {
+        let mut with_api = vec![
+            Snapshot::ok(
+                "kimi",
+                "Kimi Code",
+                None,
+                vec![
+                    Metric::progress("Session", 0.0, None),
+                    Metric::progress("API", 24.0, None),
+                ],
+            ),
+            Snapshot::ok(
+                "moonshot",
+                "Moonshot",
+                None,
+                vec![Metric::progress("Credits used", 24.0, None)],
+            ),
+        ];
+        fold_moonshot_into_kimi(&mut with_api);
+        assert!(!with_api.iter().any(|s| s.id == "moonshot"));
+
+        let mut empty_moon = vec![
+            Snapshot::ok(
+                "kimi",
+                "Kimi Code",
+                None,
+                vec![Metric::progress("Session", 0.0, None)],
+            ),
+            Snapshot::no_credentials("moonshot", "Moonshot", "paste a key"),
+        ];
+        fold_moonshot_into_kimi(&mut empty_moon);
+        assert!(!empty_moon.iter().any(|s| s.id == "moonshot"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -706,6 +706,37 @@ where
     snap
 }
 
+/// Last-good Kimi snapshot on disk. Used to skip the leftover Moonshot
+/// fetch only when that card has actually painted — a credentials file
+/// alone must not hide the wallet.
+fn cached_kimi_ok() -> bool {
+    let path = providers::config_dir().join("last_snapshots.json");
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(doc) = serde_json::from_str::<Value>(&raw) else {
+        return false;
+    };
+    doc.pointer("/kimi/snap/status").and_then(Value::as_str) == Some("ok")
+}
+
+fn is_kimi_wallet_label(label: &str) -> bool {
+    matches!(label, "API" | "Credits used" | "Balance" | "Vouchers" | "Cash")
+}
+
+fn restore_kimi_wallet_rows(current: &mut providers::Snapshot, previous: &providers::Snapshot) {
+    if current.metrics.iter().any(|m| m.label == "API") {
+        return;
+    }
+    for m in &previous.metrics {
+        if is_kimi_wallet_label(&m.label)
+            && !current.metrics.iter().any(|x| x.label == m.label)
+        {
+            current.metrics.push(m.clone());
+        }
+    }
+}
+
 /// Called by the UI. Refreshes every enabled provider at the same time and
 /// returns whatever each one found — data, "not signed in", or an error.
 #[tauri::command]
@@ -751,12 +782,19 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
         ("hermes", Box::pin(guarded("hermes".into(), "Hermes".into(), providers::hermes::snapshot()))),
         ("kimi", Box::pin(guarded("kimi".into(), "Kimi Code".into(), providers::kimi::snapshot()))),
     ];
+    // Skip the leftover Moonshot fetch only when the last Kimi card
+    // actually painted — a credentials file alone is not enough (expired
+    // login / network blip would otherwise hide the wallet with nothing
+    // to fall back to). The post-fetch retain still drops it whenever
+    // this cycle's Kimi snapshot is ok.
+    let kimi_card_live = cached_kimi_ok();
     let mut futs: Vec<(String, BoxedSnap)> = base
         .into_iter()
         .filter(|(id, _)| {
             *id != "moonshot"
                 || !providers::kimi::has_login()
                 || disabled.iter().any(|d| d == "kimi")
+                || !kimi_card_live
         })
         .map(|(id, fut)| (id.to_string(), fut))
         .collect();
@@ -920,6 +958,14 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
         if let Ok(mut map) = cache.lock() {
             let mut dirty = false;
             for s in all.iter_mut() {
+                // Plan bars can succeed while the folded Moonshot wallet
+                // call fails; keep last-known API/Balance rows so Almost
+                // Out and the tray pin don't blink off for one timeout.
+                if s.id == "kimi" && s.status == "ok" && s.warning.is_some() {
+                    if let Some(previous) = map.get("kimi") {
+                        restore_kimi_wallet_rows(s, &previous.snap);
+                    }
+                }
                 if s.status == "ok" {
                     map.insert(s.id.clone(), CachedSnap { at: now_ms, snap: s.clone() });
                     dirty = true;
@@ -1540,4 +1586,64 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_kimi_wallet_label, restore_kimi_wallet_rows};
+    use crate::providers::{Metric, Snapshot};
+
+    #[test]
+    fn kimi_wallet_labels() {
+        assert!(is_kimi_wallet_label("API"));
+        assert!(is_kimi_wallet_label("Balance"));
+        assert!(!is_kimi_wallet_label("Session"));
+        assert!(!is_kimi_wallet_label("Weekly"));
+    }
+
+    #[test]
+    fn restore_wallet_rows_when_api_missing() {
+        let mut current = Snapshot::ok(
+            "kimi",
+            "Kimi Code",
+            None,
+            vec![Metric::progress("Session", 0.0, None)],
+        );
+        current.warning = Some("Moonshot API wallet couldn't refresh".into());
+        let previous = Snapshot::ok(
+            "kimi",
+            "Kimi Code",
+            None,
+            vec![
+                Metric::progress("Session", 10.0, None),
+                Metric::progress("API", 24.0, None),
+                Metric::text("Balance", "$152.00".into()),
+            ],
+        );
+        restore_kimi_wallet_rows(&mut current, &previous);
+        let labels: Vec<_> = current.metrics.iter().map(|m| m.label.as_str()).collect();
+        assert_eq!(labels, ["Session", "API", "Balance"]);
+    }
+
+    #[test]
+    fn restore_wallet_rows_skips_when_api_present() {
+        let mut current = Snapshot::ok(
+            "kimi",
+            "Kimi Code",
+            None,
+            vec![
+                Metric::progress("Session", 0.0, None),
+                Metric::progress("API", 1.0, None),
+            ],
+        );
+        let previous = Snapshot::ok(
+            "kimi",
+            "Kimi Code",
+            None,
+            vec![Metric::progress("API", 99.0, None)],
+        );
+        restore_kimi_wallet_rows(&mut current, &previous);
+        let api = current.metrics.iter().find(|m| m.label == "API").unwrap();
+        assert!((api.used_percent.unwrap() - 1.0).abs() < 0.01);
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,12 @@ use tauri::{
     Emitter, Manager, WindowEvent,
 };
 
+/// Last-good snapshots older than this are too misleading to show or to
+/// use as a stand-in for a live Moonshot card.
+const SNAPSHOT_CACHE_MS: i64 = 24 * 60 * 60 * 1000;
+/// One failed cycle isn't "Outdated": vendors hiccup routinely.
+const STALE_GRACE_MS: i64 = 3 * 60 * 1000;
+
 // ---------------------------------------------------------------------------
 // App settings, stored at %APPDATA%\Pane\config.json
 // ---------------------------------------------------------------------------
@@ -707,8 +713,8 @@ where
 }
 
 /// Last-good Kimi snapshot on disk. Used to skip the leftover Moonshot
-/// fetch only when that card has actually painted — a credentials file
-/// alone must not hide the wallet.
+/// fetch only when that card has actually painted *recently* — a
+/// credentials file, or a day-old cache entry, must not hide the wallet.
 fn cached_kimi_ok() -> bool {
     let path = providers::config_dir().join("last_snapshots.json");
     let Ok(raw) = std::fs::read_to_string(path) else {
@@ -717,7 +723,25 @@ fn cached_kimi_ok() -> bool {
     let Ok(doc) = serde_json::from_str::<Value>(&raw) else {
         return false;
     };
-    doc.pointer("/kimi/snap/status").and_then(Value::as_str) == Some("ok")
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    cached_kimi_ok_from(&doc, now_ms)
+}
+
+fn cached_kimi_ok_from(doc: &Value, now_ms: i64) -> bool {
+    if doc.pointer("/kimi/snap/status").and_then(Value::as_str) != Some("ok") {
+        return false;
+    }
+    let at = doc.pointer("/kimi/at").and_then(Value::as_i64).unwrap_or(0);
+    at > 0 && now_ms.saturating_sub(at) <= SNAPSHOT_CACHE_MS
+}
+
+fn fold_moonshot_into_kimi(all: &mut Vec<providers::Snapshot>) {
+    if all.iter().any(|s| s.id == "kimi" && s.status == "ok") {
+        all.retain(|s| s.id != "moonshot");
+    }
 }
 
 fn is_kimi_wallet_label(label: &str) -> bool {
@@ -877,12 +901,6 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
             at: i64,
             snap: providers::Snapshot,
         }
-        const MAX_STALE_MS: i64 = 24 * 60 * 60 * 1000;
-        // One failed cycle isn't "Outdated": vendors hiccup routinely, and
-        // at short refresh intervals the tag was flashing on every blip.
-        // Data younger than the grace window serves silently; the tag (and
-        // the error on hover) appears once staleness is real.
-        const STALE_GRACE_MS: i64 = 3 * 60 * 1000;
 
         static LAST_OK: OnceLock<Mutex<HashMap<String, CachedSnap>>> = OnceLock::new();
         let cache_file = providers::config_dir().join("last_snapshots.json");
@@ -961,18 +979,31 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
                 // Plan bars can succeed while the folded Moonshot wallet
                 // call fails; keep last-known API/Balance rows so Almost
                 // Out and the tray pin don't blink off for one timeout.
+                // Do not re-cache the patched snapshot — that would reset
+                // `at` and keep serving the same balance forever.
+                let mut skip_cache = false;
                 if s.id == "kimi" && s.status == "ok" && s.warning.is_some() {
                     if let Some(previous) = map.get("kimi") {
-                        restore_kimi_wallet_rows(s, &previous.snap);
+                        let age = now_ms - previous.at;
+                        if age <= SNAPSHOT_CACHE_MS {
+                            let n = s.metrics.len();
+                            restore_kimi_wallet_rows(s, &previous.snap);
+                            if s.metrics.len() > n {
+                                skip_cache = true;
+                                if age > STALE_GRACE_MS {
+                                    s.stale = true;
+                                }
+                            }
+                        }
                     }
                 }
-                if s.status == "ok" {
+                if s.status == "ok" && !skip_cache {
                     map.insert(s.id.clone(), CachedSnap { at: now_ms, snap: s.clone() });
                     dirty = true;
                 } else if s.status == "error" {
                     if let Some(previous) = map.get(&s.id) {
                         let age = now_ms - previous.at;
-                        if age <= MAX_STALE_MS {
+                        if age <= SNAPSHOT_CACHE_MS {
                             let warning = s.error.clone();
                             *s = previous.snap.clone();
                             if age > STALE_GRACE_MS {
@@ -994,9 +1025,7 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
 
     // One Kimi card: Session / Weekly / API. Hide the leftover Moonshot
     // wallet card whenever the plan card is actually showing.
-    if all.iter().any(|s| s.id == "kimi" && s.status == "ok") {
-        all.retain(|s| s.id != "moonshot");
-    }
+    fold_moonshot_into_kimi(&mut all);
 
     httpapi::publish(&all);
     update_tray(&app, &all, &cfg);
@@ -1094,7 +1123,7 @@ fn cached_usage() -> Vec<providers::Snapshot> {
         at: i64,
         snap: providers::Snapshot,
     }
-    const MAX_STALE_MS: i64 = 24 * 60 * 60 * 1000;
+    const MAX_STALE_MS: i64 = SNAPSHOT_CACHE_MS;
     let Ok(raw) = std::fs::read_to_string(providers::config_dir().join("last_snapshots.json"))
     else {
         return Vec::new();
@@ -1148,6 +1177,7 @@ fn cached_usage() -> Vec<providers::Snapshot> {
             s
         })
         .collect();
+    fold_moonshot_into_kimi(&mut out);
     out.sort_by(|a, b| a.id.cmp(&b.id));
     out
 }
@@ -1590,8 +1620,9 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_kimi_wallet_label, restore_kimi_wallet_rows};
+    use super::{cached_kimi_ok_from, is_kimi_wallet_label, restore_kimi_wallet_rows, SNAPSHOT_CACHE_MS};
     use crate::providers::{Metric, Snapshot};
+    use serde_json::json;
 
     #[test]
     fn kimi_wallet_labels() {
@@ -1645,5 +1676,17 @@ mod tests {
         restore_kimi_wallet_rows(&mut current, &previous);
         let api = current.metrics.iter().find(|m| m.label == "API").unwrap();
         assert!((api.used_percent.unwrap() - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn cached_kimi_ok_ignores_stale_or_missing_entries() {
+        let now = 1_800_000_000_000i64;
+        let fresh = json!({"kimi": {"at": now - 60_000, "snap": {"status": "ok"}}});
+        assert!(cached_kimi_ok_from(&fresh, now));
+        let old = json!({"kimi": {"at": now - SNAPSHOT_CACHE_MS - 1, "snap": {"status": "ok"}}});
+        assert!(!cached_kimi_ok_from(&old, now));
+        let err = json!({"kimi": {"at": now, "snap": {"status": "error"}}});
+        assert!(!cached_kimi_ok_from(&err, now));
+        assert!(!cached_kimi_ok_from(&json!({}), now));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -513,7 +513,7 @@ struct StripEntry {
 /// allowlist for update_tray_strip: ids from the frontend are validated
 /// against this before being spliced into tray icon ids, and stale strip
 /// icons are removed for exactly this set.
-const STRIP_PROVIDER_IDS: [&str; 20] = [
+const STRIP_PROVIDER_IDS: [&str; 21] = [
     "claude",
     "codex",
     "cursor",
@@ -534,6 +534,7 @@ const STRIP_PROVIDER_IDS: [&str; 20] = [
     "aihubmix",
     "qwen",
     "hermes",
+    "kimi",
 ];
 
 #[tauri::command]
@@ -748,9 +749,17 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
         ("aihubmix", Box::pin(guarded("aihubmix".into(), "AihubMix".into(), providers::aihubmix::snapshot()))),
         ("qwen", Box::pin(guarded("qwen".into(), "Qwen Code".into(), providers::qwen::snapshot()))),
         ("hermes", Box::pin(guarded("hermes".into(), "Hermes".into(), providers::hermes::snapshot()))),
+        ("kimi", Box::pin(guarded("kimi".into(), "Kimi Code".into(), providers::kimi::snapshot()))),
     ];
-    let mut futs: Vec<(String, BoxedSnap)> =
-        base.into_iter().map(|(id, fut)| (id.to_string(), fut)).collect();
+    let mut futs: Vec<(String, BoxedSnap)> = base
+        .into_iter()
+        .filter(|(id, _)| {
+            *id != "moonshot"
+                || !providers::kimi::has_login()
+                || disabled.iter().any(|d| d == "kimi")
+        })
+        .map(|(id, fut)| (id.to_string(), fut))
+        .collect();
     // Extra Claude accounts (multi-login machines): each discovered config
     // dir renders its own card under a claude@<hash8> id, running the same
     // provider flow scoped to its dir. The default login keeps the bare id.
@@ -935,6 +944,12 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
                 }
             }
         }
+    }
+
+    // One Kimi card: Session / Weekly / API. Hide the leftover Moonshot
+    // wallet card whenever the plan card is actually showing.
+    if all.iter().any(|s| s.id == "kimi" && s.status == "ok") {
+        all.retain(|s| s.id != "moonshot");
     }
 
     httpapi::publish(&all);

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -103,7 +103,7 @@ async fn fetch() -> Result<Snapshot, String> {
     let (usages, api) = if super::moonshot::has_api_key() {
         tokio::join!(fetch_usages(&access), super::moonshot::api_rows())
     } else {
-        (fetch_usages(&access).await, Vec::new())
+        (fetch_usages(&access).await, Ok(Vec::new()))
     };
     let mut snap = match usages {
         Ok(doc) => parse_snapshot(&doc)?,
@@ -122,7 +122,14 @@ async fn fetch() -> Result<Snapshot, String> {
         }
         Err(UsagesError::Other(e)) => return Err(e),
     };
-    snap.metrics.extend(api);
+    match api {
+        Ok(rows) => snap.metrics.extend(rows),
+        Err(_) => {
+            snap.warning = Some(
+                "Moonshot API wallet couldn't refresh — retrying next cycle".into(),
+            );
+        }
+    }
     Ok(snap)
 }
 

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -98,9 +98,9 @@ async fn fetch() -> Result<Snapshot, String> {
         ));
     };
     let access = load_access(&path, false).await?;
-    // No Moonshot key → Session + Weekly only; don't even start a wallet
-    // fetch, so plan-only installs never grow a blank API row.
-    let (usages, api) = if super::moonshot::has_api_key() {
+    // No Moonshot key, or Moonshot switched off → Session + Weekly only.
+    // Disabled Moonshot must not be contacted through this folded card.
+    let (usages, api) = if super::moonshot::wallet_wanted() {
         tokio::join!(fetch_usages(&access), super::moonshot::api_rows())
     } else {
         (fetch_usages(&access).await, Ok(Vec::new()))

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -1,0 +1,569 @@
+//! Kimi Code — one card like OpenCode: Session + Weekly from the
+//! subscription, plus an API bar from the Moonshot pay-as-you-go wallet
+//! when a key is saved in Settings.
+//!
+//! Quota comes from GET api.kimi.com/coding/v1/usages, authenticated with
+//! the official Kimi Code CLI's OAuth login
+//! (`%USERPROFILE%\.kimi-code\credentials\kimi-code.json`). Tokens refresh
+//! against auth.kimi.com and are written back beside the CLI's file so the
+//! CLI stays signed in — same write-back as Claude/Codex.
+
+use super::{http, Metric, Snapshot};
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const ID: &str = "kimi";
+const NAME: &str = "Kimi Code";
+/// Public OAuth client id the official CLI (and OpenUsage) uses.
+const CLIENT_ID: &str = "17e5f671-d194-4dfb-9706-5516cb48c098";
+const USAGES_URL: &str = "https://api.kimi.com/coding/v1/usages";
+const TOKEN_URL: &str = "https://auth.kimi.com/api/oauth/token";
+const HOUR_MS: i64 = 3_600_000;
+const DAY_MS: i64 = 86_400_000;
+const MAX_CRED_BYTES: u64 = 64 * 1024;
+const MAX_USAGES_BYTES: usize = 256 * 1024;
+const MAX_TOKEN_BYTES: usize = 16 * 1024;
+
+pub async fn snapshot() -> Snapshot {
+    match fetch().await {
+        Ok(s) => s,
+        Err(e) => Snapshot::error(ID, NAME, e),
+    }
+}
+
+pub fn has_login() -> bool {
+    cred_path().is_some()
+}
+
+/// Official CLI home. `KIMI_CODE_HOME` is honored only when it is an
+/// absolute path — a relative value would resolve against Pane's cwd and
+/// could point the spend walk or credential write at the wrong tree.
+pub fn code_home() -> PathBuf {
+    if let Some(p) = env_code_home() {
+        return p;
+    }
+    dirs::home_dir().unwrap_or_default().join(".kimi-code")
+}
+
+fn env_code_home() -> Option<PathBuf> {
+    let raw = std::env::var("KIMI_CODE_HOME").ok()?;
+    absolute_home(&raw)
+}
+
+fn absolute_home(raw: &str) -> Option<PathBuf> {
+    let p = PathBuf::from(raw.trim());
+    if p.as_os_str().is_empty() || !p.is_absolute() {
+        return None;
+    }
+    #[cfg(windows)]
+    {
+        use std::path::Component;
+        // `\Windows\...` is "absolute" on Windows but drive-relative.
+        // Only honor a real drive/UNC prefix so a planted env can't aim
+        // credential writes at the current-drive root.
+        if !matches!(p.components().next(), Some(Component::Prefix(_))) {
+            return None;
+        }
+    }
+    Some(p)
+}
+
+fn cred_candidates(kimi_home: Option<PathBuf>, user_home: Option<PathBuf>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(home) = kimi_home {
+        candidates.push(home.join("credentials").join("kimi-code.json"));
+    }
+    if let Some(home) = user_home {
+        candidates.push(home.join(".kimi-code").join("credentials").join("kimi-code.json"));
+        // OpenUsage/Mac spelling — keep as a fallback.
+        candidates.push(home.join(".kimi").join("credentials").join("kimi-code.json"));
+    }
+    candidates
+}
+
+fn cred_path() -> Option<PathBuf> {
+    cred_candidates(env_code_home(), dirs::home_dir())
+        .into_iter()
+        .find(|p| is_regular_file(p))
+}
+
+async fn fetch() -> Result<Snapshot, String> {
+    let Some(path) = cred_path() else {
+        return Ok(Snapshot::no_credentials(
+            ID,
+            NAME,
+            "Kimi Code sign-in not found. Run `kimi login` in a terminal.",
+        ));
+    };
+    let access = load_access(&path, false).await?;
+    // No Moonshot key → Session + Weekly only; don't even start a wallet
+    // fetch, so plan-only installs never grow a blank API row.
+    let (usages, api) = if super::moonshot::has_api_key() {
+        tokio::join!(fetch_usages(&access), super::moonshot::api_rows())
+    } else {
+        (fetch_usages(&access).await, Vec::new())
+    };
+    let mut snap = match usages {
+        Ok(doc) => parse_snapshot(&doc)?,
+        Err(UsagesError::Unauthorized) => {
+            let access = load_access(&path, true).await?;
+            match fetch_usages(&access).await {
+                Ok(doc) => parse_snapshot(&doc)?,
+                Err(UsagesError::Unauthorized) => {
+                    return Err(
+                        "Kimi Code sign-in was rotated — run `kimi login` in a terminal once and Pane recovers automatically"
+                            .into(),
+                    );
+                }
+                Err(UsagesError::Other(e)) => return Err(e),
+            }
+        }
+        Err(UsagesError::Other(e)) => return Err(e),
+    };
+    snap.metrics.extend(api);
+    Ok(snap)
+}
+
+enum UsagesError {
+    Unauthorized,
+    Other(String),
+}
+
+async fn fetch_usages(access: &str) -> Result<Value, UsagesError> {
+    let resp = http()
+        .get(USAGES_URL)
+        .bearer_auth(access)
+        .header("Accept", "application/json")
+        .timeout(Duration::from_secs(8))
+        .send()
+        .await
+        .map_err(|e| UsagesError::Other(format!("usage request: {e}")))?;
+    let status = resp.status();
+    if status.as_u16() == 401 || status.as_u16() == 403 {
+        return Err(UsagesError::Unauthorized);
+    }
+    if !status.is_success() {
+        return Err(UsagesError::Other(format!("usage endpoint: HTTP {status}")));
+    }
+    super::json_body(resp, MAX_USAGES_BYTES, "usage")
+        .await
+        .map_err(UsagesError::Other)
+}
+
+/// Load a usable access token, refreshing when expired (or when `force`).
+/// Refresh tokens rotate — write the new pair back so the CLI stays signed in.
+async fn load_access(path: &Path, force: bool) -> Result<String, String> {
+    let raw = super::read_small_text(path, MAX_CRED_BYTES, "credentials")?;
+    let mut doc: Value = serde_json::from_str(&raw).map_err(|e| format!("parse credentials: {e}"))?;
+
+    let mut access = doc
+        .get("access_token")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let refresh = doc
+        .get("refresh_token")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let expires_ms = expires_at_ms(doc.get("expires_at"));
+    let now_ms = Utc::now().timestamp_millis();
+    // 5-minute buffer matches OpenUsage; Kimi access tokens are short-lived.
+    let stale = access.is_empty() || expires_ms <= now_ms + 5 * 60_000;
+    if !force && !stale {
+        return Ok(access);
+    }
+    if refresh.is_empty() {
+        return Err(
+            "token expired and no refresh token present — run `kimi login` in a terminal".into(),
+        );
+    }
+    // Refresh rotates the CLI's refresh token. If we can't write it back
+    // (a planted symlink), don't call the token endpoint — that would
+    // sign the CLI out from under the user.
+    if !can_write_creds(path) {
+        if !access.is_empty() && !force {
+            return Ok(access);
+        }
+        return Err(
+            "Kimi Code credentials are not a regular file — run `kimi login` in a terminal".into(),
+        );
+    }
+
+    let form = [
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh.as_str()),
+        ("client_id", CLIENT_ID),
+    ];
+    let resp = http()
+        .post(TOKEN_URL)
+        .header("Accept", "application/json")
+        .form(&form)
+        .timeout(Duration::from_secs(8))
+        .send()
+        .await
+        .map_err(|e| format!("token refresh: {e}"))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = bounded_text(resp, MAX_TOKEN_BYTES).await;
+        if status.as_u16() == 401 || status.as_u16() == 403 || body.contains("invalid_grant") {
+            return Err(
+                "Kimi Code sign-in was rotated — run `kimi login` in a terminal once and Pane recovers automatically"
+                    .into(),
+            );
+        }
+        return Err(format!("token refresh failed: HTTP {status}"));
+    }
+    let tok = super::json_body(resp, MAX_TOKEN_BYTES, "token refresh").await?;
+    let new_access = tok
+        .get("access_token")
+        .and_then(Value::as_str)
+        .ok_or("refresh response missing access_token")?
+        .to_string();
+    let new_refresh = tok
+        .get("refresh_token")
+        .and_then(Value::as_str)
+        .unwrap_or(&refresh)
+        .to_string();
+    let expires_in = json_f64(tok.get("expires_in")).unwrap_or(3600.0) as i64;
+
+    access = new_access.clone();
+
+    if doc.is_object() {
+        doc["access_token"] = Value::from(new_access);
+        doc["refresh_token"] = Value::from(new_refresh);
+        doc["expires_in"] = Value::from(expires_in);
+        // The CLI stores unix seconds (sometimes with a fractional part).
+        doc["expires_at"] = Value::from((now_ms / 1000) + expires_in);
+        let _ = std::fs::copy(path, path.with_extension("json.pane-bak"));
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
+            .and_then(|_| std::fs::rename(&tmp, path))
+            .map_err(|e| format!("write refreshed credentials: {e}"))?;
+    }
+    Ok(access)
+}
+
+fn can_write_creds(path: &Path) -> bool {
+    is_regular_file(path)
+}
+
+fn is_regular_file(path: &Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .ok()
+        .is_some_and(|m| m.is_file() && !m.file_type().is_symlink())
+}
+
+async fn bounded_text(resp: reqwest::Response, max_bytes: usize) -> String {
+    match resp.bytes().await {
+        Ok(b) if b.len() <= max_bytes => String::from_utf8_lossy(&b).into_owned(),
+        _ => String::new(),
+    }
+}
+
+fn parse_snapshot(doc: &Value) -> Result<Snapshot, String> {
+    const SESSION_MS: i64 = 5 * HOUR_MS;
+    const WEEK_MS: i64 = 7 * DAY_MS;
+    let mut metrics = Vec::new();
+    let mut weekly_limit = None;
+
+    // Session = rolling 5-hour window (duration 300 TIME_UNIT_MINUTE).
+    for entry in doc.get("limits").and_then(Value::as_array).unwrap_or(&vec![]) {
+        if !is_session_window(entry) {
+            continue;
+        }
+        let node = entry.get("detail").unwrap_or(entry);
+        if let Some(m) = progress_from("Session", node, SESSION_MS) {
+            metrics.push(m);
+            break;
+        }
+    }
+
+    if let Some(usage) = doc.get("usage") {
+        weekly_limit = json_f64(usage.get("limit"));
+        if let Some(m) = progress_from("Weekly", usage, WEEK_MS) {
+            metrics.push(m);
+        }
+    }
+
+    if metrics.is_empty() {
+        return Err("usage response had no recognizable limit windows".into());
+    }
+    Ok(Snapshot::ok(ID, NAME, plan_from_doc(doc, weekly_limit), metrics))
+}
+
+fn progress_from(label: &str, node: &Value, period_ms: i64) -> Option<Metric> {
+    let used = used_percent(node)?;
+    let resets_at = parse_reset(node.get("resetTime").or_else(|| node.get("reset_time")));
+    Some(Metric::progress(label, used, None).with_reset(resets_at, Some(period_ms)))
+}
+
+fn is_session_window(entry: &Value) -> bool {
+    let duration = json_f64(entry.pointer("/window/duration"));
+    let unit = entry
+        .pointer("/window/timeUnit")
+        .or_else(|| entry.pointer("/window/time_unit"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let unit = unit.to_ascii_uppercase();
+    match (duration, unit.as_str()) {
+        (Some(d), u) if (d - 300.0).abs() < 0.5 && u.contains("MINUTE") => true,
+        (Some(d), u) if (d - 5.0).abs() < 0.5 && u.contains("HOUR") => true,
+        _ => false,
+    }
+}
+
+fn used_percent(node: &Value) -> Option<f64> {
+    let limit = json_f64(node.get("limit"))?;
+    if limit <= 0.0 {
+        return None;
+    }
+    if let Some(used) = json_f64(node.get("used")) {
+        return Some((used / limit * 100.0).clamp(0.0, 100.0));
+    }
+    let remaining = json_f64(node.get("remaining"))?;
+    Some(((limit - remaining) / limit * 100.0).clamp(0.0, 100.0))
+}
+
+fn plan_from_doc(doc: &Value, weekly_limit: Option<f64>) -> Option<String> {
+    if let Some(level) = doc
+        .pointer("/user/membership/level")
+        .and_then(Value::as_str)
+        .and_then(map_membership_level)
+    {
+        return Some(level);
+    }
+    match weekly_limit.map(|n| n.round() as i64) {
+        Some(1024) => Some("Andante".into()),
+        Some(2048) => Some("Moderato".into()),
+        Some(7168) => Some("Allegretto".into()),
+        _ => None,
+    }
+}
+
+fn map_membership_level(raw: &str) -> Option<String> {
+    let upper = raw.trim().to_ascii_uppercase();
+    let key = upper.strip_prefix("LEVEL_").unwrap_or(&upper);
+    Some(match key {
+        "ANDANTE" | "BASIC" | "BEGINNER" | "INTRO" => "Andante".into(),
+        "MODERATO" | "INTERMEDIATE" => "Moderato".into(),
+        "ALLEGROTTO" | "ADVANCED" | "PROFESSIONAL" | "PRO" => "Allegretto".into(),
+        other if other.is_empty() => return None,
+        other => title_case(other),
+    })
+}
+
+fn title_case(s: &str) -> String {
+    let mut out = String::new();
+    let mut cap = true;
+    for c in s.chars() {
+        if c == '_' || c == '-' {
+            out.push(' ');
+            cap = true;
+            continue;
+        }
+        if cap {
+            out.extend(c.to_uppercase());
+            cap = false;
+        } else {
+            out.extend(c.to_lowercase());
+        }
+    }
+    out
+}
+
+fn json_f64(v: Option<&Value>) -> Option<f64> {
+    match v? {
+        Value::Number(n) => n.as_f64(),
+        Value::String(s) => s.trim().parse().ok(),
+        _ => None,
+    }
+}
+
+fn expires_at_ms(v: Option<&Value>) -> i64 {
+    let Some(n) = json_f64(v) else { return 0 };
+    if n.abs() >= 1e12 {
+        n as i64
+    } else {
+        (n * 1000.0) as i64
+    }
+}
+
+/// `resetTime` is ISO-8601; some responses carry extra fractional digits
+/// that strict RFC3339 rejects, so trim the fraction to microseconds.
+fn parse_reset(v: Option<&Value>) -> Option<i64> {
+    match v? {
+        Value::String(s) => parse_iso_ms(s),
+        Value::Number(n) => {
+            let n = n.as_f64()?;
+            Some(if n.abs() < 1e10 { (n * 1000.0) as i64 } else { n as i64 })
+        }
+        _ => None,
+    }
+}
+
+fn parse_iso_ms(s: &str) -> Option<i64> {
+    let s = s.trim();
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Some(dt.timestamp_millis());
+    }
+    let dot = s.find('.')?;
+    let (head, rest) = s.split_at(dot);
+    let rest = &rest[1..];
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    let tz: String = rest.chars().skip_while(|c| c.is_ascii_digit()).collect();
+    if digits.is_empty() {
+        return None;
+    }
+    let frac: String = digits.chars().chain(std::iter::repeat('0')).take(6).collect();
+    DateTime::parse_from_rfc3339(&format!("{head}.{frac}{tz}"))
+        .ok()
+        .map(|dt| dt.timestamp_millis())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn labels(metrics: &[Metric]) -> Vec<&str> {
+        metrics.iter().map(|m| m.label.as_str()).collect()
+    }
+
+    #[test]
+    fn session_then_weekly_like_claude() {
+        let doc = json!({
+            "usage": {
+                "limit": "2048",
+                "used": "214",
+                "remaining": "1834",
+                "resetTime": "2026-01-09T15:23:13.716839Z"
+            },
+            "limits": [{
+                "window": {"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"},
+                "detail": {
+                    "limit": "200",
+                    "used": "139",
+                    "remaining": "61",
+                    "resetTime": "2026-01-06T13:33:02.717479433Z"
+                }
+            }],
+            "user": {"membership": {"level": "LEVEL_INTERMEDIATE"}}
+        });
+        let snap = parse_snapshot(&doc).expect("parse");
+        assert_eq!(snap.id, "kimi");
+        assert_eq!(snap.name, "Kimi Code");
+        assert_eq!(snap.plan.as_deref(), Some("Moderato"));
+        assert_eq!(labels(&snap.metrics), ["Session", "Weekly"]);
+        let session = &snap.metrics[0];
+        assert!((session.used_percent.unwrap() - 69.5).abs() < 0.01);
+        assert_eq!(session.period_ms, Some(5 * HOUR_MS));
+        assert!(session.resets_at.is_some());
+        let weekly = &snap.metrics[1];
+        assert!((weekly.used_percent.unwrap() - (214.0 / 2048.0 * 100.0)).abs() < 0.01);
+        assert_eq!(weekly.period_ms, Some(7 * DAY_MS));
+    }
+
+    #[test]
+    fn remaining_without_used_still_meters() {
+        let doc = json!({
+            "usage": {"limit": "100", "remaining": "74", "resetTime": "2026-02-11T17:32:50.757941Z"},
+            "limits": [{
+                "window": {"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"},
+                "detail": {"limit": "100", "remaining": "85", "resetTime": "2026-02-07T12:32:50.757941Z"}
+            }]
+        });
+        let snap = parse_snapshot(&doc).expect("parse");
+        assert_eq!(labels(&snap.metrics), ["Session", "Weekly"]);
+        assert!((snap.metrics[0].used_percent.unwrap() - 15.0).abs() < 0.01);
+        assert!((snap.metrics[1].used_percent.unwrap() - 26.0).abs() < 0.01);
+        assert_eq!(snap.plan.as_deref(), None);
+    }
+
+    #[test]
+    fn weekly_limit_names_the_tier() {
+        let andante = json!({"usage": {"limit": 1024, "used": 10, "remaining": 1014}});
+        assert_eq!(parse_snapshot(&andante).unwrap().plan.as_deref(), Some("Andante"));
+        let allegro = json!({"usage": {"limit": "7168", "used": "0", "remaining": "7168"}});
+        assert_eq!(parse_snapshot(&allegro).unwrap().plan.as_deref(), Some("Allegretto"));
+    }
+
+    #[test]
+    fn ignores_non_session_windows() {
+        let doc = json!({
+            "usage": {"limit": "100", "used": "10", "remaining": "90"},
+            "limits": [{
+                "window": {"duration": 10080, "timeUnit": "TIME_UNIT_MINUTE"},
+                "detail": {"limit": "100", "used": "10", "remaining": "90"}
+            }]
+        });
+        let snap = parse_snapshot(&doc).expect("weekly-only is ok");
+        assert_eq!(labels(&snap.metrics), ["Weekly"]);
+    }
+
+    #[test]
+    fn empty_body_is_an_error() {
+        assert!(parse_snapshot(&json!({})).is_err());
+    }
+
+    #[test]
+    fn iso_with_extra_fractional_digits_parses() {
+        let ms = parse_iso_ms("2026-01-06T13:33:02.717479433Z").expect("ns iso");
+        let expected = DateTime::parse_from_rfc3339("2026-01-06T13:33:02.717479Z")
+            .unwrap()
+            .timestamp_millis();
+        assert_eq!(ms, expected);
+    }
+
+    #[test]
+    fn expires_at_seconds_and_millis() {
+        assert_eq!(expires_at_ms(Some(&json!(1_700_000_000))), 1_700_000_000_000);
+        assert_eq!(expires_at_ms(Some(&json!(1_700_000_000_000i64))), 1_700_000_000_000);
+        assert_eq!(expires_at_ms(Some(&json!("1700000000"))), 1_700_000_000_000);
+    }
+
+    #[test]
+    fn relative_kimi_code_home_is_ignored() {
+        assert!(absolute_home("relative/path").is_none());
+        assert!(absolute_home("").is_none());
+        assert!(absolute_home("  ").is_none());
+        #[cfg(windows)]
+        {
+            assert!(absolute_home(r"\Windows\System32").is_none());
+            assert!(absolute_home(r"C:\Users\jazii\.kimi-code").is_some());
+        }
+        #[cfg(not(windows))]
+        {
+            assert!(absolute_home("/home/me/.kimi-code").is_some());
+        }
+    }
+
+    #[test]
+    fn cred_candidates_prefer_kimi_home_then_dot_dirs() {
+        let kimi = PathBuf::from(r"D:\custom-kimi");
+        let user = PathBuf::from(r"C:\Users\me");
+        let paths = cred_candidates(Some(kimi), Some(user));
+        assert_eq!(
+            paths,
+            [
+                PathBuf::from(r"D:\custom-kimi\credentials\kimi-code.json"),
+                PathBuf::from(r"C:\Users\me\.kimi-code\credentials\kimi-code.json"),
+                PathBuf::from(r"C:\Users\me\.kimi\credentials\kimi-code.json"),
+            ]
+        );
+    }
+
+    #[test]
+    fn oversized_credentials_are_rejected() {
+        let dir = std::env::temp_dir().join(format!("pane-kimi-cred-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("kimi-code.json");
+        std::fs::write(&path, vec![b'x'; (MAX_CRED_BYTES as usize) + 1]).unwrap();
+        let err = crate::providers::read_small_text(&path, MAX_CRED_BYTES, "credentials").unwrap_err();
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+        assert!(err.contains("large"), "{err}");
+    }
+}

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -12,6 +12,7 @@ pub mod elevenlabs;
 pub mod grok;
 pub mod hermes;
 pub mod kilo;
+pub mod kimi;
 pub mod minimax;
 pub mod moonshot;
 pub mod ollama;
@@ -165,6 +166,39 @@ pub fn http() -> reqwest::Client {
         }
     }
     builder.build().expect("failed to build http client")
+}
+
+/// JSON bodies from vendor APIs are tiny (quota + token responses). Cap
+/// before parse so a huge payload can't stall a refresh or blow RAM —
+/// same idea as the share-card decode bound.
+pub(crate) async fn json_body(
+    resp: reqwest::Response,
+    max_bytes: usize,
+    what: &str,
+) -> Result<serde_json::Value, String> {
+    if resp.content_length().is_some_and(|n| n > max_bytes as u64) {
+        return Err(format!("{what}: response too large"));
+    }
+    let bytes = resp.bytes().await.map_err(|e| format!("{what}: {e}"))?;
+    if bytes.len() > max_bytes {
+        return Err(format!("{what}: response too large"));
+    }
+    serde_json::from_slice(&bytes).map_err(|e| format!("{what} parse: {e}"))
+}
+
+pub(crate) fn read_small_text(
+    path: &std::path::Path,
+    max_bytes: u64,
+    what: &str,
+) -> Result<String, String> {
+    let meta = std::fs::symlink_metadata(path).map_err(|e| format!("read {what}: {e}"))?;
+    if meta.file_type().is_symlink() || !meta.is_file() {
+        return Err(format!("{what} is not a regular file"));
+    }
+    if meta.len() > max_bytes {
+        return Err(format!("{what} is unexpectedly large — not reading it"));
+    }
+    std::fs::read_to_string(path).map_err(|e| format!("read {what}: {e}"))
 }
 
 /// Where Pane keeps its own settings, e.g. saved API keys:

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -352,6 +352,22 @@ pub(crate) fn account_scan_roots() -> Vec<std::path::PathBuf> {
     roots
 }
 
+/// True when Customize has this provider switched off. Disabled providers
+/// must not make network calls — including a folded-in wallet fetch that
+/// lives on another card (Kimi Code's Moonshot API bar).
+pub fn provider_disabled(id: &str) -> bool {
+    let Ok(raw) = std::fs::read_to_string(config_dir().join("config.json")) else {
+        return false;
+    };
+    let Ok(cfg) = serde_json::from_str::<serde_json::Value>(raw.trim_start_matches('\u{feff}'))
+    else {
+        return false;
+    };
+    cfg.get("disabled")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|a| a.iter().any(|v| v.as_str() == Some(id)))
+}
+
 /// API key lookup: our saved config file first, then environment variables.
 pub fn stored_api_key(provider: &str, env_vars: &[&str]) -> Option<String> {
     let path = config_dir().join(format!("{provider}.json"));

--- a/src-tauri/src/providers/moonshot.rs
+++ b/src-tauri/src/providers/moonshot.rs
@@ -25,11 +25,22 @@ pub fn has_api_key() -> bool {
     stored_api_key("moonshot", &["MOONSHOT_API_KEY", "KIMI_API_KEY"]).is_some()
 }
 
+/// Wallet fetch is allowed only with a saved key *and* Moonshot switched
+/// on. A disabled Moonshot must not be contacted via the folded Kimi card.
+pub fn wallet_wanted() -> bool {
+    wallet_wanted_from(has_api_key(), super::provider_disabled("moonshot"))
+}
+
+fn wallet_wanted_from(has_key: bool, moonshot_disabled: bool) -> bool {
+    has_key && !moonshot_disabled
+}
+
 /// Wallet rows for the Kimi Code card (Session / Weekly / API). Empty `Ok`
-/// when no key is saved — the plan bars still stand on their own. `Err`
-/// is a failed balance call the caller can warn on without failing the plan.
+/// when no key is saved or Moonshot is off — the plan bars still stand on
+/// their own. `Err` is a failed balance call the caller can warn on
+/// without failing the plan.
 pub async fn api_rows() -> Result<Vec<Metric>, String> {
-    if !has_api_key() {
+    if !wallet_wanted() {
         return Ok(Vec::new());
     }
     fetch_balance(true).await
@@ -167,5 +178,13 @@ mod tests {
             rows.iter().map(|m| m.label.as_str()).collect::<Vec<_>>(),
             ["Balance", "Cash"]
         );
+    }
+
+    #[test]
+    fn wallet_stays_off_when_moonshot_is_disabled() {
+        assert!(wallet_wanted_from(true, false));
+        assert!(!wallet_wanted_from(true, true));
+        assert!(!wallet_wanted_from(false, false));
+        assert!(!wallet_wanted_from(false, true));
     }
 }

--- a/src-tauri/src/providers/moonshot.rs
+++ b/src-tauri/src/providers/moonshot.rs
@@ -1,8 +1,10 @@
 use super::{http, stored_api_key, Metric, Snapshot};
 use serde_json::Value;
+use std::time::Duration;
 
 const ID: &str = "moonshot";
 const NAME: &str = "Moonshot";
+const MAX_BALANCE_BYTES: usize = 64 * 1024;
 
 // Global platform first, mainland China second — same key shape either way.
 const ENDPOINTS: [&str; 2] = [
@@ -17,18 +19,50 @@ pub async fn snapshot() -> Snapshot {
     }
 }
 
+/// True when a Moonshot/Kimi API key is saved or in the environment.
+/// Plan-only installs have none — the Kimi card then skips the API row.
+pub fn has_api_key() -> bool {
+    stored_api_key("moonshot", &["MOONSHOT_API_KEY", "KIMI_API_KEY"]).is_some()
+}
+
+/// Wallet rows for the Kimi Code card (Session / Weekly / API). Empty when
+/// no key is saved — the plan bars still stand on their own.
+pub async fn api_rows() -> Vec<Metric> {
+    if !has_api_key() {
+        return Vec::new();
+    }
+    match fetch_balance(true).await {
+        Ok(rows) => rows,
+        Err(_) => Vec::new(),
+    }
+}
+
 async fn fetch() -> Result<Snapshot, String> {
-    let Some(key) = stored_api_key("moonshot", &["MOONSHOT_API_KEY", "KIMI_API_KEY"]) else {
+    if stored_api_key("moonshot", &["MOONSHOT_API_KEY", "KIMI_API_KEY"]).is_none() {
         return Ok(Snapshot::no_credentials(
             ID,
             NAME,
             "Paste a Moonshot (Kimi) API key in Settings (gear icon).",
         ));
+    }
+    let rows = fetch_balance(false).await?;
+    Ok(Snapshot::ok(ID, NAME, Some("Pay as you go".into()), rows))
+}
+
+async fn fetch_balance(api_label: bool) -> Result<Vec<Metric>, String> {
+    let Some(key) = stored_api_key("moonshot", &["MOONSHOT_API_KEY", "KIMI_API_KEY"]) else {
+        return Err("no key".into());
     };
 
     let mut last_err = String::from("no endpoint reachable");
     for url in ENDPOINTS {
-        let resp = match http().get(url).bearer_auth(&key).send().await {
+        let resp = match http()
+            .get(url)
+            .bearer_auth(&key)
+            .timeout(Duration::from_secs(8))
+            .send()
+            .await
+        {
             Ok(r) => r,
             Err(e) => {
                 last_err = format!("balance request: {e}");
@@ -43,7 +77,13 @@ async fn fetch() -> Result<Snapshot, String> {
             last_err = format!("balance endpoint: HTTP {}", resp.status());
             continue;
         }
-        let doc: Value = resp.json().await.map_err(|e| format!("balance parse: {e}"))?;
+        let doc: Value = match super::json_body(resp, MAX_BALANCE_BYTES, "balance").await {
+            Ok(d) => d,
+            Err(e) => {
+                last_err = e;
+                continue;
+            }
+        };
         let data = doc.get("data").unwrap_or(&doc);
         let available = data.get("available_balance").and_then(Value::as_f64);
         let voucher = data.get("voucher_balance").and_then(Value::as_f64);
@@ -54,22 +94,80 @@ async fn fetch() -> Result<Snapshot, String> {
             continue;
         };
         let sign = if url.contains(".cn") { "¥" } else { "$" };
-        let mut metrics = Vec::new();
-        // A percent bar against the highest balance ever seen — gives the
-        // card a usage line and feeds the low-credit notifications.
-        if let Some(meter) = super::credit_meter(ID, sign, available) {
-            metrics.push(meter);
-        }
-        metrics.push(Metric::text("Balance", format!("{sign}{available:.2}")));
-        if let Some(v) = voucher {
-            if v > 0.0 {
-                metrics.push(Metric::text("Vouchers", format!("{sign}{v:.2}")));
-            }
-        }
-        if let Some(c) = cash {
-            metrics.push(Metric::text("Cash", format!("{sign}{c:.2}")));
-        }
-        return Ok(Snapshot::ok(ID, NAME, Some("Pay as you go".into()), metrics));
+        return Ok(rows_from_balance(available, voucher, cash, sign, api_label));
     }
     Err(last_err)
+}
+
+fn rows_from_balance(
+    available: f64,
+    voucher: Option<f64>,
+    cash: Option<f64>,
+    sign: &str,
+    api_label: bool,
+) -> Vec<Metric> {
+    let mut metrics = Vec::new();
+    // High-water key stays "moonshot" so a fold onto the Kimi card keeps
+    // the same Credits-used baseline the Moonshot card already learned.
+    let label = wallet_label(api_label);
+    if let Some(meter) = super::credit_meter_labeled(ID, sign, available, label, "") {
+        metrics.push(meter);
+    }
+    metrics.extend(text_rows(available, voucher, cash, sign, api_label));
+    metrics
+}
+
+fn wallet_label(api_label: bool) -> &'static str {
+    if api_label {
+        "API"
+    } else {
+        "Credits used"
+    }
+}
+
+fn text_rows(
+    available: f64,
+    voucher: Option<f64>,
+    cash: Option<f64>,
+    sign: &str,
+    api_label: bool,
+) -> Vec<Metric> {
+    let mut metrics = Vec::new();
+    metrics.push(Metric::text("Balance", format!("{sign}{available:.2}")));
+    if let Some(v) = voucher {
+        if v > 0.0 {
+            metrics.push(Metric::text("Vouchers", format!("{sign}{v:.2}")));
+        }
+    }
+    if let Some(c) = cash {
+        if !api_label || c > 0.0 {
+            metrics.push(Metric::text("Cash", format!("{sign}{c:.2}")));
+        }
+    }
+    metrics
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kimi_fold_labels_the_wallet_api() {
+        assert_eq!(wallet_label(true), "API");
+        let rows = text_rows(80.0, Some(80.0), Some(0.0), "$", true);
+        assert_eq!(
+            rows.iter().map(|m| m.label.as_str()).collect::<Vec<_>>(),
+            ["Balance", "Vouchers"]
+        );
+    }
+
+    #[test]
+    fn standalone_moonshot_keeps_credits_used() {
+        assert_eq!(wallet_label(false), "Credits used");
+        let rows = text_rows(50.0, None, Some(0.0), "$", false);
+        assert_eq!(
+            rows.iter().map(|m| m.label.as_str()).collect::<Vec<_>>(),
+            ["Balance", "Cash"]
+        );
+    }
 }

--- a/src-tauri/src/providers/moonshot.rs
+++ b/src-tauri/src/providers/moonshot.rs
@@ -25,16 +25,14 @@ pub fn has_api_key() -> bool {
     stored_api_key("moonshot", &["MOONSHOT_API_KEY", "KIMI_API_KEY"]).is_some()
 }
 
-/// Wallet rows for the Kimi Code card (Session / Weekly / API). Empty when
-/// no key is saved — the plan bars still stand on their own.
-pub async fn api_rows() -> Vec<Metric> {
+/// Wallet rows for the Kimi Code card (Session / Weekly / API). Empty `Ok`
+/// when no key is saved — the plan bars still stand on their own. `Err`
+/// is a failed balance call the caller can warn on without failing the plan.
+pub async fn api_rows() -> Result<Vec<Metric>, String> {
     if !has_api_key() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
-    match fetch_balance(true).await {
-        Ok(rows) => rows,
-        Err(_) => Vec::new(),
-    }
+    fetch_balance(true).await
 }
 
 async fn fetch() -> Result<Snapshot, String> {

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -1585,7 +1585,7 @@ fn devin_model(raw: &str) -> String {
 /// One Kimi Code CLI wire.jsonl line → spend event. usage.record rows are
 /// self-contained: model, token buckets, epoch-ms time. Only the "turn"
 /// scope counts — other scopes would double-report the same tokens.
-fn moonshot_line(line: &str, data: &mut FileData) {
+fn kimi_line(line: &str, data: &mut FileData) {
     if !line.contains("\"usage.record\"") {
         return;
     }
@@ -1691,21 +1691,19 @@ fn qwen() -> ProviderSpend {
     build_spend("qwen", "Qwen Code", all)
 }
 
-/// Moonshot spend: Kimi Code CLI sessions under ~/.kimi-code/sessions —
-/// each agent's wire.jsonl logs one usage.record per turn.
-fn moonshot() -> ProviderSpend {
-    let root = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".kimi-code")
-        .join("sessions");
+/// Kimi Code spend: CLI sessions under ~/.kimi-code/sessions — each
+/// agent's wire.jsonl logs one usage.record per turn. Lives on the plan
+/// card (not Moonshot PAYG).
+fn kimi() -> ProviderSpend {
+    let root = providers::kimi::code_home().join("sessions");
     let mut files = Vec::new();
     recent_jsonl_files(&root, &mut files);
     let mut all = FileData::default();
     for file in files {
-        let data = file_days(&file, &mut |line, data| moonshot_line(line, data));
+        let data = file_days(&file, &mut |line, data| kimi_line(line, data));
         merge_data(&mut all, data);
     }
-    build_spend("moonshot", "Moonshot", all)
+    build_spend("kimi", "Kimi Code", all)
 }
 
 /// Cursor spend from the dashboard's usage-events CSV export (fetched by the
@@ -2189,7 +2187,7 @@ mod tests {
     }
 
     #[test]
-    fn moonshot_counts_turn_records_only() {
+    fn kimi_counts_turn_records_only() {
         let mut data = FileData::default();
         let turn = json!({"type": "usage.record", "model": "moonshot-ai/kimi-test-model",
             "usage": {"inputOther": 400.0, "output": 200.0, "inputCacheRead": 300.0,
@@ -2197,8 +2195,8 @@ mod tests {
             "usageScope": "turn", "time": 1784208630652i64})
         .to_string();
         let session_scope = turn.replace("\"turn\"", "\"session\"");
-        moonshot_line(&turn, &mut data);
-        moonshot_line(&session_scope, &mut data);
+        kimi_line(&turn, &mut data);
+        kimi_line(&session_scope, &mut data);
         // One event; unknown model → tokens counted, dollars honest zero.
         assert_eq!(data.days.values().map(|v| v.1).sum::<f64>(), 1_000.0);
         assert_eq!(data.unpriced.get("kimi-test-model"), Some(&1));
@@ -2405,7 +2403,7 @@ pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
         aihubmix_sp,
         devin(),
         minimax(minimax_extra),
-        moonshot(),
+        kimi(),
         qwen(),
     ];
     list.extend(extra_claude_spends);

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -1693,9 +1693,9 @@ fn qwen() -> ProviderSpend {
 
 /// Kimi Code spend: CLI sessions under ~/.kimi-code/sessions — each
 /// agent's wire.jsonl logs one usage.record per turn. Files on the plan
-/// card when that login exists; otherwise they stay on Moonshot so
-/// API-only installs (and leftover logs with no `kimi login`) don't lose
-/// the dollars to a disabled no-credentials Kimi card.
+/// card when that login exists *and* the card is on; otherwise they stay
+/// on Moonshot so API-only installs (and leftover logs, or a Kimi card
+/// still sitting in Disabled after `kimi login`) don't lose the dollars.
 fn kimi() -> ProviderSpend {
     let root = providers::kimi::code_home().join("sessions");
     let mut files = Vec::new();
@@ -1705,12 +1705,15 @@ fn kimi() -> ProviderSpend {
         let data = file_days(&file, &mut |line, data| kimi_line(line, data));
         merge_data(&mut all, data);
     }
-    let (id, name) = kimi_spend_target(providers::kimi::has_login());
+    let (id, name) = kimi_spend_target(
+        providers::kimi::has_login(),
+        providers::provider_disabled("kimi"),
+    );
     build_spend(id, name, all)
 }
 
-fn kimi_spend_target(has_login: bool) -> (&'static str, &'static str) {
-    if has_login {
+fn kimi_spend_target(has_login: bool, kimi_disabled: bool) -> (&'static str, &'static str) {
+    if has_login && !kimi_disabled {
         ("kimi", "Kimi Code")
     } else {
         ("moonshot", "Moonshot")
@@ -2216,8 +2219,10 @@ mod tests {
 
     #[test]
     fn kimi_spend_stays_on_moonshot_without_login() {
-        assert_eq!(kimi_spend_target(true), ("kimi", "Kimi Code"));
-        assert_eq!(kimi_spend_target(false), ("moonshot", "Moonshot"));
+        assert_eq!(kimi_spend_target(true, false), ("kimi", "Kimi Code"));
+        assert_eq!(kimi_spend_target(false, false), ("moonshot", "Moonshot"));
+        assert_eq!(kimi_spend_target(true, true), ("moonshot", "Moonshot"));
+        assert_eq!(kimi_spend_target(false, true), ("moonshot", "Moonshot"));
     }
 
     /// Live diagnostic (ignored): what each spend source produced from

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -1692,8 +1692,10 @@ fn qwen() -> ProviderSpend {
 }
 
 /// Kimi Code spend: CLI sessions under ~/.kimi-code/sessions — each
-/// agent's wire.jsonl logs one usage.record per turn. Lives on the plan
-/// card (not Moonshot PAYG).
+/// agent's wire.jsonl logs one usage.record per turn. Files on the plan
+/// card when that login exists; otherwise they stay on Moonshot so
+/// API-only installs (and leftover logs with no `kimi login`) don't lose
+/// the dollars to a disabled no-credentials Kimi card.
 fn kimi() -> ProviderSpend {
     let root = providers::kimi::code_home().join("sessions");
     let mut files = Vec::new();
@@ -1703,7 +1705,16 @@ fn kimi() -> ProviderSpend {
         let data = file_days(&file, &mut |line, data| kimi_line(line, data));
         merge_data(&mut all, data);
     }
-    build_spend("kimi", "Kimi Code", all)
+    let (id, name) = kimi_spend_target(providers::kimi::has_login());
+    build_spend(id, name, all)
+}
+
+fn kimi_spend_target(has_login: bool) -> (&'static str, &'static str) {
+    if has_login {
+        ("kimi", "Kimi Code")
+    } else {
+        ("moonshot", "Moonshot")
+    }
 }
 
 /// Cursor spend from the dashboard's usage-events CSV export (fetched by the
@@ -2201,6 +2212,12 @@ mod tests {
         assert_eq!(data.days.values().map(|v| v.1).sum::<f64>(), 1_000.0);
         assert_eq!(data.unpriced.get("kimi-test-model"), Some(&1));
         assert!(data.days.keys().all(|(_, m)| m == "kimi-test-model"));
+    }
+
+    #[test]
+    fn kimi_spend_stays_on_moonshot_without_login() {
+        assert_eq!(kimi_spend_target(true), ("kimi", "Kimi Code"));
+        assert_eq!(kimi_spend_target(false), ("moonshot", "Moonshot"));
     }
 
     /// Live diagnostic (ignored): what each spend source produced from

--- a/src/assets/providers/kimi.svg
+++ b/src/assets/providers/kimi.svg
@@ -1,0 +1,3 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill="currentColor" d="M22 16h20v27.2L68.4 16H86L52.8 50 86 84H68.4L42 56.6V84H22V16z"/>
+</svg>

--- a/src/main.ts
+++ b/src/main.ts
@@ -513,11 +513,43 @@ function ensureLayout(): void {
     }
   }
 
-  if (config.pinned && providerFamily(config.pinned.provider) === "cursor") {
+    if (config.pinned && providerFamily(config.pinned.provider) === "cursor") {
     const renamed = CURSOR_RENAMES[config.pinned.label];
     const to = renamed ?? (totalIsText && config.pinned.label === "Total usage" ? "Cursor Models" : null);
     if (to) {
       config.pinned = { ...config.pinned, label: to };
+      void patchConfig({ pinned: config.pinned }).catch(() => {});
+    }
+  }
+
+  // Kimi Code folds the Moonshot wallet onto the plan card. Stars and the
+  // tray pin on "Credits used" would otherwise vanish with that card.
+  const kimiLive = lastSnapshots.some((s) => s.id === "kimi" && s.status === "ok");
+  if (kimiLive) {
+    const moonL = layout.providers.moonshot;
+    const starAt = moonL?.starred.indexOf("Credits used") ?? -1;
+    if (starAt >= 0 && moonL) {
+      moonL.starred.splice(starAt, 1);
+      let kimiL = layout.providers.kimi;
+      if (!kimiL) {
+        kimiL = defaultProviderLayout(
+          lastSnapshots.find((s) => s.id === "kimi"),
+          lastSpend.find((sp) => sp.id === "kimi"),
+          false,
+        );
+        layout.providers.kimi = kimiL;
+      }
+      if (!kimiL.starred.includes("API")) {
+        if (kimiL.starred.length >= 2) kimiL.starred.pop();
+        kimiL.starred.push("API");
+      }
+      changed = true;
+    }
+    if (
+      config.pinned?.provider === "moonshot" &&
+      (config.pinned.label === "Credits used" || config.pinned.label === "API")
+    ) {
+      config.pinned = { provider: "kimi", label: "API" };
       void patchConfig({ pinned: config.pinned }).catch(() => {});
     }
   }
@@ -1967,6 +1999,14 @@ function renderCustomize(): string {
       // fetched) — that one must keep rendering, or its re-enable toggle
       // vanishes with it and the account is stuck off forever.
       if (id.includes("@") && !snapshot && !config.disabled.includes(id)) return "";
+      // Folded into the Kimi Code card while that plan is connected —
+      // keep Moonshot in saved layout, just don't show a ghost toggle.
+      if (
+        id === "moonshot" &&
+        lastSnapshots.some((s) => s.id === "kimi" && s.status === "ok")
+      ) {
+        return "";
+      }
       // Dynamic account cards carry their name in the snapshot
       // ("Claude — Org"); static providers come from the fixed list.
       const name = ALL_PROVIDERS.find(([pid]) => pid === id)?.[1] ?? snapshot?.name ?? id;
@@ -2316,14 +2356,11 @@ async function refresh(force = false): Promise<void> {
         await patchConfig({ layout: config.layout, disabled: prunedDisabled }).catch(() => {});
       }
     }
-    // One Kimi card (Session / Weekly / API). Fold the leftover Moonshot
-    // wallet away in Customize so it isn't enabled-but-invisible.
-    if (
-      snapshots.some((s) => s.id === "kimi" && s.status === "ok") &&
-      !config.disabled.includes("moonshot")
-    ) {
+    // One Kimi card (Session / Weekly / API). Hide the leftover Moonshot
+    // wallet at render time only — don't write it into Disabled, or the
+    // card would stay gone after Kimi Code is disconnected.
+    if (snapshots.some((s) => s.id === "kimi" && s.status === "ok")) {
       snapshots = snapshots.filter((s) => s.id !== "moonshot");
-      await patchConfig({ disabled: [...config.disabled, "moonshot"] }).catch(() => {});
     }
     const firstData = lastSnapshots.length === 0;
     lastFetch = Date.now();

--- a/src/main.ts
+++ b/src/main.ts
@@ -2270,6 +2270,13 @@ function renderIfVisible(): void {
   populatePinnedOptions();
 }
 
+function hideFoldedMoonshot(snapshots: Snapshot[]): Snapshot[] {
+  if (snapshots.some((s) => s.id === "kimi" && s.status === "ok")) {
+    return snapshots.filter((s) => s.id !== "moonshot");
+  }
+  return snapshots;
+}
+
 /// First paint from the previous run's snapshots (disk cache): numbers on
 /// screen in milliseconds instead of a blank "Refreshing…" while the
 /// slowest provider answers — at boot that wait ran 30-40 seconds. Cards
@@ -2279,7 +2286,7 @@ async function paintCachedSnapshots(): Promise<void> {
   // anyway, and refresh()'s first-launch detection must see the live list.
   if (config.layout === null) return;
   try {
-    const cached = await invoke<Snapshot[]>("cached_usage");
+    const cached = hideFoldedMoonshot(await invoke<Snapshot[]>("cached_usage"));
     // The live fetch may have already landed — never paint over it.
     if (!cached.length || lastSnapshots.length) return;
     lastSnapshots = cached;
@@ -2356,12 +2363,7 @@ async function refresh(force = false): Promise<void> {
         await patchConfig({ layout: config.layout, disabled: prunedDisabled }).catch(() => {});
       }
     }
-    // One Kimi card (Session / Weekly / API). Hide the leftover Moonshot
-    // wallet at render time only — don't write it into Disabled, or the
-    // card would stay gone after Kimi Code is disconnected.
-    if (snapshots.some((s) => s.id === "kimi" && s.status === "ok")) {
-      snapshots = snapshots.filter((s) => s.id !== "moonshot");
-    }
+    snapshots = hideFoldedMoonshot(snapshots);
     const firstData = lastSnapshots.length === 0;
     lastFetch = Date.now();
     lastSnapshots = snapshots;

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import cursorIcon from "./assets/providers/cursor.svg?raw";
 import devinIcon from "./assets/providers/devin.svg?raw";
 import grokIcon from "./assets/providers/grok.svg?raw";
 import hermesIcon from "./assets/providers/hermes.svg?raw";
+import kimiIcon from "./assets/providers/kimi.svg?raw";
 import minimaxIcon from "./assets/providers/minimax.svg?raw";
 import opencodeIcon from "./assets/providers/opencode.svg?raw";
 import openrouterIcon from "./assets/providers/openrouter.svg?raw";
@@ -38,6 +39,7 @@ const PROVIDER_ICONS: Record<string, string> = {
   devin: devinIcon,
   grok: grokIcon,
   hermes: hermesIcon,
+  kimi: kimiIcon,
   minimax: minimaxIcon,
   opencode: opencodeIcon,
   openrouter: openrouterIcon,
@@ -104,6 +106,7 @@ const RELOGIN: Record<string, string> = {
   antigravity: "open Antigravity and sign in again",
   ollama: "make sure Ollama is running",
   hermes: "open the Hermes desktop app once so it writes its local ledger",
+  kimi: "run `kimi login` in a terminal",
 };
 
 /// The ⚠ Outdated tooltip: what went wrong, what fixes it, and the
@@ -209,6 +212,7 @@ const ALL_PROVIDERS: [string, string][] = [
   ["aihubmix", "AihubMix"],
   ["qwen", "Qwen Code"],
   ["hermes", "Hermes"],
+  ["kimi", "Kimi Code"],
 ];
 
 // Same quick links the Mac app ships (status pages + vendor dashboards).
@@ -258,6 +262,11 @@ const PROVIDER_LINKS: Record<string, { label: string; url: string }[]> = {
   codebuff: [{ label: "Dashboard", url: "https://www.codebuff.com/profile" }],
   kilo: [{ label: "Dashboard", url: "https://app.kilo.ai/" }],
   hermes: [{ label: "Site", url: "https://hermes-agent.com/" }],
+  kimi: [
+    { label: "Console", url: "https://www.kimi.com/code/console" },
+    { label: "Quota", url: "https://www.kimi.com/membership/subscription?tab=quota" },
+    { label: "API", url: "https://platform.moonshot.ai/console" },
+  ],
 };
 
 // Brand palette for the Total Spend ring (Mac parity); unknown providers
@@ -274,6 +283,7 @@ const SPEND_COLORS: Record<string, string> = {
   devin: "#38bdf8",
   cursor: "var(--spend-cursor)", // brand black, theme-flipped in CSS
   moonshot: "#e0b354", // moon gold
+  kimi: "#ff8a4c", // Kimi Code peach
   hermes: "#c2a878", // Nous tan
   aihubmix: "#5eead4", // hub teal
   qwen: "#8b5cf6", // Qwen violet
@@ -877,6 +887,7 @@ function renderCard(s: Snapshot): string {
     ? `<span class="stale" title="${escapeHtml(staleHelp(s))}">⚠ Outdated</span>`
     : "";
   const links = (PROVIDER_LINKS[s.id] ?? PROVIDER_LINKS[providerFamily(s.id)] ?? [])
+    .filter((l) => l.label !== "API" || s.metrics.some((m) => m.label === "API"))
     .map((l) => `<button class="quick-link" data-link="${escapeHtml(l.url)}">${escapeHtml(l.label)}</button>`)
     .join("<span class='quick-sep'>·</span>");
   const linksRow = links ? `<div class="quick-links">${links}</div>` : "";
@@ -2304,6 +2315,15 @@ async function refresh(force = false): Promise<void> {
         for (const id of staleLayout) delete config.layout.providers[id];
         await patchConfig({ layout: config.layout, disabled: prunedDisabled }).catch(() => {});
       }
+    }
+    // One Kimi card (Session / Weekly / API). Fold the leftover Moonshot
+    // wallet away in Customize so it isn't enabled-but-invisible.
+    if (
+      snapshots.some((s) => s.id === "kimi" && s.status === "ok") &&
+      !config.disabled.includes("moonshot")
+    ) {
+      snapshots = snapshots.filter((s) => s.id !== "moonshot");
+      await patchConfig({ disabled: [...config.disabled, "moonshot"] }).catch(() => {});
     }
     const firstData = lastSnapshots.length === 0;
     lastFetch = Date.now();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1999,14 +1999,10 @@ function renderCustomize(): string {
       // fetched) — that one must keep rendering, or its re-enable toggle
       // vanishes with it and the account is stuck off forever.
       if (id.includes("@") && !snapshot && !config.disabled.includes(id)) return "";
-      // Folded into the Kimi Code card while that plan is connected —
-      // keep Moonshot in saved layout, just don't show a ghost toggle.
-      if (
-        id === "moonshot" &&
-        lastSnapshots.some((s) => s.id === "kimi" && s.status === "ok")
-      ) {
-        return "";
-      }
+      // Moonshot's leftover *card* is folded into Kimi on the dashboard,
+      // but this toggle still owns the wallet: off means no Moonshot HTTP
+      // and no API bar on the Kimi card. Hide it and there's no way to
+      // stop those calls.
       // Dynamic account cards carry their name in the snapshot
       // ("Claude — Org"); static providers come from the fixed list.
       const name = ALL_PROVIDERS.find(([pid]) => pid === id)?.[1] ?? snapshot?.name ?? id;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2271,7 +2271,12 @@ function renderIfVisible(): void {
 }
 
 function hideFoldedMoonshot(snapshots: Snapshot[]): Snapshot[] {
-  if (snapshots.some((s) => s.id === "kimi" && s.status === "ok")) {
+  const kimi = snapshots.find((s) => s.id === "kimi" && s.status === "ok");
+  if (!kimi) return snapshots;
+  const wallet = (s: Snapshot) =>
+    s.metrics.some((m) => ["API", "Credits used", "Balance", "Vouchers", "Cash"].includes(m.label));
+  const moon = snapshots.find((s) => s.id === "moonshot");
+  if (wallet(kimi) || !moon || moon.metrics.length === 0) {
     return snapshots.filter((s) => s.id !== "moonshot");
   }
   return snapshots;

--- a/src/main.ts
+++ b/src/main.ts
@@ -523,8 +523,12 @@ function ensureLayout(): void {
   }
 
   // Kimi Code folds the Moonshot wallet onto the plan card. Stars and the
-  // tray pin on "Credits used" would otherwise vanish with that card.
-  const kimiLive = lastSnapshots.some((s) => s.id === "kimi" && s.status === "ok");
+  // tray pin on "Credits used" would otherwise vanish with that card —
+  // but only migrate when the API bar is actually on that card, or we
+  // plant a phantom star and the tray number goes blank.
+  const kimiLive = lastSnapshots.some(
+    (s) => s.id === "kimi" && s.status === "ok" && s.metrics.some((m) => m.label === "API"),
+  );
   if (kimiLive) {
     const moonL = layout.providers.moonshot;
     const starAt = moonL?.starred.indexOf("Credits used") ?? -1;


### PR DESCRIPTION
## Summary
- New **Kimi Code** card from the official CLI login (`kimi login`): Session (5h) and Weekly bars, with the plan name (Andante / Moderato / Allegretto).
- If a Moonshot wallet key is saved, an **API** bar joins that card; plan-only installs stay at two bars. The leftover Moonshot card hides while Kimi Code is connected and still shows for API-only installs.
- Local `wire.jsonl` spend moves onto this card. Credential and API reads are size-capped; relative `KIMI_CODE_HOME` is ignored; the session-log walk does not add extra directory canonicalize.

## Test plan
- [ ] With `kimi login` only: Session + Weekly, no API row, no Moonshot card.
- [ ] With a Moonshot key saved: Session + Weekly + API; Balance/Vouchers behind Show more.
- [ ] API-only (no Kimi login): Moonshot card still appears.
- [ ] Refresh stays snappy (no 0.4.37-style log-walk lag).
- [ ] Spend (Today / Yesterday / Last 30 Days) sits on the Kimi card.
- [ ] Do not ship a release until this has been tested locally.

Made with Cursor

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->