### PR TITLE
Unlock Refresh while spend is still scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Refresh responds while usage is updating.** The button used to stay
+  locked until the slow spend scan finished (tens of seconds on a cold
+  start), so clicks looked dead and a just-saved **Kimi API** key left
+  "moonshot key saved" stuck on the footer. Usage unlocks Refresh as soon
+  as the cards update; a click (or key save) during a fetch shows
+  Refreshing… immediately; and the sidebar sits above Settings so Refresh
+  still works with the panel open.
+
 ## 0.4.41 — 2026-08-20
 
 ### Fixed

--- a/src/main.ts
+++ b/src/main.ts
@@ -357,6 +357,7 @@ let refreshQueued = false;
 // at save time — the exemption lasts through that pass plus one more.
 const recentlyKeyed = new Map<string, number>();
 let refreshGeneration = 0;
+let lastAppliedSpendGen = 0;
 let refreshTimer: number | undefined;
 let lastSnapshots: Snapshot[] = [];
 let lastSpend: ProviderSpend[] = [];
@@ -2485,9 +2486,13 @@ async function refresh(force = false): Promise<void> {
   }
   const spend = await spendPromise;
   spendLoaded = true;
-  // A newer refresh may have started (and even finished) while this scan
-  // was still walking logs — don't paint stale dollars over it.
-  if (spend && myGen === refreshGeneration) lastSpend = spend;
+  // Overlapping scans are allowed now that Refresh unlocks before spend
+  // finishes. Keep the newest successful result — a later failed scan
+  // (null) must not discard dollars an older pass already computed.
+  if (spend && myGen >= lastAppliedSpendGen) {
+    lastSpend = spend;
+    lastAppliedSpendGen = myGen;
+  }
   if (lastSnapshots.length) ensureLayout();
   if (!customizeOpen && lastSnapshots.length) renderIfVisible();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -221,6 +221,10 @@ const ALL_PROVIDERS: [string, string][] = [
   ["kimi", "Kimi Code"],
 ];
 
+function providerDisplayName(id: string): string {
+  return ALL_PROVIDERS.find(([pid]) => pid === id)?.[1] ?? id;
+}
+
 // Same quick links the Mac app ships (status pages + vendor dashboards).
 const PROVIDER_LINKS: Record<string, { label: string; url: string }[]> = {
   claude: [
@@ -2352,25 +2356,36 @@ async function paintCachedSnapshots(): Promise<void> {
   }
 }
 
+function setRefreshLock(on: boolean): void {
+  refreshing = on;
+  document.body.classList.toggle("refreshing", on);
+  document.querySelector("#refresh")?.setAttribute("aria-busy", on ? "true" : "false");
+}
+
 async function refresh(force = false): Promise<void> {
   if (refreshing) {
     // Remember a forced request instead of dropping it: the in-flight
     // fetch may have started before whatever prompted this one (a saved
     // key, a toggle), so one more pass runs when it finishes.
-    if (force) refreshQueued = true;
+    if (force) {
+      refreshQueued = true;
+      // The save message (or a stale "Updated") would otherwise sit on
+      // the footer until the in-flight fetch ends, and Refresh looks dead.
+      document.querySelector("#status")!.textContent = "Refreshing…";
+    }
     return;
   }
   if (!force && Date.now() - lastFetch < STALE_MS) return;
-  refreshing = true;
+  setRefreshLock(true);
   const myGen = ++refreshGeneration;
-  await unparkRecentlyKeyed();
-
   const status = document.querySelector("#status")!;
   status.textContent = "Refreshing…";
   // The spend scan re-reads every session log on a cold start and can take
-  // tens of seconds — it must never hold up the usage cards' first paint.
+  // tens of seconds — it must never hold up the usage cards' first paint,
+  // or the Refresh button (the lock used to stay on until spend finished).
   const spendPromise = invoke<ProviderSpend[]>("fetch_spend").catch(() => null);
   try {
+    await unparkRecentlyKeyed();
     let snapshots = await invoke<Snapshot[]>("fetch_usage");
     // First launch ever (no layout yet): start with only the providers that
     // actually have credentials on this PC, like the Mac app's first-run
@@ -2461,17 +2476,20 @@ async function refresh(force = false): Promise<void> {
     status.textContent = `Updated ${time}`;
   } catch (err) {
     status.textContent = `Refresh failed: ${err}`;
+  } finally {
+    setRefreshLock(false);
+    if (refreshQueued) {
+      refreshQueued = false;
+      void refresh(true);
+    }
   }
   const spend = await spendPromise;
   spendLoaded = true;
-  if (spend) lastSpend = spend;
+  // A newer refresh may have started (and even finished) while this scan
+  // was still walking logs — don't paint stale dollars over it.
+  if (spend && myGen === refreshGeneration) lastSpend = spend;
   if (lastSnapshots.length) ensureLayout();
   if (!customizeOpen && lastSnapshots.length) renderIfVisible();
-  refreshing = false;
-  if (refreshQueued) {
-    refreshQueued = false;
-    void refresh(true);
-  }
 }
 
 function scheduleAutoRefresh(): void {
@@ -2816,7 +2834,8 @@ async function saveApiKey(provider: string): Promise<void> {
         disabled: config.disabled.filter((id) => id !== provider),
       }).catch(() => {});
     }
-    status.textContent = `${provider} key saved`;
+    const name = providerDisplayName(provider);
+    status.textContent = `${name} key saved`;
     await refresh(true);
   } catch (err) {
     recentlyKeyed.delete(provider);

--- a/src/styles.css
+++ b/src/styles.css
@@ -109,7 +109,14 @@ body {
   top: 0;
   bottom: 0;
   width: 10px;
-  z-index: 30;
+  /* Above Settings/Customize (50) and the footer (55) so Refresh stays
+     clickable while a panel is open or the status line is long. */
+  z-index: 65;
+}
+
+#side-zone:hover,
+#side-zone:focus-within {
+  width: 42px;
 }
 
 /* Liquid glass, same recipe as jazii.dev's floating dock. */
@@ -226,7 +233,8 @@ body {
 #settings-btn:hover,
 #customize-btn:hover,
 #customize-btn.active,
-#theme-btn:hover {
+#theme-btn:hover,
+body.refreshing #refresh {
   background: var(--accent);
   color: var(--foreground);
 }


### PR DESCRIPTION
## Summary
- Unlock Refresh as soon as usage cards update, instead of holding it until the slow spend scan finishes.
- A saved Kimi API key now says **Kimi API key saved** (not moonshot). A click or save during an in-flight fetch shows Refreshing immediately.
- Raise the sidebar above Settings so Refresh stays clickable with the panel open.

## Test plan
- [x] Local install: save a Kimi API key while a refresh is running — footer says Kimi API, Refresh still works, no spinning arrow
- [ ] Click Refresh twice quickly — second click queues and the footer shows Refreshing until the next pass lands
- [ ] Open Settings, save a key, hit Refresh from the left rail without closing the panel

Made with Cursor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->