### PR TITLE
Name Pane as an AI plan tracker in the README opener

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 
 # Pane
 
-**All your AI subscription limits in one liquid-glass tray popover for Windows.**
+**Pane tracker: all your AI plans and subscriptions in one Windows tray.**
 
 One click on the tray icon answers the questions every AI power user keeps
 asking: *How much of my Claude session is left? When does my Codex weekly
 reset? What did today actually cost me?*
 
-**[pane.jazii.dev](https://pane.jazii.dev)** · [Install](#install) · [How it works](#how-it-works) · [Providers](#providers-21-and-counting) · [Features](#features) · [Privacy](#privacy--security) · [Credits](#credits)
+Pane is the [OpenUsage](https://www.openusage.ai/) port for Windows: a free
+AI plan tracker for Claude, Codex, Cursor, Copilot, Kimi, Grok, and 15 more.
+
+**[pane.jazii.dev](https://pane.jazii.dev)** · [Guides](https://pane.jazii.dev/guides) · [Install](#install) · [How it works](#how-it-works) · [Providers](#providers-21-and-counting) · [Features](#features) · [Privacy](#privacy--security) · [Credits](#credits)
 
 <img src="docs/promo.png" width="760" alt="Pane — track all your AI subscription limits in one tray app: Total Spend donut with per-provider slices, usage cards with pace bars" />
 


### PR DESCRIPTION
## Summary
- Rewrite the README opener so GitHub search and the repo homepage match the site: Pane tracker, AI plan tracker, OpenUsage for Windows.
- Add a link to the new `/guides` cluster next to pane.jazii.dev.

## Test plan
- [ ] Read the README header on the PR files tab
- [ ] Click pane.jazii.dev and Guides
- [ ] Confirm the rest of the README (install, providers, privacy) is unchanged

Made with Cursor

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->