### PR TITLE
Release 0.4.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.4.41 — 2026-08-20
+
+### Fixed
+- **Kimi Code plan name matches the membership page** — current paid
+  names on [kimi.ai](https://www.kimi.ai/membership/pricing) are
+  Moderato, Allegretto, Allegro, and Vivace. Pane still printed the old
+  three-name table, so `LEVEL_INTERMEDIATE` showed as Moderato
+  (issue #156; it is Allegretto) and `LEVEL_ADVANCED` showed as
+  Allegretto (it is Allegro). `LEVEL_PREMIUM` is Vivace.
+
 ## 0.4.40 — 2026-08-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ success/failure counts — never amounts or error text) — see
 | Antigravity | Local language server, or Google Cloud Code API via Credential Manager |
 | DeepSeek | API key (Settings) → balance |
 | Moonshot (Kimi API) | API key (Settings) → balance (global + CN endpoints) |
-| Kimi Code | Official CLI login (`kimi login`) → Session + Weekly plan bars; Moonshot API key → API wallet bar; local session spend |
+| Kimi Code | Official CLI login (`kimi login`) → Session + Weekly plan bars and membership name (Moderato / Allegretto / Allegro / Vivace); Moonshot API key → API wallet bar; local session spend |
 | ElevenLabs | API key (Settings) → character quota with reset pacing |
 | Ollama | Local server on :11434 — installed + loaded models, no key |
 | Codebuff | `codebuff login` credentials file or API key → credits + weekly limit |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — full Mac parity (and beyond)
 
-**Status (v0.4.40, 2026-08-20): every wave below is shipped, and the
+**Status (v0.4.41, 2026-08-20): every wave below is shipped, and the
 post-launch releases keep going.** Pane has full feature parity with the
 macOS original plus 21 providers, signed auto-updates published by CI,
 Codex reset-credit redemption, update-check-on-open with a one-click

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -201,8 +201,22 @@ Ground rules that apply to every provider:
   Moonshot/Kimi API key is saved, `api.moonshot.ai|cn/v1/users/me/balance`
   for the API bar. This is the Kimi Code *subscription* plus the
   pay-as-you-go wallet on the same card.
-- **Shows:** Session (5-hour) and Weekly bars with reset pacing, plan
-  name (Andante / Moderato / Allegretto when the weekly quota matches).
+- **Shows:** Session (5-hour) and Weekly bars with reset pacing, plus the
+  membership plan name from `user.membership.level`. Names match
+  [kimi.ai/membership/pricing](https://www.kimi.ai/membership/pricing):
+  Moderato ($19), Allegretto ($39), Allegro ($99), Vivace ($199).
+
+  | API `user.membership.level` | Card name |
+  |---|---|
+  | `LEVEL_STANDARD` / `LEVEL_MODERATO` | Moderato |
+  | `LEVEL_INTERMEDIATE` | Allegretto |
+  | `LEVEL_ADVANCED` | Allegro |
+  | `LEVEL_PREMIUM` | Vivace |
+
+  Older codes still map if the API sends them (`LEVEL_FREE` /
+  `LEVEL_BASIC` → Adagio, `LEVEL_ANDANTE` → Andante). Weekly request
+  caps 1024 / 2048 / 7168 are a fallback only, when the API omits the
+  level.
   Those two windows are the same clocks as Kimi's website "5-hour Code"
   and "7-day Code" rows; the coding usage API currently reports remaining
   as whole percents (`limit`/`remaining` of 100), so usage under 1% can

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.40",
+      "version": "0.4.41",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.40",
+  "version": "0.4.41",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.40"
+version = "0.4.41"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -343,6 +343,9 @@ fn plan_from_doc(doc: &Value, weekly_limit: Option<f64>) -> Option<String> {
         return Some(level);
     }
     match weekly_limit.map(|n| n.round() as i64) {
+        // Last resort when the API omits membership.level. These are the
+        // old request-count caps; current responses usually send percent
+        // (limit 100) plus a LEVEL_* code instead.
         Some(1024) => Some("Andante".into()),
         Some(2048) => Some("Moderato".into()),
         Some(7168) => Some("Allegretto".into()),
@@ -350,13 +353,23 @@ fn plan_from_doc(doc: &Value, weekly_limit: Option<f64>) -> Option<String> {
     }
 }
 
+/// Display names match https://www.kimi.ai/membership/pricing
+/// (Moderato / Allegretto / Allegro / Vivace). `LEVEL_*` codes shifted
+/// when Allegro and Vivace launched (issue #156): INTERMEDIATE used to
+/// print as Moderato. Older codes (Adagio / Andante) are mapped if the
+/// API still sends them.
 fn map_membership_level(raw: &str) -> Option<String> {
     let upper = raw.trim().to_ascii_uppercase();
     let key = upper.strip_prefix("LEVEL_").unwrap_or(&upper);
     Some(match key {
-        "ANDANTE" | "BASIC" | "BEGINNER" | "INTRO" => "Andante".into(),
-        "MODERATO" | "INTERMEDIATE" => "Moderato".into(),
-        "ALLEGROTTO" | "ADVANCED" | "PROFESSIONAL" | "PRO" => "Allegretto".into(),
+        "FREE" | "ADAGIO" | "BASIC" => "Adagio".into(),
+        "ANDANTE" | "BEGINNER" | "INTRO" => "Andante".into(),
+        "MODERATO" | "STANDARD" => "Moderato".into(),
+        "INTERMEDIATE" | "ALLEGRETTO" | "ALLEGROTTO" | "PROFESSIONAL" | "PRO" => {
+            "Allegretto".into()
+        }
+        "ADVANCED" | "ALLEGRO" => "Allegro".into(),
+        "PREMIUM" | "VIVACE" => "Vivace".into(),
         other if other.is_empty() => return None,
         other => title_case(other),
     })
@@ -462,7 +475,7 @@ mod tests {
         let snap = parse_snapshot(&doc).expect("parse");
         assert_eq!(snap.id, "kimi");
         assert_eq!(snap.name, "Kimi Code");
-        assert_eq!(snap.plan.as_deref(), Some("Moderato"));
+        assert_eq!(snap.plan.as_deref(), Some("Allegretto"));
         assert_eq!(labels(&snap.metrics), ["Session", "Weekly"]);
         let session = &snap.metrics[0];
         assert!((session.used_percent.unwrap() - 69.5).abs() < 0.01);
@@ -493,8 +506,33 @@ mod tests {
     fn weekly_limit_names_the_tier() {
         let andante = json!({"usage": {"limit": 1024, "used": 10, "remaining": 1014}});
         assert_eq!(parse_snapshot(&andante).unwrap().plan.as_deref(), Some("Andante"));
-        let allegro = json!({"usage": {"limit": "7168", "used": "0", "remaining": "7168"}});
-        assert_eq!(parse_snapshot(&allegro).unwrap().plan.as_deref(), Some("Allegretto"));
+        let mid = json!({"usage": {"limit": 2048, "used": 0, "remaining": 2048}});
+        assert_eq!(parse_snapshot(&mid).unwrap().plan.as_deref(), Some("Moderato"));
+        let high = json!({"usage": {"limit": "7168", "used": "0", "remaining": "7168"}});
+        assert_eq!(parse_snapshot(&high).unwrap().plan.as_deref(), Some("Allegretto"));
+    }
+
+    #[test]
+    fn membership_level_matches_kimi_page_names() {
+        let cases = [
+            ("LEVEL_FREE", "Adagio"),
+            ("LEVEL_BASIC", "Adagio"),
+            ("ADAGIO", "Adagio"),
+            ("LEVEL_ANDANTE", "Andante"),
+            ("LEVEL_STANDARD", "Moderato"),
+            ("LEVEL_MODERATO", "Moderato"),
+            ("LEVEL_INTERMEDIATE", "Allegretto"),
+            ("ALLEGRETTO", "Allegretto"),
+            ("ALLEGROTTO", "Allegretto"),
+            ("LEVEL_ADVANCED", "Allegro"),
+            ("LEVEL_ALLEGRO", "Allegro"),
+            ("LEVEL_PREMIUM", "Vivace"),
+            ("VIVACE", "Vivace"),
+            ("PRO", "Allegretto"),
+        ];
+        for (raw, name) in cases {
+            assert_eq!(map_membership_level(raw).as_deref(), Some(name), "{raw}");
+        }
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Map Kimi Code `user.membership.level` to the current [kimi.ai](https://www.kimi.ai/membership/pricing) names: Moderato, Allegretto, Allegro, Vivace.
- `LEVEL_INTERMEDIATE` was printing Moderato (issue #156; it is Allegretto). `LEVEL_ADVANCED` is Allegro; `LEVEL_PREMIUM` is Vivace.
- Stamp **0.4.41** (tauri.conf / package.json / Cargo.toml + lockfiles, CHANGELOG, ROADMAP).

## Test plan
- [x] Local install of the name-fix build: reporter case (Allegretto) and jazii's card now match the membership page
- [x] `cargo test --lib providers::kimi` — 11 passed
- [ ] CI release build produces installer + updater artifacts after tag

Fixes #156

Made with Cursor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->