### PR TITLE
Release 0.4.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.39 — 2026-08-19
 
 ### Added
 - **Kimi Code plan card** — one card like OpenCode: Session and Weekly

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ One click on the tray icon answers the questions every AI power user keeps
 asking: *How much of my Claude session is left? When does my Codex weekly
 reset? What did today actually cost me?*
 
-**[pane.jazii.dev](https://pane.jazii.dev)** · [Install](#install) · [How it works](#how-it-works) · [Providers](#providers-17-and-counting) · [Features](#features) · [Privacy](#privacy--security) · [Credits](#credits)
+**[pane.jazii.dev](https://pane.jazii.dev)** · [Install](#install) · [How it works](#how-it-works) · [Providers](#providers-21-and-counting) · [Features](#features) · [Privacy](#privacy--security) · [Credits](#credits)
 
 <img src="docs/promo.png" width="760" alt="Pane — track all your AI subscription limits in one tray app: Total Spend donut with per-provider slices, usage cards with pace bars" />
 
@@ -146,7 +146,7 @@ statistic (random ID, version, which providers are enabled, provider
 success/failure counts — never amounts or error text) — see
 [Privacy](#privacy--security) for the full contract and the off switch.
 
-## Providers (20 and counting)
+## Providers (21 and counting)
 
 | Provider | How Pane connects |
 |---|---|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Roadmap — full Mac parity (and beyond)
 
-**Status (v0.4.6+, 2026-07-10): every wave below is shipped, and the
+**Status (v0.4.39, 2026-08-19): every wave below is shipped, and the
 post-launch releases keep going.** Pane has full feature parity with the
-macOS original plus 18 providers, signed auto-updates published by CI,
+macOS original plus 21 providers, signed auto-updates published by CI,
 Codex reset-credit redemption, update-check-on-open with a one-click
 footer button, live model pricing that re-prices within the hour when
 new models appear, modern Cursor plan support, and a Mac-parity design

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -193,8 +193,13 @@ Ground rules that apply to every provider:
   pay-as-you-go wallet on the same card.
 - **Shows:** Session (5-hour) and Weekly bars with reset pacing, plan
   name (Andante / Moderato / Allegretto when the weekly quota matches).
-  The **API** bar (credits used vs the highest balance Pane has seen)
-  only appears when a Moonshot/Kimi API key is saved — plan-only
+  Those two windows are the same clocks as Kimi's website "5-hour Code"
+  and "7-day Code" rows; the coding usage API currently reports remaining
+  as whole percents (`limit`/`remaining` of 100), so usage under 1% can
+  still show as 0% in Pane. The website's **Total usage** bar is a
+  separate monthly membership credit pool (Kimi chat + Code) and is not
+  on this card. The **API** bar (credits used vs the highest balance Pane
+  has seen) only appears when a Moonshot/Kimi API key is saved — plan-only
   installs never get a third quota row. Balance/Vouchers sit behind
   Show more on that bar. Local spend from
   `~\.kimi-code\sessions\**\wire.jsonl` (one usage.record per turn).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.38",
+  "version": "0.4.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.38",
+      "version": "0.4.39",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.38",
+  "version": "0.4.39",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.38"
+version = "0.4.39"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.38"
+version = "0.4.39"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.38",
+  "version": "0.4.39",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Version bump to 0.4.39 (`package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`) plus the CHANGELOG roll for the Kimi Code plan card (#146).
- Docs catch-up: README/ROADMAP now say 21 providers; `docs/providers.md` notes that Kimi Session/Weekly come from whole-percent remaining, so sub-1% usage can still show as 0% in Pane.

After merge: tag `v0.4.39` on the merge commit to build and publish the signed release.

## Test plan
- [x] Local install `Pane_0.4.39_x64-setup.exe /S /UPDATE` — ProductVersion is 0.4.39
- [x] Pane launched after the silent install
- [ ] Devin review

Made with Cursor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->