### PR TITLE
Show Cursor credit grants as a bar and bonus usage as a text row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
   to keep those dollars on Codex. They move to Kimi Code (or Moonshot
   when there's no Kimi login), with the vendor prefix peeled so they
   merge with the CLI's own logs.
+- **Cursor promo credits and bonus usage show up.** Credit grants
+  (`GetCreditGrantsBalance`) are a used/total progress bar like Codex
+  Extra credits, and Cursor's sponsored bonus usage (`bonusSpend`) is a
+  text row behind Show more — free usage model providers cover, shown
+  as context rather than a meter. Cents-as-strings parse; a failed
+  grants call logs instead of going silent.
 - **Kimi Code plan usage now has dollar amounts** — the official CLI logs
   plan K3 as `kimi-code/k3` (and K2.7 Code as `kimi-for-coding`), which
   missed the rate table, so Today could show a million tokens at $0.00.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,10 @@
   Extra credits, and Cursor's sponsored bonus usage (`bonusSpend`) is a
   text row behind Show more — free usage model providers cover, shown
   as context rather than a meter. Cents-as-strings parse; a failed
-  grants call logs instead of going silent.
+  grants call logs instead of going silent. An expired grant
+  (`hasCreditGrants: false`) stays hidden even if leftover totals are
+  still on the payload. Tucking Bonus behind Show more runs once so a
+  later Customize drag is not undone every refresh.
 - **Kimi Code plan usage now has dollar amounts** — the official CLI logs
   plan K3 as `kimi-code/k3` (and K2.7 Code as `kimi-for-coding`), which
   missed the rate table, so Today could show a million tokens at $0.00.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -80,8 +80,14 @@ Ground rules that apply to every provider:
   (`%APPDATA%\Cursor\User\globalStorage\state.vscdb` — copied before
   reading, never modified).
 - **Calls:** `cursor.com` / `api2.cursor.sh` usage APIs; the dashboard's
-  usage-events CSV export (for spend).
-- **Shows:** credits, usage meters, plan; per-day spend.
+  usage-events CSV export (for spend). `GetCreditGrantsBalance` cents
+  fields may be strings or numbers.
+- **Shows:** Cursor Models / Other Models bars; a **Credits** progress
+  row when the account has promo grants (`totalCents` vs remaining);
+  a **Bonus** text row behind Show more when `planUsage.bonusSpend` is
+  reported — free provider-sponsored usage, with the pool estimate
+  (derived from `totalPercentUsed`) as context when it is sane; Total
+  usage text on bucket-era personal plans; per-day spend.
 
 ## OpenCode (Go plan)
 

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -237,6 +237,65 @@ fn dollars(cents: f64) -> String {
     }
 }
 
+/// Promo / grant balance from `GetCreditGrantsBalance`. Live shape
+/// (2026-08): `{hasCreditGrants, creditBalanceCents, totalCents,
+/// usedCents}` with cents as strings or numbers. Returns None when
+/// there is nothing to show — never a 0% bar for a missing pool.
+fn credit_grants_metric(grants: &Value) -> Option<Metric> {
+    let has = grants.get("hasCreditGrants").and_then(Value::as_bool);
+    let total = num(grants.get("totalCents")).unwrap_or(0.0);
+    let used = num(grants.get("usedCents")).unwrap_or(0.0);
+    let remaining = num(grants.get("creditBalanceCents"))
+        .unwrap_or_else(|| (total - used).max(0.0));
+    if has == Some(false) && total <= 0.0 && remaining <= 0.0 {
+        return None;
+    }
+    if total > 0.0 {
+        let pct = ((total - remaining) / total * 100.0).clamp(0.0, 100.0);
+        Some(Metric::progress(
+            "Credits",
+            pct,
+            Some(format!("{} left of {}", dollars(remaining), dollars(total))),
+        ))
+    } else if remaining > 0.0 {
+        Some(Metric::text("Credits", dollars(remaining)))
+    } else {
+        if has == Some(true) {
+            eprintln!(
+                "[pane] cursor credit grants: hasCreditGrants but no totalCents/creditBalanceCents"
+            );
+        }
+        None
+    }
+}
+
+/// Cursor's sponsored / gifted bonus pool (`planUsage.bonusSpend`) — free
+/// usage model providers cover beyond the plan, not money the user owes.
+/// Shown as a text row (tucked behind Show more like other balances), not
+/// a bar: the RPC never names the pool size, so the ceiling would have to
+/// be derived from `totalPercentUsed` (`totalSpend / pct - includedSpend`)
+/// — Cursor's percent fields have contradicted each other before (the
+/// bucket-era 0% bug, `remainingBonus:false` against a 36% total), so the
+/// derived number rides along as context when it's sane, never as a meter.
+fn bonus_metric(plan_usage: &Value, total_pct: Option<f64>) -> Option<Metric> {
+    let bonus_spend = num(plan_usage.get("bonusSpend")).filter(|v| *v > 0.0)?;
+    let included = num(plan_usage.get("includedSpend")).unwrap_or(0.0);
+    let bonus_pool = match (num(plan_usage.get("totalSpend")), total_pct) {
+        (Some(spent), Some(pct)) if pct >= 1.0 && spent > 0.0 => {
+            (spent / pct * 100.0 - included).max(0.0)
+        }
+        _ => 0.0,
+    };
+    Some(if bonus_pool >= bonus_spend && bonus_pool > 0.0 {
+        Metric::text(
+            "Bonus",
+            format!("{} of {} used", dollars(bonus_spend), dollars(bonus_pool)),
+        )
+    } else {
+        Metric::text("Bonus", format!("{} used", dollars(bonus_spend)))
+    })
+}
+
 fn title_case(s: &str) -> String {
     s.split_whitespace()
         .map(|w| {
@@ -363,16 +422,18 @@ async fn fetch() -> Result<Snapshot, String> {
 
     let mut metrics = Vec::new();
 
-    // Unexpired credit grants + any negative Stripe balance = money that
-    // gets burned before the plan pool does.
-    if let Ok(Some(grants)) = credit_grants {
-        let has = grants.get("hasCreditGrants").and_then(Value::as_bool) == Some(true);
-        let total = if has { num(grants.get("totalCents")).unwrap_or(0.0) } else { 0.0 };
-        let used = if has { num(grants.get("usedCents")).unwrap_or(0.0) } else { 0.0 };
-        if total > 0.0 {
-            let remaining = (total - used).max(0.0);
-            metrics.push(Metric::text("Credits", dollars(remaining)));
+    // Unexpired credit grants — money that gets burned before the plan
+    // pool does. Cursor reports the pool size (`totalCents`) so this is
+    // a real used/total bar like Codex Extra credits, not a high-water
+    // guess. Cents often arrive as strings; `num()` accepts both.
+    match credit_grants {
+        Ok(Some(grants)) => {
+            if let Some(row) = credit_grants_metric(&grants) {
+                metrics.push(row);
+            }
         }
+        Ok(None) => {}
+        Err(e) => eprintln!("[pane] cursor credit grants: {e}"),
     }
 
     let spend_limit = usage.get("spendLimitUsage").filter(|v| v.is_object());
@@ -415,6 +476,10 @@ async fn fetch() -> Result<Snapshot, String> {
             Metric::progress("Other Models", api.clamp(0.0, 100.0), None)
                 .with_reset(resets_at, Some(period_ms)),
         );
+    }
+
+    if let Some(row) = bonus_metric(plan_usage, total_pct) {
+        metrics.push(row);
     }
 
     if is_team {
@@ -556,3 +621,86 @@ async fn legacy_fetch(token: &str) -> Result<Snapshot, String> {
     }
     Ok(Snapshot::ok(ID, NAME, plan, metrics))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn credit_grants_string_cents_become_a_bar() {
+        let grants = json!({
+            "hasCreditGrants": true,
+            "creditBalanceCents": "228",
+            "totalCents": "2500",
+            "usedCents": "2272"
+        });
+        let m = credit_grants_metric(&grants).expect("row");
+        assert_eq!(m.kind, "progress");
+        assert_eq!(m.label, "Credits");
+        assert!((m.used_percent.unwrap() - 90.88).abs() < 0.02);
+        assert_eq!(m.detail.as_deref(), Some("$2.28 left of $25.00"));
+    }
+
+    #[test]
+    fn credit_grants_numeric_cents_also_parse() {
+        let grants = json!({
+            "hasCreditGrants": true,
+            "totalCents": 20000,
+            "usedCents": 0,
+            "creditBalanceCents": 20000
+        });
+        let m = credit_grants_metric(&grants).expect("row");
+        assert_eq!(m.used_percent, Some(0.0));
+        assert_eq!(m.detail.as_deref(), Some("$200 left of $200"));
+    }
+
+    #[test]
+    fn credit_grants_absent_or_empty_hide() {
+        assert!(credit_grants_metric(&json!({"hasCreditGrants": false})).is_none());
+        assert!(credit_grants_metric(&json!({})).is_none());
+        assert!(credit_grants_metric(&json!({"hasCreditGrants": true})).is_none());
+    }
+
+    #[test]
+    fn credit_grants_balance_only_is_text() {
+        let grants = json!({
+            "hasCreditGrants": true,
+            "creditBalanceCents": "1500"
+        });
+        let m = credit_grants_metric(&grants).expect("row");
+        assert_eq!(m.kind, "text");
+        assert_eq!(m.value.as_deref(), Some("$15.00"));
+    }
+
+    #[test]
+    fn bonus_is_a_text_row_with_pool_context() {
+        // Live 2026-08 shape: $122.51 spent, 35.51% of included+bonus,
+        // $20 included, $102.51 bonus spend → bonus pool ≈ $325.
+        let plan = json!({
+            "totalSpend": 12251,
+            "includedSpend": 2000,
+            "bonusSpend": 10251,
+        });
+        let m = bonus_metric(&plan, Some(35.51014492753623)).expect("row");
+        assert_eq!(m.kind, "text");
+        assert_eq!(m.label, "Bonus");
+        // dollars() rounds ≥$100 to whole dollars: 10251¢ → $103, pool $325.
+        assert_eq!(m.value.as_deref(), Some("$103 of $325 used"));
+    }
+
+    #[test]
+    fn bonus_tiny_percent_drops_the_derived_pool() {
+        let plan = json!({ "bonusSpend": 500, "totalSpend": 500, "includedSpend": 0 });
+        let m = bonus_metric(&plan, Some(0.2)).expect("row");
+        assert_eq!(m.kind, "text");
+        assert_eq!(m.value.as_deref(), Some("$5.00 used"));
+    }
+
+    #[test]
+    fn bonus_zero_hides() {
+        assert!(bonus_metric(&json!({"bonusSpend": 0}), Some(10.0)).is_none());
+        assert!(bonus_metric(&json!({}), Some(10.0)).is_none());
+    }
+}
+

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -247,7 +247,17 @@ fn credit_grants_metric(grants: &Value) -> Option<Metric> {
     let used = num(grants.get("usedCents")).unwrap_or(0.0);
     let remaining = num(grants.get("creditBalanceCents"))
         .unwrap_or_else(|| (total - used).max(0.0));
-    if has == Some(false) && total <= 0.0 && remaining <= 0.0 {
+    // Explicit false wins even if leftover totals are still on the payload
+    // (expired grant). A 100% bar from that would also trip Almost Out.
+    if has == Some(false) {
+        return None;
+    }
+    if total <= 0.0 && remaining <= 0.0 {
+        if has == Some(true) {
+            eprintln!(
+                "[pane] cursor credit grants: hasCreditGrants but no totalCents/creditBalanceCents"
+            );
+        }
         return None;
     }
     if total > 0.0 {
@@ -257,15 +267,8 @@ fn credit_grants_metric(grants: &Value) -> Option<Metric> {
             pct,
             Some(format!("{} left of {}", dollars(remaining), dollars(total))),
         ))
-    } else if remaining > 0.0 {
-        Some(Metric::text("Credits", dollars(remaining)))
     } else {
-        if has == Some(true) {
-            eprintln!(
-                "[pane] cursor credit grants: hasCreditGrants but no totalCents/creditBalanceCents"
-            );
-        }
-        None
+        Some(Metric::text("Credits", dollars(remaining)))
     }
 }
 
@@ -660,6 +663,23 @@ mod tests {
         assert!(credit_grants_metric(&json!({"hasCreditGrants": false})).is_none());
         assert!(credit_grants_metric(&json!({})).is_none());
         assert!(credit_grants_metric(&json!({"hasCreditGrants": true})).is_none());
+    }
+
+    #[test]
+    fn credit_grants_false_hides_even_with_leftover_totals() {
+        let grants = json!({
+            "hasCreditGrants": false,
+            "totalCents": "2500",
+            "usedCents": "2500",
+            "creditBalanceCents": "0"
+        });
+        assert!(credit_grants_metric(&grants).is_none());
+        let leftover = json!({
+            "hasCreditGrants": false,
+            "totalCents": 20000,
+            "creditBalanceCents": 228
+        });
+        assert!(credit_grants_metric(&leftover).is_none());
     }
 
     #[test]

--- a/src/main.ts
+++ b/src/main.ts
@@ -529,6 +529,36 @@ function ensureLayout(): void {
     }
   }
 
+  // "Bonus" briefly rendered as a bar and is now a text row (free
+  // provider-sponsored usage — context, not a meter). Layouts saved in
+  // that window placed it always-visible; tuck it behind Show more like
+  // the other balance rows, and drop any star/pin on it (the tray strip
+  // and pinned tray number only accept progress metrics).
+  const bonusIsText =
+    cursorSnap?.metrics.find((m) => m.label === "Bonus")?.kind === "text";
+  if (bonusIsText) {
+    for (const [pid, L] of Object.entries(layout.providers)) {
+      if (providerFamily(pid) !== "cursor") continue;
+      if (L.metricOrder.includes("Bonus") && !L.onDemand.includes("Bonus")) {
+        L.onDemand.push("Bonus");
+        changed = true;
+      }
+      const starAt = L.starred.indexOf("Bonus");
+      if (starAt >= 0) {
+        L.starred.splice(starAt, 1);
+        changed = true;
+      }
+    }
+    if (
+      config.pinned &&
+      providerFamily(config.pinned.provider) === "cursor" &&
+      config.pinned.label === "Bonus"
+    ) {
+      config.pinned = null;
+      void patchConfig({ pinned: null }).catch(() => {});
+    }
+  }
+
   // Kimi Code folds the Moonshot wallet onto the plan card. Stars and the
   // tray pin on "Credits used" would otherwise vanish with that card —
   // but only migrate when the API bar is actually on that card, or we

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,9 @@ interface ProviderLayout {
   hidden: string[];
   starred: string[];
   expanded: boolean;
+  // One-shot: Bonus used to be a bar (always-visible). After the demotion
+  // to a text row we tuck it once; later drags out of Show more stick.
+  tuckedBonus?: boolean;
 }
 
 interface Layout {
@@ -535,16 +538,19 @@ function ensureLayout(): void {
 
   // "Bonus" briefly rendered as a bar and is now a text row (free
   // provider-sponsored usage — context, not a meter). Layouts saved in
-  // that window placed it always-visible; tuck it behind Show more like
-  // the other balance rows, and drop any star/pin on it (the tray strip
-  // and pinned tray number only accept progress metrics).
+  // that window placed it always-visible; tuck it behind Show more once,
+  // then leave later Customize drags alone. Stars/pins on it still drop
+  // every pass — the tray strip only accepts progress metrics.
   const bonusIsText =
     cursorSnap?.metrics.find((m) => m.label === "Bonus")?.kind === "text";
   if (bonusIsText) {
     for (const [pid, L] of Object.entries(layout.providers)) {
       if (providerFamily(pid) !== "cursor") continue;
-      if (L.metricOrder.includes("Bonus") && !L.onDemand.includes("Bonus")) {
-        L.onDemand.push("Bonus");
+      if (!L.tuckedBonus) {
+        if (L.metricOrder.includes("Bonus") && !L.onDemand.includes("Bonus")) {
+          L.onDemand.push("Bonus");
+        }
+        L.tuckedBonus = true;
         changed = true;
       }
       const starAt = L.starred.indexOf("Bonus");


### PR DESCRIPTION
## Summary
- Cursor promo credit grants (GetCreditGrantsBalance) now show as a used/total progress bar, like Codex Extra credits. Cents sent as strings parse correctly.
- Sponsored bonus usage (bonusSpend) is a text row behind Show more — context, not a meter.

## Test plan
- [x] `cargo test --lib` on the full stack (109 passed, 9 ignored)
- [x] `npx tsc --noEmit` clean
- [x] Final tree matches `refs/backup/pre-split` (Cargo.toml line-ending noise excluded)
- [ ] If the Cursor account has promo grants, a Credits bar appears
- [ ] Bonus is a text row behind Show more, not a progress bar

Stacked on #153 — merge that one first; GitHub retargets this PR automatically.

Made with Cursor
