### PR TITLE
Price Kimi Code plan slugs at Moonshot's published first-party rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Kimi Code plan usage now has dollar amounts** — the official CLI logs
+  plan K3 as `kimi-code/k3` (and K2.7 Code as `kimi-for-coding`), which
+  missed the rate table, so Today could show a million tokens at $0.00.
+  Every current Moonshot model now uses the published API card
+  (K3 $3 / $15 / $0.30 cache; K2.7 Code $0.95 / $4 / $0.19; HighSpeed
+  is 2×; K2.6 $0.95 / $4 / $0.16; K2.5 $0.60 / $3 / $0.10; V1 8k/32k/128k
+  at $0.20/$2, $1/$3, $2/$5). Reseller catalog rows no longer override
+  those first-party rates. Codex OAuth (`kimi-oauth/k3`) and prefixed
+  API spellings share the same table. Discontinued K2 / kimi-latest
+  names still come from the public catalogs.
+
 ## 0.4.39 — 2026-08-19
 
 ### Added

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -202,7 +202,12 @@ Ground rules that apply to every provider:
   has seen) only appears when a Moonshot/Kimi API key is saved — plan-only
   installs never get a third quota row. Balance/Vouchers sit behind
   Show more on that bar. Local spend from
-  `~\.kimi-code\sessions\**\wire.jsonl` (one usage.record per turn).
+  `~\.kimi-code\sessions\**\wire.jsonl` (one usage.record per turn),
+  priced at Moonshot's published API rates (K3 $3/$15/$0.30 cache;
+  K2.7 Code $0.95/$4/$0.19, HighSpeed 2×; K2.6 $0.95/$4/$0.16;
+  K2.5 $0.60/$3/$0.10; V1 8k/32k/128k at $0.20/$2, $1/$3, $2/$5).
+  Plan logs name K3 `k3` / `kimi-code/k3` and K2.7 Code `kimi-for-coding`;
+  those map to the same cards as `kimi-k3` and `kimi-k2.7-code`.
   The separate Moonshot card is hidden while this card is connected.
   Switching Moonshot off in Customize still skips the wallet fetch (no
   API bar, no `api.moonshot.ai|cn` call). If the Kimi card is off,

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -705,9 +705,15 @@ fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
 /// Last-segment match so CLI plan logs (`kimi-code/k3`), API prefixes
 /// (`moonshot-ai/kimi-k3`), and Codex OAuth (`kimi-oauth/k3`) share one
 /// table. Cache writes unpublished → input rate.
+///
+/// Generic tails (`k3`, `k2.5`) only match when the slug is bare or under
+/// a Kimi/Moonshot prefix — `openrouter/k3` must not steal this card
+/// ahead of that provider's catalog row. Tails that already say `kimi-`
+/// / `moonshot-` (Fireworks `kimi-k2p7-code`) match under any prefix.
 fn kimi_vendor_price(canonical: &str) -> Option<Price> {
-    let bare = canonical.rsplit('/').next().unwrap_or(canonical);
-    match bare {
+    let bare = kimi_vendor_tail(canonical)?.to_ascii_lowercase();
+    match bare.as_str() {
+
         // platform.kimi.ai/docs/pricing/chat-k3 — k3-256k is the same API
         // rate card (the 2× figure on the membership page is plan *quota*,
         // not dollars).
@@ -736,6 +742,27 @@ fn kimi_vendor_price(canonical: &str) -> Option<Price> {
             Some(Price::flat(2.0, 5.0, 2.0, 2.0))
         }
         _ => None,
+    }
+}
+
+fn kimi_vendor_tail(canonical: &str) -> Option<&str> {
+    let lower = canonical.to_ascii_lowercase();
+    let tail = lower.rsplit('/').next().unwrap_or(lower.as_str());
+    let named = tail.starts_with("kimi") || tail.starts_with("moonshot");
+    let known_prefix = [
+        "moonshot-ai/",
+        "moonshotai/",
+        "kimi-code/",
+        "kimi-oauth/",
+        "moonshot/",
+        "kimi/",
+    ]
+    .iter()
+    .any(|p| lower.starts_with(p));
+    if named || known_prefix || !canonical.contains('/') {
+        canonical.rsplit('/').next()
+    } else {
+        None
     }
 }
 
@@ -1048,6 +1075,20 @@ mod tests {
         store.modelsdev.insert("kimi-k2.5".into(), Price::flat(0.50, 2.80, 0.125, 0.625));
         let p = super::resolve(&store, "kimi-k2.5", 0).unwrap();
         assert_eq!((p.input, p.output, p.cache_read), (0.60, 3.0, 0.10));
+    }
+
+    #[test]
+    fn kimi_vendor_ignores_foreign_prefix_on_short_tails() {
+        // Generic tails under another vendor must not steal Moonshot rates.
+        assert!(super::kimi_vendor_price("openrouter/k3").is_none());
+        assert!(super::kimi_vendor_price("acme/k2.5").is_none());
+        assert!(super::kimi_vendor_price("groq/k2.7-code").is_none());
+        // Bare plan ids and Kimi/Moonshot prefixes still match.
+        assert!(super::kimi_vendor_price("k3").is_some());
+        assert!(super::kimi_vendor_price("kimi-code/k3").is_some());
+        assert!(super::kimi_vendor_price("Kimi-OAuth/K3").is_some());
+        // A tail that already says kimi- is unambiguous even under Fireworks.
+        assert!(super::kimi_vendor_price("accounts/fireworks/models/kimi-k2p7-code").is_some());
     }
 
     #[test]

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -166,7 +166,7 @@ pub fn generation() -> u64 {
 /// fingerprinted below — an app update that reprices the same files would
 /// otherwise leave history at the old dollars until upstream happens to
 /// rewrite a catalog.
-const CORRECTIONS_REV: u32 = 7; // 7: GLM-5.3 AihubMix preview rates + last-segment dated DeepSeek
+const CORRECTIONS_REV: u32 = 8; // 8: Moonshot first-party Kimi rates (plan slugs + K3/K2.7/K2.6/K2.5/V1)
 /// The live OpenUsage supplement is ~105 alias rules (Daybreak, Cursor
 /// Router prose names, GPT-5.3–5.6 effort slugs). 64 silently dropped
 /// everything after `gpt-5.2`. Per-rule caps below still bound memory.
@@ -563,6 +563,24 @@ fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
     if let Some(p) = s.supplement.get(&canonical).filter(real) {
         return Some(*p);
     }
+    // Moonshot bills Pane's Kimi Code / API logs on its own card. LiteLLM
+    // and models.dev mix reseller markups and stubs that drop cache-hit
+    // rates, so first-party Kimi slugs take the published Moonshot table
+    // before those catalogs. Other baked models (DeepSeek, Grok, Qwen)
+    // still sit after catalogs so they self-retire.
+    if let Some(p) = kimi_vendor_price(&canonical) {
+        return Some(p);
+    }
+    // Kimi HighSpeed is a published 2× serving tier, not a distinct model.
+    // Only peel known Kimi bases so an unrelated `-highspeed` slug cannot
+    // inherit a 2× multiplier.
+    if let Some(base) = canonical.strip_suffix("-highspeed") {
+        if kimi_vendor_price(base).is_some() {
+            if let Some(p) = resolve(s, base, depth + 1) {
+                return Some(scaled_price(&p, 2.0));
+            }
+        }
+    }
     if let Some(p) = s.litellm.get(&canonical).filter(real) {
         return Some(*p);
     }
@@ -683,16 +701,53 @@ fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
     None
 }
 
-/// Kimi K3 — platform.kimi.ai/docs/pricing/chat-k3 (USD/MTok): input $3,
-/// cache hit $0.30, output $15; no published cache-write rate, so writes
-/// bill at the input rate. The `-code` spelling follows the K2.7 pattern
-/// (the supplement priced k2.7 and k2.7-code identically); "moonshot/" and
-/// "moonshot-ai/" prefixed spellings match how the CLIs log it.
+/// First-party Moonshot / Kimi rates from platform.kimi.ai (USD/MTok).
+/// Last-segment match so CLI plan logs (`kimi-code/k3`), API prefixes
+/// (`moonshot-ai/kimi-k3`), and Codex OAuth (`kimi-oauth/k3`) share one
+/// table. Cache writes unpublished → input rate.
+fn kimi_vendor_price(canonical: &str) -> Option<Price> {
+    let bare = canonical.rsplit('/').next().unwrap_or(canonical);
+    match bare {
+        // platform.kimi.ai/docs/pricing/chat-k3 — k3-256k is the same API
+        // rate card (the 2× figure on the membership page is plan *quota*,
+        // not dollars).
+        "k3" | "k3-256k" | "kimi-k3" | "kimi-k3-code" => Some(Price::flat(3.0, 15.0, 0.3, 3.0)),
+        // platform.kimi.ai/docs/pricing/chat-k27-code — Kimi Code's
+        // `kimi-for-coding` id is this model. HighSpeed is published at 2×.
+        // `kimi-k2p7*` is Fireworks' spelling of the same SKU.
+        "kimi-for-coding" | "kimi-k2.7-code" | "kimi-k2.7" | "k2.7-code"
+        | "kimi-k2p7-code" | "kimi-k2p7" => Some(Price::flat(0.95, 4.0, 0.19, 0.95)),
+        "kimi-for-coding-highspeed" | "kimi-k2.7-code-highspeed" | "k2.7-code-highspeed"
+        | "kimi-k2p7-code-highspeed" => Some(Price::flat(1.90, 8.0, 0.38, 1.90)),
+        // platform.kimi.ai/docs/pricing/chat-k26
+        "kimi-k2.6" | "kimi-k2p6" | "k2.6" => Some(Price::flat(0.95, 4.0, 0.16, 0.95)),
+        // platform.kimi.ai/docs/pricing/chat-k25
+        "kimi-k2.5" | "kimi-k2p5" | "k2.5" => Some(Price::flat(0.60, 3.0, 0.10, 0.60)),
+        // platform.kimi.ai/docs/pricing/chat-v1 — no cache-hit column;
+        // unpublished cache bills at the input rate. Vision SKUs share
+        // the same dollar card as the matching context size.
+        "moonshot-v1-8k" | "moonshot-v1-8k-vision-preview" | "moonshot-v1-8k-0430" => {
+            Some(Price::flat(0.20, 2.0, 0.20, 0.20))
+        }
+        "moonshot-v1-32k" | "moonshot-v1-32k-vision-preview" | "moonshot-v1-32k-0430" => {
+            Some(Price::flat(1.0, 3.0, 1.0, 1.0))
+        }
+        "moonshot-v1-128k" | "moonshot-v1-128k-vision-preview" | "moonshot-v1-128k-0430" => {
+            Some(Price::flat(2.0, 5.0, 2.0, 2.0))
+        }
+        _ => None,
+    }
+}
+
 fn builtin_price(canonical: &str) -> Option<Price> {
     // Gateways prefix the vendor slug (`xai/grok-4.6`, `deepseek/…`,
     // `accounts/fireworks/models/deepseek-v4-pro`). Peel to the last
     // path segment so one arm covers every spelling; catalogs still
-    // outrank this table because resolve() consults them first.
+    // outrank this table (except Kimi — see kimi_vendor_price) because
+    // resolve() consults them first.
+    if let Some(p) = kimi_vendor_price(canonical) {
+        return Some(p);
+    }
     let bare = canonical.rsplit('/').next().unwrap_or(canonical);
     match bare {
         // AihubMix DeepSeek V4 family — the gateway's OWN rate cards
@@ -716,7 +771,6 @@ fn builtin_price(canonical: &str) -> Option<Price> {
         // Hermes still prices its AihubMix `glm-5.3` rows by looking up
         // this SKU (see providers::hermes::price_lookup_slug).
         "coding-glm-5.3" => Some(Price::flat(0.06, 0.22, 0.06, 0.06)),
-        "kimi-k3" | "kimi-k3-code" => Some(Price::flat(3.0, 15.0, 0.3, 3.0)),
         // Alibaba Model Studio, GA'd 2026-08-03 (USD/MTok): input $2,
         // output $6, implicit cache read $0.25, explicit cache write $2.50.
         // Public catalogs still carry 0/0 placeholders for these slugs.
@@ -930,14 +984,70 @@ mod tests {
         for slug in [
             "kimi-k3",                    // Cursor / Devin bare
             "kimi-k3-code",               // Kimi Code CLI variant
+            "k3",                         // Kimi Code plan id (`kimi-code/k3`)
+            "k3-256k",                    // 256k K3 SKU, same API rates
             "moonshot/kimi-k3",           // catalog-style prefix
             "moonshot-ai/kimi-k3-code",   // Kimi CLI's own prefix
+            "kimi-code/k3",               // plan login, last-segment peel
+            "kimi-oauth/k3",              // Codex OAuth log
             "kimi-k3-high",               // effort tier → peels to base
             "kimi-k3-max",                // mode → peels to base
         ] {
             let p = super::lookup(slug).unwrap_or_else(|| panic!("{slug} did not price"));
             assert_eq!((p.input, p.output, p.cache_read), (3.0, 15.0, 0.3), "{slug}");
         }
+    }
+
+    #[test]
+    fn kimi_k27_code_and_highspeed_plan_spellings() {
+        // platform.kimi.ai/docs/pricing/chat-k27-code
+        for slug in [
+            "kimi-k2.7-code",
+            "kimi-for-coding",
+            "kimi-code/kimi-for-coding",
+        ] {
+            let p = super::lookup(slug).unwrap_or_else(|| panic!("{slug} did not price"));
+            assert_eq!((p.input, p.output, p.cache_read), (0.95, 4.0, 0.19), "{slug}");
+        }
+        for slug in [
+            "kimi-k2.7-code-highspeed",
+            "kimi-for-coding-highspeed",
+            "kimi-code/kimi-for-coding-highspeed",
+        ] {
+            let p = super::lookup(slug).unwrap_or_else(|| panic!("{slug} did not price"));
+            assert_eq!((p.input, p.output, p.cache_read), (1.90, 8.0, 0.38), "{slug}");
+        }
+    }
+
+    #[test]
+    fn kimi_k26_k25_and_v1_use_published_rates() {
+        for slug in ["kimi-k2.6", "moonshot-ai/kimi-k2.6", "kimi-k2p6"] {
+            let p = super::lookup(slug).unwrap_or_else(|| panic!("{slug} did not price"));
+            assert_eq!((p.input, p.output, p.cache_read), (0.95, 4.0, 0.16), "{slug}");
+        }
+        for slug in ["kimi-k2.5", "moonshot-ai/kimi-k2.5", "kimi-code/k2.5"] {
+            let p = super::lookup(slug).unwrap_or_else(|| panic!("{slug} did not price"));
+            assert_eq!((p.input, p.output, p.cache_read), (0.60, 3.0, 0.10), "{slug}");
+        }
+        for (slug, want) in [
+            ("moonshot-v1-8k", (0.20, 2.0, 0.20)),
+            ("moonshot-v1-8k-vision-preview", (0.20, 2.0, 0.20)),
+            ("moonshot-v1-32k", (1.0, 3.0, 1.0)),
+            ("moonshot-v1-128k", (2.0, 5.0, 2.0)),
+            ("moonshot-ai/moonshot-v1-128k-vision-preview", (2.0, 5.0, 2.0)),
+        ] {
+            let p = super::lookup(slug).unwrap_or_else(|| panic!("{slug} did not price"));
+            assert_eq!((p.input, p.output, p.cache_read), want, "{slug}");
+        }
+    }
+
+    #[test]
+    fn kimi_vendor_beats_reseller_catalog_stubs() {
+        let mut store = super::Store::default();
+        store.litellm.insert("kimi-k2.5".into(), Price::flat(0.60, 3.0, 0.60, 0.60));
+        store.modelsdev.insert("kimi-k2.5".into(), Price::flat(0.50, 2.80, 0.125, 0.625));
+        let p = super::resolve(&store, "kimi-k2.5", 0).unwrap();
+        assert_eq!((p.input, p.output, p.cache_read), (0.60, 3.0, 0.10));
     }
 
     #[test]

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -1598,8 +1598,12 @@ fn kimi_line(line: &str, data: &mut FileData) {
     }
     let Some(ts) = parse_ts(v.get("time")) else { return };
     let model_raw = v.get("model").and_then(Value::as_str).unwrap_or("unknown");
-    let model = model_raw
-        .strip_prefix("moonshot-ai/")
+    // CLI plan logs `kimi-code/k3`; API logs `moonshot-ai/kimi-k3`; Codex
+    // OAuth logs `kimi-oauth/k3`. Peel those vendor prefixes so one rate
+    // table covers every spelling.
+    let model = ["moonshot-ai/", "kimi-code/", "kimi-oauth/"]
+        .iter()
+        .find_map(|p| model_raw.strip_prefix(p))
         .unwrap_or(model_raw)
         .to_string();
     let u = v.get("usage").cloned().unwrap_or(Value::Null);
@@ -2215,6 +2219,36 @@ mod tests {
         assert_eq!(data.days.values().map(|v| v.1).sum::<f64>(), 1_000.0);
         assert_eq!(data.unpriced.get("kimi-test-model"), Some(&1));
         assert!(data.days.keys().all(|(_, m)| m == "kimi-test-model"));
+    }
+
+    #[test]
+    fn kimi_plan_k3_slug_uses_published_rates() {
+        let mut data = FileData::default();
+        let turn = json!({"type": "usage.record", "model": "kimi-code/k3",
+            "usage": {"inputOther": 1000.0, "output": 1000.0, "inputCacheRead": 0.0,
+                      "inputCacheCreation": 0.0},
+            "usageScope": "turn", "time": 1784208630652i64})
+        .to_string();
+        kimi_line(&turn, &mut data);
+        assert!(data.unpriced.is_empty(), "plan k3 should price: {:?}", data.unpriced);
+        assert!(data.days.keys().all(|(_, m)| m == "k3"));
+        let cost: f64 = data.days.values().map(|v| v.0).sum();
+        let expect = (1000.0 * 3.0 + 1000.0 * 15.0) / 1e6;
+        assert!((cost - expect).abs() < 1e-9, "cost {cost} != {expect}");
+    }
+
+    #[test]
+    fn kimi_k25_cache_hits_use_published_rate() {
+        let mut data = FileData::default();
+        let turn = json!({"type": "usage.record", "model": "moonshot-ai/kimi-k2.5",
+            "usage": {"inputOther": 0.0, "output": 0.0, "inputCacheRead": 1_000_000.0,
+                      "inputCacheCreation": 0.0},
+            "usageScope": "turn", "time": 1784208630652i64})
+        .to_string();
+        kimi_line(&turn, &mut data);
+        assert!(data.unpriced.is_empty(), "k2.5 should price: {:?}", data.unpriced);
+        let cost: f64 = data.days.values().map(|v| v.0).sum();
+        assert!((cost - 0.10).abs() < 1e-9, "cost {cost} != 0.10");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Kimi Code CLI logs plan turns as `kimi-code/k3` (and `kimi-for-coding`), which missed the rate table, so a day of plan usage could show a million tokens at $0.00.
- Every current Moonshot model now prices from the published platform.kimi.ai cards, and first-party rates win over reseller catalog stubs.

## Test plan
- [x] `cargo test --lib` on this slice (97 passed, 9 ignored)
- [ ] Kimi card Today/30 days shows dollars for plan K3 (`kimi-code/k3`), not $0.00 + unpriced warning
- [ ] HighSpeed K2.7 Code is 2x the base K2.7 Code rates

Made with Cursor

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->