### PR TITLE
Label the Moonshot toggle and key field Kimi API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@
   API spellings share the same table. Discontinued K2 / kimi-latest
   names still come from the public catalogs.
 
+### Changed
+- Customize toggle and Settings key field labeled **Kimi API** (was
+  Moonshot). The internal id is still `moonshot` so existing layouts
+  and telemetry keep working. The toggle still gates the wallet fetch
+  and the API bar on the Kimi Code card.
+
 ## 0.4.39 — 2026-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,11 @@
   names still come from the public catalogs.
 
 ### Changed
-- Customize toggle and Settings key field labeled **Kimi API** (was
-  Moonshot). The internal id is still `moonshot` so existing layouts
-  and telemetry keep working. The toggle still gates the wallet fetch
-  and the API bar on the Kimi Code card.
+- Customize toggle, Settings key field, leftover dashboard card, and
+  spend card labeled **Kimi API** (was Moonshot). The internal id is
+  still `moonshot` so existing layouts and telemetry keep working. The
+  toggle still gates the wallet fetch and the API bar on the Kimi Code
+  card.
 
 ## 0.4.39 — 2026-08-19
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -168,14 +168,16 @@ Ground rules that apply to every provider:
   Google's own token refresh.
 - **Shows:** Gemini + Claude pool windows, plan.
 
-## DeepSeek / Moonshot / ElevenLabs / Venice-class key providers
+## DeepSeek / Kimi API / ElevenLabs / Venice-class key providers
 
 - **Reads:** pasted key or env var only (`DEEPSEEK_API_KEY`,
   `MOONSHOT_API_KEY`/`KIMI_API_KEY`, `ELEVENLABS_API_KEY`).
+  The Customize toggle and Settings field are labeled **Kimi API**;
+  the internal id is still `moonshot`.
 - **Calls:** `api.deepseek.com/user/balance`;
   `api.moonshot.ai|cn/v1/users/me/balance`;
   `api.elevenlabs.io/v1/user/subscription`.
-- **Shows:** balances / character quota with reset pacing; Moonshot and
+- **Shows:** balances / character quota with reset pacing; Kimi API and
   DeepSeek add a "Credits used" percent bar metered against the highest
   balance Pane has seen locally (top-ups raise it; feeds the Almost Out
   notification).
@@ -212,10 +214,10 @@ Ground rules that apply to every provider:
   Codex (and Claude) sessions that log `kimi-oauth/…` or `moonshot-ai/…`
   via a router move those spend rows here, prefix peeled, so they do not
   stay on the Codex/Claude card.
-  The separate Moonshot card is hidden while this card is connected.
-  Switching Moonshot off in Customize still skips the wallet fetch (no
-  API bar, no `api.moonshot.ai|cn` call). If the Kimi card is off,
-  local session spend stays on Moonshot.
+  The leftover Kimi API (Moonshot) card is hidden while this card is
+  connected. Switching **Kimi API** off in Customize still skips the
+  wallet fetch (no API bar, no `api.moonshot.ai|cn` call). If the Kimi
+  card is off, local session spend stays on moonshot.
 
 ## Hermes (Nous Research desktop)
 

--- a/index.html
+++ b/index.html
@@ -242,8 +242,8 @@
             <button data-save="deepseek">Save</button>
           </div>
           <div class="key-row">
-            <label for="key-moonshot">Moonshot</label>
-            <input id="key-moonshot" type="password" placeholder="sk-… (Kimi API)" />
+            <label for="key-moonshot">Kimi API</label>
+            <input id="key-moonshot" type="password" placeholder="sk-… (platform.kimi.ai key)" />
             <button data-save="moonshot">Save</button>
           </div>
           <div class="key-row">

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -806,7 +806,7 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
         ("zai", Box::pin(guarded("zai".into(), "Z.ai".into(), providers::zai::snapshot()))),
         ("antigravity", Box::pin(guarded("antigravity".into(), "Antigravity".into(), providers::antigravity::snapshot()))),
         ("deepseek", Box::pin(guarded("deepseek".into(), "DeepSeek".into(), providers::deepseek::snapshot()))),
-        ("moonshot", Box::pin(guarded("moonshot".into(), "Moonshot".into(), providers::moonshot::snapshot()))),
+        ("moonshot", Box::pin(guarded("moonshot".into(), "Kimi API".into(), providers::moonshot::snapshot()))),
         ("elevenlabs", Box::pin(guarded("elevenlabs".into(), "ElevenLabs".into(), providers::elevenlabs::snapshot()))),
         ("ollama", Box::pin(guarded("ollama".into(), "Ollama".into(), providers::ollama::snapshot()))),
         ("codebuff", Box::pin(guarded("codebuff".into(), "Codebuff".into(), providers::codebuff::snapshot()))),
@@ -1714,7 +1714,7 @@ mod tests {
             ),
             Snapshot::ok(
                 "moonshot",
-                "Moonshot",
+                "Kimi API",
                 None,
                 vec![Metric::progress("Credits used", 24.0, None)],
             ),
@@ -1737,7 +1737,7 @@ mod tests {
             ),
             Snapshot::ok(
                 "moonshot",
-                "Moonshot",
+                "Kimi API",
                 None,
                 vec![Metric::progress("Credits used", 24.0, None)],
             ),
@@ -1752,7 +1752,7 @@ mod tests {
                 None,
                 vec![Metric::progress("Session", 0.0, None)],
             ),
-            Snapshot::no_credentials("moonshot", "Moonshot", "paste a key"),
+            Snapshot::no_credentials("moonshot", "Kimi API", "paste a key"),
         ];
         fold_moonshot_into_kimi(&mut empty_moon);
         assert!(!empty_moon.iter().any(|s| s.id == "moonshot"));

--- a/src-tauri/src/providers/moonshot.rs
+++ b/src-tauri/src/providers/moonshot.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 use std::time::Duration;
 
 const ID: &str = "moonshot";
-const NAME: &str = "Moonshot";
+const NAME: &str = "Kimi API";
 const MAX_BALANCE_BYTES: usize = 64 * 1024;
 
 // Global platform first, mainland China second — same key shape either way.
@@ -51,7 +51,7 @@ async fn fetch() -> Result<Snapshot, String> {
         return Ok(Snapshot::no_credentials(
             ID,
             NAME,
-            "Paste a Moonshot (Kimi) API key in Settings (gear icon).",
+            "Paste a Kimi API key in Settings (gear icon).",
         ));
     }
     let rows = fetch_balance(false).await?;

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -1928,7 +1928,7 @@ fn kimi_spend_target(has_login: bool, kimi_disabled: bool) -> (&'static str, &'s
     if has_login && !kimi_disabled {
         ("kimi", "Kimi Code")
     } else {
-        ("moonshot", "Moonshot")
+        ("moonshot", "Kimi API")
     }
 }
 
@@ -2624,9 +2624,9 @@ mod tests {
     #[test]
     fn kimi_spend_stays_on_moonshot_without_login() {
         assert_eq!(kimi_spend_target(true, false), ("kimi", "Kimi Code"));
-        assert_eq!(kimi_spend_target(false, false), ("moonshot", "Moonshot"));
-        assert_eq!(kimi_spend_target(true, true), ("moonshot", "Moonshot"));
-        assert_eq!(kimi_spend_target(false, true), ("moonshot", "Moonshot"));
+        assert_eq!(kimi_spend_target(false, false), ("moonshot", "Kimi API"));
+        assert_eq!(kimi_spend_target(true, true), ("moonshot", "Kimi API"));
+        assert_eq!(kimi_spend_target(false, true), ("moonshot", "Kimi API"));
     }
 
     /// Live diagnostic (ignored): what each spend source produced from

--- a/src/main.ts
+++ b/src/main.ts
@@ -204,7 +204,10 @@ const ALL_PROVIDERS: [string, string][] = [
   ["zai", "Z.ai"],
   ["antigravity", "Antigravity"],
   ["deepseek", "DeepSeek"],
-  ["moonshot", "Moonshot"],
+  // Internal id stays "moonshot" (config/layout/telemetry compatibility);
+  // the toggle reads "Kimi API" because that's what it gates: the API bar
+  // on the Kimi card (or the standalone wallet card without a CLI login).
+  ["moonshot", "Kimi API"],
   ["elevenlabs", "ElevenLabs"],
   ["ollama", "Ollama"],
   ["codebuff", "Codebuff"],
@@ -2003,10 +2006,10 @@ function renderCustomize(): string {
       // fetched) — that one must keep rendering, or its re-enable toggle
       // vanishes with it and the account is stuck off forever.
       if (id.includes("@") && !snapshot && !config.disabled.includes(id)) return "";
-      // Moonshot's leftover *card* is folded into Kimi on the dashboard,
-      // but this toggle still owns the wallet: off means no Moonshot HTTP
-      // and no API bar on the Kimi card. Hide it and there's no way to
-      // stop those calls.
+      // The leftover Moonshot *card* folds into Kimi Code on the dashboard.
+      // This toggle (labeled "Kimi API") still owns the wallet: off means
+      // no Moonshot HTTP and no API bar on the Kimi card. Hide it and
+      // there's no way to stop those calls.
       // Dynamic account cards carry their name in the snapshot
       // ("Claude — Org"); static providers come from the fixed list.
       const name = ALL_PROVIDERS.find(([pid]) => pid === id)?.[1] ?? snapshot?.name ?? id;


### PR DESCRIPTION
## Summary
- The Customize toggle and Settings key field said Moonshot; they now say Kimi API.
- The internal id stays `moonshot` so existing layouts and telemetry keep working. The toggle still gates the wallet fetch and the API bar on the Kimi Code card.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Customize list shows Kimi API (not Moonshot)
- [ ] Settings key row is labeled Kimi API with the platform.kimi.ai placeholder

Stacked on #150 — merge that one first; GitHub retargets this PR automatically.

Made with Cursor

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->