### PR TITLE
Enable a provider when its key is saved and queue forced refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@
   refresh into a stuck "key saved" status with no fetch. A key pasted
   during that first refresh is also kept out of the auto-disable list,
   so the just-saved provider is not parked because the in-flight fetch
-  still said it had no credentials.
+  still said it had no credentials. A failed save or a cleared key drops
+  that exemption immediately, so Customize can turn the provider back
+  off.
 - **Kimi usage routed through Codex (or Claude) lands on the Kimi card.**
   Sessions that log `kimi-oauth/k3` or `moonshot-ai/…` via a router used
   to keep those dollars on Codex. They move to Kimi Code (or Moonshot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   refresh only re-reads files whose prices actually moved. A baked-pricing
   code change still discards the cache. One last full scan migrates to
   the new format.
+- **Pasting an API key actually shows that provider.** Saving a key now
+  turns the provider on if Customize had it off (first-run parks
+  keyless providers there), and a save no longer races an in-flight
+  refresh into a stuck "key saved" status with no fetch.
 - **Kimi usage routed through Codex (or Claude) lands on the Kimi card.**
   Sessions that log `kimi-oauth/k3` or `moonshot-ai/…` via a router used
   to keep those dollars on Codex. They move to Kimi Code (or Moonshot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@
 - **Pasting an API key actually shows that provider.** Saving a key now
   turns the provider on if Customize had it off (first-run parks
   keyless providers there), and a save no longer races an in-flight
-  refresh into a stuck "key saved" status with no fetch.
+  refresh into a stuck "key saved" status with no fetch. A key pasted
+  during that first refresh is also kept out of the auto-disable list,
+  so the just-saved provider is not parked because the in-flight fetch
+  still said it had no credentials.
 - **Kimi usage routed through Codex (or Claude) lands on the Kimi card.**
   Sessions that log `kimi-oauth/k3` or `moonshot-ai/…` via a router used
   to keep those dollars on Codex. They move to Kimi Code (or Moonshot

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -180,7 +180,8 @@ Ground rules that apply to every provider:
 - **Shows:** balances / character quota with reset pacing; Kimi API and
   DeepSeek add a "Credits used" percent bar metered against the highest
   balance Pane has seen locally (top-ups raise it; feeds the Almost Out
-  notification).
+  notification). Saving a key in Settings turns that provider on if
+  Customize had it off.
 
 ## Kimi Code
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -346,7 +346,10 @@ let refreshQueued = false;
 // A key saved while the first refresh is still in flight. First-run (and
 // "new provider") auto-disable keys off that fetch's no_credentials list,
 // which can predate the save and park the provider we just turned on.
-const recentlyKeyed = new Set<string>();
+// Value is the refresh generation that was in flight (or last completed)
+// at save time — the exemption lasts through that pass plus one more.
+const recentlyKeyed = new Map<string, number>();
+let refreshGeneration = 0;
 let refreshTimer: number | undefined;
 let lastSnapshots: Snapshot[] = [];
 let lastSpend: ProviderSpend[] = [];
@@ -2323,6 +2326,7 @@ async function refresh(force = false): Promise<void> {
   }
   if (!force && Date.now() - lastFetch < STALE_MS) return;
   refreshing = true;
+  const myGen = ++refreshGeneration;
   await unparkRecentlyKeyed();
 
   const status = document.querySelector("#status")!;
@@ -2400,6 +2404,12 @@ async function refresh(force = false): Promise<void> {
     snapshots = hideFoldedMoonshot(snapshots);
     for (const s of snapshots) {
       if (s.status !== "no_credentials") recentlyKeyed.delete(s.id);
+    }
+    // Drop exemptions from saves that happened before this refresh started
+    // (a failed save is removed in the catch; a cleared key is removed on
+    // empty paste). One follow-up fetch is enough to pick the new key up.
+    for (const [id, gen] of [...recentlyKeyed]) {
+      if (gen < myGen) recentlyKeyed.delete(id);
     }
     const firstData = lastSnapshots.length === 0;
     lastFetch = Date.now();
@@ -2615,6 +2625,9 @@ function withPendingToggles(base: string[]): string[] {
     if (t.enable) s.delete(t.id);
     else s.add(t.id);
   }
+  // A just-saved key wins over a Customize disable still in the queue —
+  // the save is "show me this provider".
+  for (const id of recentlyKeyed.keys()) s.delete(id);
   return [...s];
 }
 
@@ -2738,7 +2751,7 @@ function setupCustomizeDnD(providersEl: HTMLElement): void {
 // ---------------------------------------------------------------------------
 
 async function unparkRecentlyKeyed(): Promise<void> {
-  if (![...recentlyKeyed].some((id) => config.disabled.includes(id))) return;
+  if (!config.disabled.some((id) => recentlyKeyed.has(id))) return;
   await patchConfig({
     disabled: config.disabled.filter((id) => !recentlyKeyed.has(id)),
   }).catch(() => {});
@@ -2749,9 +2762,13 @@ async function saveApiKey(provider: string): Promise<void> {
   const status = document.querySelector("#status")!;
   try {
     const key = input.value;
-    // Mark before any await so an in-flight first-run pass cannot park
-    // this provider after our save returns.
-    if (key.trim()) recentlyKeyed.add(provider);
+    if (!key.trim()) {
+      recentlyKeyed.delete(provider);
+    } else {
+      // Mark before any await so an in-flight first-run pass cannot park
+      // this provider after our save returns.
+      recentlyKeyed.set(provider, refreshGeneration);
+    }
     await invoke("set_api_key", { provider, key });
     input.value = "";
     // Pasting a key says "show me this provider" — pull it out of Disabled.
@@ -2766,6 +2783,7 @@ async function saveApiKey(provider: string): Promise<void> {
     status.textContent = `${provider} key saved`;
     await refresh(true);
   } catch (err) {
+    recentlyKeyed.delete(provider);
     status.textContent = `Could not save key: ${err}`;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -343,6 +343,10 @@ let refreshing = false;
 // API key races the auto-refresh timer). Dropping it would leave the new
 // state unfetched and the status line stuck on the save message.
 let refreshQueued = false;
+// A key saved while the first refresh is still in flight. First-run (and
+// "new provider") auto-disable keys off that fetch's no_credentials list,
+// which can predate the save and park the provider we just turned on.
+const recentlyKeyed = new Set<string>();
 let refreshTimer: number | undefined;
 let lastSnapshots: Snapshot[] = [];
 let lastSpend: ProviderSpend[] = [];
@@ -2319,6 +2323,7 @@ async function refresh(force = false): Promise<void> {
   }
   if (!force && Date.now() - lastFetch < STALE_MS) return;
   refreshing = true;
+  await unparkRecentlyKeyed();
 
   const status = document.querySelector("#status")!;
   status.textContent = "Refreshing…";
@@ -2336,11 +2341,17 @@ async function refresh(force = false): Promise<void> {
       // in Customize (a fresh PC with zero AI tools sees just those two).
       const starters = new Set(["claude", "codex"]);
       const noCreds = snapshots
-        .filter((s) => s.status === "no_credentials" && !starters.has(s.id))
+        .filter(
+          (s) =>
+            s.status === "no_credentials" &&
+            !starters.has(s.id) &&
+            !recentlyKeyed.has(s.id)
+        )
         .map((s) => s.id);
       if (noCreds.length) {
         snapshots = snapshots.filter((s) => !noCreds.includes(s.id));
         await patchConfig({ disabled: noCreds }).catch(() => {});
+        await unparkRecentlyKeyed();
       }
     } else if (config.layout) {
       // App updates ship new providers; ones this PC has no credentials for
@@ -2349,7 +2360,11 @@ async function refresh(force = false): Promise<void> {
       const known = config.layout.providers;
       const fresh = snapshots
         .filter(
-          (s) => s.status === "no_credentials" && !(s.id in known) && !config.disabled.includes(s.id)
+          (s) =>
+            s.status === "no_credentials" &&
+            !(s.id in known) &&
+            !config.disabled.includes(s.id) &&
+            !recentlyKeyed.has(s.id)
         )
         .map((s) => s.id);
       if (fresh.length) {
@@ -2358,6 +2373,7 @@ async function refresh(force = false): Promise<void> {
           disabled: [...config.disabled, ...fresh],
           layout: config.layout,
         }).catch(() => {});
+        await unparkRecentlyKeyed();
       }
 
       // Updates also RETIRE providers; saved layouts keep referencing their
@@ -2382,6 +2398,9 @@ async function refresh(force = false): Promise<void> {
       }
     }
     snapshots = hideFoldedMoonshot(snapshots);
+    for (const s of snapshots) {
+      if (s.status !== "no_credentials") recentlyKeyed.delete(s.id);
+    }
     const firstData = lastSnapshots.length === 0;
     lastFetch = Date.now();
     lastSnapshots = snapshots;
@@ -2718,11 +2737,21 @@ function setupCustomizeDnD(providersEl: HTMLElement): void {
 // Settings pane
 // ---------------------------------------------------------------------------
 
+async function unparkRecentlyKeyed(): Promise<void> {
+  if (![...recentlyKeyed].some((id) => config.disabled.includes(id))) return;
+  await patchConfig({
+    disabled: config.disabled.filter((id) => !recentlyKeyed.has(id)),
+  }).catch(() => {});
+}
+
 async function saveApiKey(provider: string): Promise<void> {
   const input = document.querySelector<HTMLInputElement>(`#key-${provider}`)!;
   const status = document.querySelector("#status")!;
   try {
     const key = input.value;
+    // Mark before any await so an in-flight first-run pass cannot park
+    // this provider after our save returns.
+    if (key.trim()) recentlyKeyed.add(provider);
     await invoke("set_api_key", { provider, key });
     input.value = "";
     // Pasting a key says "show me this provider" — pull it out of Disabled.

--- a/src/main.ts
+++ b/src/main.ts
@@ -339,6 +339,10 @@ let config: Config = {
 };
 let lastFetch = 0;
 let refreshing = false;
+// A forced refresh requested while one was already in flight (saving an
+// API key races the auto-refresh timer). Dropping it would leave the new
+// state unfetched and the status line stuck on the save message.
+let refreshQueued = false;
 let refreshTimer: number | undefined;
 let lastSnapshots: Snapshot[] = [];
 let lastSpend: ProviderSpend[] = [];
@@ -2306,7 +2310,13 @@ async function paintCachedSnapshots(): Promise<void> {
 }
 
 async function refresh(force = false): Promise<void> {
-  if (refreshing) return;
+  if (refreshing) {
+    // Remember a forced request instead of dropping it: the in-flight
+    // fetch may have started before whatever prompted this one (a saved
+    // key, a toggle), so one more pass runs when it finishes.
+    if (force) refreshQueued = true;
+    return;
+  }
   if (!force && Date.now() - lastFetch < STALE_MS) return;
   refreshing = true;
 
@@ -2393,6 +2403,10 @@ async function refresh(force = false): Promise<void> {
   if (lastSnapshots.length) ensureLayout();
   if (!customizeOpen && lastSnapshots.length) renderIfVisible();
   refreshing = false;
+  if (refreshQueued) {
+    refreshQueued = false;
+    void refresh(true);
+  }
 }
 
 function scheduleAutoRefresh(): void {
@@ -2708,8 +2722,18 @@ async function saveApiKey(provider: string): Promise<void> {
   const input = document.querySelector<HTMLInputElement>(`#key-${provider}`)!;
   const status = document.querySelector("#status")!;
   try {
-    await invoke("set_api_key", { provider, key: input.value });
+    const key = input.value;
+    await invoke("set_api_key", { provider, key });
     input.value = "";
+    // Pasting a key says "show me this provider" — pull it out of Disabled.
+    // First-run auto-disable parks keyless providers there, and a key saved
+    // against a still-disabled toggle would otherwise never produce a bar
+    // no matter how often Refresh is clicked.
+    if (key.trim() && config.disabled.includes(provider)) {
+      await patchConfig({
+        disabled: config.disabled.filter((id) => id !== provider),
+      }).catch(() => {});
+    }
     status.textContent = `${provider} key saved`;
     await refresh(true);
   } catch (err) {


### PR DESCRIPTION
## Summary
- First-run parks keyless providers in Disabled, so pasting a Kimi API (or other) key never produced a bar.
- Saving a key now turns that provider on, and a save no longer races an in-flight refresh into a stuck "key saved" status with no fetch.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Disable Kimi API in Customize, paste a key in Settings, save — the provider turns back on and a refresh actually runs
- [ ] Status line does not stay stuck on "moonshot key saved"

Stacked on #151 — merge that one first; GitHub retargets this PR automatically.

Made with Cursor

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->