### PR TITLE
Add Simplified Chinese in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+- **Chinese in Settings → Language.** Auto follows the PC language;
+  English and 中文 are explicit. Cards, Settings, Customize, tray
+  tooltips, and quota toasts switch as soon as you pick one. Provider
+  names, plan names, and the changelog stay English. Vendor "connect me"
+  error hints stay English for now.
+
 ### Fixed
 - **Refresh responds while usage is updating.** The button used to stay
   locked until the slow spend scan finished (tens of seconds on a cold

--- a/index.html
+++ b/index.html
@@ -87,128 +87,136 @@
       <div id="side-zone">
         <aside class="sidebar">
           <span id="app-logo" class="app-logo" title="Pane"></span>
-          <nav id="trail" aria-label="Card navigation"></nav>
+          <nav id="trail" aria-label="Card navigation" data-i18n-aria="sidebar.cards"></nav>
           <div class="sidebar-buttons">
-            <button id="theme-btn" title="Light / dark mode">&#9728;</button>
-            <button id="refresh" title="Refresh now">&#10227;</button>
-            <button id="customize-btn" title="Customize">&#9776;</button>
-            <button id="settings-btn" title="Settings">&#9881;</button>
+            <button id="theme-btn" title="Light / dark mode" data-i18n-title="sidebar.theme">&#9728;</button>
+            <button id="refresh" title="Refresh now" data-i18n-title="sidebar.refresh">&#10227;</button>
+            <button id="customize-btn" title="Customize" data-i18n-title="sidebar.customize">&#9776;</button>
+            <button id="settings-btn" title="Settings" data-i18n-title="sidebar.settings">&#9881;</button>
           </div>
         </aside>
       </div>
     </main>
 
     <!-- Customize: full-window panel sliding in from the left. -->
-    <aside id="drawer" aria-label="Customize">
+    <aside id="drawer" aria-label="Customize" data-i18n-aria="sidebar.customize">
       <div id="drawer-body"></div>
     </aside>
 
     <!-- Settings: full-window panel sliding in from the right. -->
-    <aside id="settings" aria-label="Settings">
+    <aside id="settings" aria-label="Settings" data-i18n-aria="settings.title">
       <div class="panel-head glass-bar">
-        <button class="mini-btn" id="settings-close">&#8592; Done</button>
-        <span class="panel-title">Settings</span>
+        <button class="mini-btn" id="settings-close" data-i18n="settings.done">&#8592; Done</button>
+        <span class="panel-title" data-i18n="settings.title">Settings</span>
       </div>
 
       <div class="acc-group open">
-        <button class="acc-head">General <span class="chev">&#8964;</span></button>
+        <button class="acc-head"><span data-i18n="settings.general">General</span> <span class="chev">&#8964;</span></button>
         <div class="acc-body"><div class="acc-inner">
           <div class="setting-row">
-            <label for="interval">Refresh every</label>
-            <input id="interval" type="number" min="1" max="120" value="5" /> <span class="unit">min</span>
+            <label for="locale" data-i18n="settings.language">Language</label>
+            <select id="locale">
+              <option value="auto" data-i18n="settings.langAuto">Auto</option>
+              <option value="en" data-i18n="settings.langEn">English</option>
+              <option value="zh" data-i18n="settings.langZh">中文</option>
+            </select>
           </div>
           <div class="setting-row">
-            <label class="toggle"><input id="autostart" type="checkbox" /> Start with Windows</label>
+            <label for="interval" data-i18n="settings.refreshEvery">Refresh every</label>
+            <input id="interval" type="number" min="1" max="120" value="5" /> <span class="unit" data-i18n="settings.min">min</span>
           </div>
           <div class="setting-row">
-            <label class="toggle"><input id="pacing" type="checkbox" /> Always show pacing</label>
+            <label class="toggle"><input id="autostart" type="checkbox" /> <span data-i18n="settings.startWithWindows">Start with Windows</span></label>
           </div>
           <div class="setting-row">
-            <label for="pinned">Tray icon shows</label>
+            <label class="toggle"><input id="pacing" type="checkbox" /> <span data-i18n="settings.pacing">Always show pacing</span></label>
+          </div>
+          <div class="setting-row">
+            <label for="pinned" data-i18n="settings.trayShows">Tray icon shows</label>
             <select id="pinned"></select>
           </div>
           <div class="setting-row">
-            <label for="timeformat">Time format</label>
+            <label for="timeformat" data-i18n="settings.timeFormat">Time format</label>
             <select id="timeformat">
-              <option value="auto">Auto</option>
-              <option value="12">12-hour</option>
-              <option value="24">24-hour</option>
+              <option value="auto" data-i18n="settings.timeAuto">Auto</option>
+              <option value="12" data-i18n="settings.time12">12-hour</option>
+              <option value="24" data-i18n="settings.time24">24-hour</option>
             </select>
           </div>
           <div class="setting-row">
-            <label for="appearance">Appearance</label>
+            <label for="appearance" data-i18n="settings.appearance">Appearance</label>
             <select id="appearance">
-              <option value="system">System</option>
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
+              <option value="system" data-i18n="settings.appearSystem">System</option>
+              <option value="light" data-i18n="settings.appearLight">Light</option>
+              <option value="dark" data-i18n="settings.appearDark">Dark</option>
             </select>
           </div>
           <div class="setting-row">
-            <label class="toggle"><input id="density" type="checkbox" /> Compact layout</label>
+            <label class="toggle"><input id="density" type="checkbox" /> <span data-i18n="settings.compact">Compact layout</span></label>
           </div>
           <div class="setting-row">
-            <label class="toggle" title="Turn off on slower PCs — replaces the glass refraction with a simple solid look"><input id="glass" type="checkbox" /> Liquid glass effects</label>
+            <label class="toggle" title="Turn off on slower PCs — replaces the glass refraction with a simple solid look" data-i18n-title="settings.glassTip"><input id="glass" type="checkbox" /> <span data-i18n="settings.glass">Liquid glass effects</span></label>
           </div>
           <div class="setting-row">
-            <label class="toggle" title="Skip card entrance motion and the day/night wipe. Windows' own 'Animation effects' setting is still respected."><input id="reduce-anim" type="checkbox" /> Reduce animations</label>
+            <label class="toggle" title="Skip card entrance motion and the day/night wipe. Windows' own 'Animation effects' setting is still respected." data-i18n-title="settings.reduceAnimTip"><input id="reduce-anim" type="checkbox" /> <span data-i18n="settings.reduceAnim">Reduce animations</span></label>
           </div>
           <div class="setting-row">
-            <label class="toggle"><input id="show-total-spend" type="checkbox" /> Show Total Spend card</label>
+            <label class="toggle"><input id="show-total-spend" type="checkbox" /> <span data-i18n="settings.showSpend">Show Total Spend card</span></label>
           </div>
           <div class="setting-row">
-            <label for="shortcut">Global shortcut</label>
-            <input id="shortcut" type="text" placeholder="e.g. Ctrl+Shift+U" spellcheck="false" />
+            <label for="shortcut" data-i18n="settings.shortcut">Global shortcut</label>
+            <input id="shortcut" type="text" placeholder="e.g. Ctrl+Shift+U" data-i18n-placeholder="settings.shortcutPh" spellcheck="false" />
           </div>
         </div></div>
       </div>
 
       <div class="acc-group">
-        <button class="acc-head">Notifications <span class="chev">&#8964;</span></button>
+        <button class="acc-head"><span data-i18n="settings.notifications">Notifications</span> <span class="chev">&#8964;</span></button>
         <div class="acc-body"><div class="acc-inner">
-          <p class="settings-note">
+          <p class="settings-note" data-i18n="settings.notifyNote">
             Windows toasts when a quota worsens — once per metric per reset period.
           </p>
           <div class="setting-row">
-            <label class="toggle"><input id="notify-almost" type="checkbox" /> Almost out (&lt;10% left)</label>
+            <label class="toggle"><input id="notify-almost" type="checkbox" /> <span data-i18n="settings.notifyAlmost">Almost out (&lt;10% left)</span></label>
           </div>
           <div class="setting-row">
-            <label class="toggle"><input id="notify-close" type="checkbox" /> Cutting it close</label>
+            <label class="toggle"><input id="notify-close" type="checkbox" /> <span data-i18n="settings.notifyClose">Cutting it close</span></label>
           </div>
           <div class="setting-row">
-            <label class="toggle"><input id="notify-runout" type="checkbox" /> Will run out</label>
+            <label class="toggle"><input id="notify-runout" type="checkbox" /> <span data-i18n="settings.notifyRunout">Will run out</span></label>
           </div>
         </div></div>
       </div>
 
       <div class="acc-group">
-        <button class="acc-head">Privacy <span class="chev">&#8964;</span></button>
+        <button class="acc-head"><span data-i18n="settings.privacy">Privacy</span> <span class="chev">&#8964;</span></button>
         <div class="acc-body"><div class="acc-inner">
-          <p class="settings-note">
+          <p class="settings-note" data-i18n="settings.privacyNote">
             One anonymous "alive today" ping and per-provider success/failure
             counts, once a day, under a random ID attached to nothing. No
             usage amounts, no spend, no IPs stored. Full details in
             docs/privacy.md.
           </p>
           <div class="setting-row">
-            <label class="toggle"><input id="telemetry" type="checkbox" /> Share anonymous usage statistics</label>
+            <label class="toggle"><input id="telemetry" type="checkbox" /> <span data-i18n="settings.telemetry">Share anonymous usage statistics</span></label>
           </div>
           <div class="setting-row">
-            <label class="toggle" title="During Presentation Settings, exclusive fullscreen, or remote control, tray percentages hide. The Pane icon and starred provider logos stay. A Teams/Zoom window share is not detected. Off by default."><input id="hide-while-sharing" type="checkbox" /> Hide tray numbers while screen sharing</label>
+            <label class="toggle" title="During Presentation Settings, exclusive fullscreen, or remote control, tray percentages hide. The Pane icon and starred provider logos stay. A Teams/Zoom window share is not detected. Off by default." data-i18n-title="settings.hideSharingTip"><input id="hide-while-sharing" type="checkbox" /> <span data-i18n="settings.hideSharing">Hide tray numbers while screen sharing</span></label>
           </div>
         </div></div>
       </div>
 
       <div class="acc-group">
-        <button class="acc-head">Network <span class="chev">&#8964;</span></button>
+        <button class="acc-head"><span data-i18n="settings.network">Network</span> <span class="chev">&#8964;</span></button>
         <div class="acc-body"><div class="acc-inner">
           <div class="setting-row">
-            <label class="toggle"><input id="proxy-enabled" type="checkbox" /> Use proxy</label>
+            <label class="toggle"><input id="proxy-enabled" type="checkbox" /> <span data-i18n="settings.useProxy">Use proxy</span></label>
           </div>
           <div class="setting-row">
-            <label for="proxy-url">Proxy URL</label>
+            <label for="proxy-url" data-i18n="settings.proxyUrl">Proxy URL</label>
             <input id="proxy-url" type="text" placeholder="socks5://host:1080" spellcheck="false" />
           </div>
-          <p class="settings-note">
+          <p class="settings-note" data-i18n="settings.networkNote">
             Applies after the app restarts. Local usage API always runs at
             http://127.0.0.1:6736/v1/usage
           </p>
@@ -216,85 +224,85 @@
       </div>
 
       <div class="acc-group">
-        <button class="acc-head">API keys <span class="chev">&#8964;</span></button>
+        <button class="acc-head"><span data-i18n="settings.apiKeys">API keys</span> <span class="chev">&#8964;</span></button>
         <div class="acc-body"><div class="acc-inner">
-          <p class="settings-note">
+          <p class="settings-note" data-i18n="settings.apiKeysNote">
             Stored only on this PC (%APPDATA%\Pane). Leave empty and save to remove.
           </p>
           <div class="key-row">
             <label for="key-openrouter">OpenRouter</label>
             <input id="key-openrouter" type="password" placeholder="sk-or-v1-…" />
-            <button data-save="openrouter">Save</button>
+            <button data-save="openrouter" data-i18n="settings.save">Save</button>
           </div>
           <div class="key-row">
             <label for="key-zai">Z.ai</label>
-            <input id="key-zai" type="password" placeholder="API key" />
-            <button data-save="zai">Save</button>
+            <input id="key-zai" type="password" placeholder="API key" data-i18n-placeholder="settings.keyPlaceholder" />
+            <button data-save="zai" data-i18n="settings.save">Save</button>
           </div>
           <div class="key-row">
             <label for="key-minimax">MiniMax</label>
-            <input id="key-minimax" type="password" placeholder="API key (auto-detected from CLI)" />
-            <button data-save="minimax">Save</button>
+            <input id="key-minimax" type="password" placeholder="API key (auto-detected from CLI)" data-i18n-placeholder="settings.keyPhMinimax" />
+            <button data-save="minimax" data-i18n="settings.save">Save</button>
           </div>
           <div class="key-row">
             <label for="key-deepseek">DeepSeek</label>
             <input id="key-deepseek" type="password" placeholder="sk-…" />
-            <button data-save="deepseek">Save</button>
+            <button data-save="deepseek" data-i18n="settings.save">Save</button>
           </div>
           <div class="key-row">
             <label for="key-moonshot">Kimi API</label>
-            <input id="key-moonshot" type="password" placeholder="sk-… (platform.kimi.ai key)" />
-            <button data-save="moonshot">Save</button>
+            <input id="key-moonshot" type="password" placeholder="sk-… (platform.kimi.ai key)" data-i18n-placeholder="settings.keyPhMoonshot" />
+            <button data-save="moonshot" data-i18n="settings.save">Save</button>
           </div>
           <div class="key-row">
             <label for="key-elevenlabs">ElevenLabs</label>
-            <input id="key-elevenlabs" type="password" placeholder="API key" />
-            <button data-save="elevenlabs">Save</button>
+            <input id="key-elevenlabs" type="password" placeholder="API key" data-i18n-placeholder="settings.keyPlaceholder" />
+            <button data-save="elevenlabs" data-i18n="settings.save">Save</button>
           </div>
           <div class="key-row">
             <label for="key-codebuff">Codebuff</label>
-            <input id="key-codebuff" type="password" placeholder="API key (auto-detected from CLI)" />
-            <button data-save="codebuff">Save</button>
+            <input id="key-codebuff" type="password" placeholder="API key (auto-detected from CLI)" data-i18n-placeholder="settings.keyPhCodebuff" />
+            <button data-save="codebuff" data-i18n="settings.save">Save</button>
           </div>
           <div class="key-row">
             <label for="key-kilo">Kilo</label>
-            <input id="key-kilo" type="password" placeholder="API key (auto-detected from CLI)" />
-            <button data-save="kilo">Save</button>
+            <input id="key-kilo" type="password" placeholder="API key (auto-detected from CLI)" data-i18n-placeholder="settings.keyPhKilo" />
+            <button data-save="kilo" data-i18n="settings.save">Save</button>
           </div>
           <div class="key-row">
             <label for="key-aihubmix">AihubMix</label>
-            <input id="key-aihubmix" type="password" placeholder="sk-… (auto-detected from OpenCode)" />
-            <button data-save="aihubmix">Save</button>
+            <input id="key-aihubmix" type="password" placeholder="sk-… (auto-detected from OpenCode)" data-i18n-placeholder="settings.keyPhAihubmix" />
+            <button data-save="aihubmix" data-i18n="settings.save">Save</button>
           </div>
           <div class="key-row">
             <label for="key-qwen">Qwen Code</label>
-            <input id="key-qwen" type="password" placeholder="sk-sp-… (auto-detected from env)" />
-            <button data-save="qwen">Save</button>
+            <input id="key-qwen" type="password" placeholder="sk-sp-… (auto-detected from env)" data-i18n-placeholder="settings.keyPhQwen" />
+            <button data-save="qwen" data-i18n="settings.save">Save</button>
           </div>
         </div></div>
       </div>
 
       <div class="acc-group">
-        <button class="acc-head">Advanced <span class="chev">&#8964;</span></button>
+        <button class="acc-head"><span data-i18n="settings.advanced">Advanced</span> <span class="chev">&#8964;</span></button>
         <div class="acc-body"><div class="acc-inner">
-          <p class="settings-note">
+          <p class="settings-note" data-i18n="settings.advancedNote">
             Restores every preference to its default and re-detects installed
             tools. API keys and your usage history stay. Proxy changes still
             need a restart.
           </p>
-          <button id="reset-all-settings" type="button" class="danger-btn">
+          <button id="reset-all-settings" type="button" class="danger-btn" data-i18n="settings.resetAll">
             Reset all settings
           </button>
         </div></div>
       </div>
 
-      <button id="changelog-btn" type="button">
+      <button id="changelog-btn" type="button" data-i18n="settings.changelog">
         What&#8217;s new &#183; Changelog
       </button>
 
-      <p class="settings-note" style="margin-top: 12px">
+      <p class="settings-note" style="margin-top: 12px" data-i18n="settings.customizeHint">
         Providers, row order, and tray-strip stars live in
-        <strong>Customize</strong> (&#9776; in the sidebar). Star up to 2
+        Customize (&#9776; in the sidebar). Star up to 2
         metrics per provider there to show them as tray icons.
       </p>
     </aside>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,5 +40,5 @@ toml = "0.8"
 regex = "1"
 webview2-com = "0.38"
 windows-core = "0.61"
-windows = { version = "0.61", features = ["Win32_Foundation", "Win32_Security_Credentials", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
+windows = { version = "0.61", features = ["Win32_Foundation", "Win32_Globalization", "Win32_Security_Credentials", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 

--- a/src-tauri/src/alerts.rs
+++ b/src-tauri/src/alerts.rs
@@ -120,22 +120,40 @@ pub fn evaluate(snapshots: &[Snapshot], cfg: &Value) -> Vec<Alert> {
             entry.seen = true;
 
             if !baseline {
-                let name = format!("{} {}", snapshot.name, metric.label);
+                let shown = crate::i18n::metric_label(cfg, &metric.label);
+                let name = format!("{} {}", snapshot.name, shown);
+                let zh = crate::i18n::is_zh(cfg);
                 if want_runout && run_out_now && !entry.run_out {
                     alerts.push(Alert {
-                        title: "Will Run Out".into(),
-                        body: format!("{name} is on pace to hit its limit before the reset."),
+                        title: if zh { "将会用完".into() } else { "Will Run Out".into() },
+                        body: if zh {
+                            format!("{name} 按当前速度会在重置前用完。")
+                        } else {
+                            format!("{name} is on pace to hit its limit before the reset.")
+                        },
                     });
                 } else if want_close && close_now && !entry.close {
                     alerts.push(Alert {
-                        title: "Cutting It Close".into(),
-                        body: format!("{name} is on pace to finish with only ~{spare:.0}% spare."),
+                        title: if zh {
+                            "余量紧张".into()
+                        } else {
+                            "Cutting It Close".into()
+                        },
+                        body: if zh {
+                            format!("{name} 按当前速度重置时大约只剩 {spare:.0}%。")
+                        } else {
+                            format!("{name} is on pace to finish with only ~{spare:.0}% spare.")
+                        },
                     });
                 }
                 if want_almost && almost_now && !entry.almost_out {
                     alerts.push(Alert {
-                        title: "Almost Out".into(),
-                        body: format!("{name} is under 10% remaining ({left:.0}% left)."),
+                        title: if zh { "即将用完".into() } else { "Almost Out".into() },
+                        body: if zh {
+                            format!("{name} 剩余不足 10%（还剩 {left:.0}%）。")
+                        } else {
+                            format!("{name} is under 10% remaining ({left:.0}% left).")
+                        },
                     });
                 }
             }

--- a/src-tauri/src/i18n.rs
+++ b/src-tauri/src/i18n.rs
@@ -1,0 +1,111 @@
+//! UI locale for tray + Windows toasts. The popover translates in TypeScript;
+//! these strings have to live here because they are painted by Rust.
+
+use serde_json::Value;
+
+pub fn resolved_locale(cfg: &Value) -> &'static str {
+    match cfg.get("locale").and_then(Value::as_str) {
+        Some("zh") => "zh",
+        Some("en") => "en",
+        _ => {
+            if system_locale_is_zh() {
+                "zh"
+            } else {
+                "en"
+            }
+        }
+    }
+}
+
+pub fn is_zh(cfg: &Value) -> bool {
+    resolved_locale(cfg) == "zh"
+}
+
+pub fn quit_label(cfg: &Value) -> &'static str {
+    if is_zh(cfg) {
+        "退出 Pane"
+    } else {
+        "Quit Pane"
+    }
+}
+
+pub fn metric_label(cfg: &Value, label: &str) -> String {
+    if !is_zh(cfg) {
+        return label.to_string();
+    }
+    match label {
+        "Session" => "会话".into(),
+        "Weekly" => "每周".into(),
+        "Monthly" => "每月".into(),
+        "Daily" => "每天".into(),
+        "Usage" => "用量".into(),
+        "Credits" => "额度".into(),
+        "Credits used" => "已用额度".into(),
+        "API" => "API".into(),
+        "Balance" => "余额".into(),
+        "Vouchers" => "代金券".into(),
+        "Cash" => "现金".into(),
+        "Limit" => "上限".into(),
+        "Used" => "已用".into(),
+        "On-demand" => "按量".into(),
+        "Cursor Models" => "Cursor 模型".into(),
+        "Other Models" => "其他模型".into(),
+        "Total usage" => "总用量".into(),
+        "Bonus" => "赠送".into(),
+        "Extra usage" => "额外用量".into(),
+        "Extra credits" => "额外额度".into(),
+        "Reset credits" => "重置额度".into(),
+        "Extra balance" => "额外余额".into(),
+        "Kilo Pass" => "Kilo Pass".into(),
+        "Requests today" => "今日请求".into(),
+        "Requests this month" => "本月请求".into(),
+        "Requests this cycle" => "本周期请求".into(),
+        "Last used" => "上次使用".into(),
+        "Via" => "经由".into(),
+        "Sessions" => "会话数".into(),
+        other if other.ends_with(" weekly") => {
+            format!("{} 每周", other.trim_end_matches(" weekly"))
+        }
+        other => other.to_string(),
+    }
+}
+
+pub fn pct_left(cfg: &Value, name: &str, label: &str, left: f64) -> String {
+    let shown = metric_label(cfg, label);
+    if is_zh(cfg) {
+        format!("{name} {shown}: 剩余 {left:.0}%")
+    } else {
+        format!("{name} {shown}: {left:.0}% left")
+    }
+}
+
+fn system_locale_is_zh() -> bool {
+    use windows::Win32::Globalization::GetUserDefaultLocaleName;
+    let mut buf = [0u16; 85];
+    let n = unsafe { GetUserDefaultLocaleName(&mut buf) };
+    if n <= 1 {
+        return false;
+    }
+    let s = String::from_utf16_lossy(&buf[..(n as usize - 1)]);
+    s.to_ascii_lowercase().starts_with("zh")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn explicit_locale_wins() {
+        assert_eq!(resolved_locale(&json!({"locale": "zh"})), "zh");
+        assert_eq!(resolved_locale(&json!({"locale": "en"})), "en");
+    }
+
+    #[test]
+    fn zh_metric_labels() {
+        let zh = json!({"locale": "zh"});
+        assert_eq!(metric_label(&zh, "Session"), "会话");
+        assert_eq!(metric_label(&zh, "Sonnet weekly"), "Sonnet 每周");
+        assert_eq!(metric_label(&json!({"locale": "en"}), "Session"), "Session");
+    }
+}

--- a/src-tauri/src/i18n.rs
+++ b/src-tauri/src/i18n.rs
@@ -79,15 +79,17 @@ pub fn pct_left(cfg: &Value, name: &str, label: &str, left: f64) -> String {
     }
 }
 
-fn system_locale_is_zh() -> bool {
-    use windows::Win32::Globalization::GetUserDefaultLocaleName;
-    let mut buf = [0u16; 85];
-    let n = unsafe { GetUserDefaultLocaleName(&mut buf) };
-    if n <= 1 {
-        return false;
-    }
-    let s = String::from_utf16_lossy(&buf[..(n as usize - 1)]);
-    s.to_ascii_lowercase().starts_with("zh")
+/// Primary language 0x04 = Chinese (zh-CN, zh-TW, zh-HK, …).
+fn langid_is_zh(langid: u16) -> bool {
+    const LANG_CHINESE: u16 = 0x04;
+    langid & 0x03FF == LANG_CHINESE
+}
+
+/// Windows *display* language, not the regional-format locale.
+/// Same source the popover asks for via `system_ui_locale`.
+pub fn system_locale_is_zh() -> bool {
+    use windows::Win32::Globalization::GetUserDefaultUILanguage;
+    langid_is_zh(unsafe { GetUserDefaultUILanguage() })
 }
 
 #[cfg(test)]
@@ -107,5 +109,14 @@ mod tests {
         assert_eq!(metric_label(&zh, "Session"), "会话");
         assert_eq!(metric_label(&zh, "Sonnet weekly"), "Sonnet 每周");
         assert_eq!(metric_label(&json!({"locale": "en"}), "Session"), "Session");
+    }
+
+    #[test]
+    fn chinese_langids_match() {
+        assert!(langid_is_zh(0x0804)); // zh-CN
+        assert!(langid_is_zh(0x0404)); // zh-TW
+        assert!(langid_is_zh(0x0C04)); // zh-HK
+        assert!(!langid_is_zh(0x0409)); // en-US
+        assert!(!langid_is_zh(0x0411)); // ja
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -115,6 +115,15 @@ fn config_with_defaults(mut cfg: Value) -> Value {
 }
 
 #[tauri::command]
+fn system_ui_locale() -> &'static str {
+    if i18n::system_locale_is_zh() {
+        "zh"
+    } else {
+        "en"
+    }
+}
+
+#[tauri::command]
 fn get_config() -> Value {
     config_with_defaults(load_config())
 }
@@ -1575,6 +1584,7 @@ pub fn run() {
             set_api_key,
             get_config,
             set_config,
+            system_ui_locale,
             get_autostart,
             set_autostart,
             update_tray_strip,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -195,6 +195,16 @@ fn set_config(app: tauri::AppHandle, patch: Value) -> Result<Value, String> {
 }
 
 fn apply_tray_locale(app: &tauri::AppHandle, cfg: &Value) {
+    let next = i18n::resolved_locale(cfg);
+    static LAST: Mutex<Option<&'static str>> = Mutex::new(None);
+    let Ok(mut last) = LAST.lock() else {
+        return;
+    };
+    if *last == Some(next) {
+        return;
+    }
+    *last = Some(next);
+    drop(last);
     let Ok(quit) = MenuItem::with_id(app, "quit", i18n::quit_label(cfg), true, None::<&str>) else {
         return;
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod alerts;
 mod httpapi;
+mod i18n;
 mod pricing;
 mod providers;
 mod spend;
@@ -109,6 +110,7 @@ fn config_with_defaults(mut cfg: Value) -> Value {
     obj.entry("telemetry").or_insert(json!(true));
     obj.entry("reduceAnimations").or_insert(json!(false));
     obj.entry("hideUsageWhileSharing").or_insert(json!(false));
+    obj.entry("locale").or_insert(json!("auto"));
     cfg
 }
 
@@ -150,15 +152,20 @@ const CONFIG_KEYS: &[&str] = &[
     "telemetry",
     "reduceAnimations",
     "hideUsageWhileSharing",
+    "locale",
 ];
 
-#[tauri::command]
-fn set_config(patch: Value) -> Result<Value, String> {
+fn set_config_inner(patch: Value) -> Result<Value, String> {
     let mut cfg = config_with_defaults(load_config());
     if let (Some(target), Some(source)) = (cfg.as_object_mut(), patch.as_object()) {
         for (k, v) in source {
             if CONFIG_KEYS.contains(&k.as_str()) {
-                target.insert(k.clone(), v.clone());
+                if k == "locale" {
+                    let ok = matches!(v.as_str(), Some("auto" | "en" | "zh"));
+                    target.insert(k.clone(), if ok { v.clone() } else { json!("auto") });
+                } else {
+                    target.insert(k.clone(), v.clone());
+                }
             } else {
                 eprintln!("[pane] set_config: ignoring unknown key '{k}'");
             }
@@ -180,6 +187,25 @@ fn set_config(patch: Value) -> Result<Value, String> {
     Ok(cfg)
 }
 
+#[tauri::command]
+fn set_config(app: tauri::AppHandle, patch: Value) -> Result<Value, String> {
+    let cfg = set_config_inner(patch)?;
+    apply_tray_locale(&app, &cfg);
+    Ok(cfg)
+}
+
+fn apply_tray_locale(app: &tauri::AppHandle, cfg: &Value) {
+    let Ok(quit) = MenuItem::with_id(app, "quit", i18n::quit_label(cfg), true, None::<&str>) else {
+        return;
+    };
+    let Ok(menu) = Menu::with_items(app, &[&quit]) else {
+        return;
+    };
+    if let Some(tray) = app.tray_by_id("tray") {
+        let _ = tray.set_menu(Some(menu));
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Start with Windows
 // ---------------------------------------------------------------------------
@@ -194,7 +220,7 @@ fn get_autostart(app: tauri::AppHandle) -> bool {
 fn set_autostart(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
     use tauri_plugin_autostart::ManagerExt;
     // Remember the choice so startup knows whether to re-assert it.
-    let _ = set_config(json!({ "autostart": enabled }));
+    let _ = set_config_inner(json!({ "autostart": enabled }));
     let manager = app.autolaunch();
     if enabled {
         manager.enable().map_err(|e| e.to_string())
@@ -333,7 +359,8 @@ fn update_tray(app: &tauri::AppHandle, snapshots: &[providers::Snapshot], cfg: &
     for s in snapshots.iter().filter(|s| s.status == "ok").take(6) {
         if let Some(m) = s.metrics.iter().find(|m| m.kind == "progress") {
             let left = (100.0 - m.used_percent.unwrap_or(0.0)).clamp(0.0, 100.0).round();
-            tooltip.push_str(&format!("\n{} {}: {left:.0}% left", s.name, m.label));
+            tooltip.push('\n');
+            tooltip.push_str(&i18n::pct_left(cfg, &s.name, &m.label, left));
         }
     }
 
@@ -1551,7 +1578,13 @@ pub fn run() {
         .setup(|app| {
             spawn_update_checker(app.handle());
             spawn_share_watcher(app.handle().clone());
-            let quit = MenuItem::with_id(app, "quit", "Quit Pane", true, None::<&str>)?;
+            let quit = MenuItem::with_id(
+                app,
+                "quit",
+                i18n::quit_label(&config_with_defaults(load_config())),
+                true,
+                None::<&str>,
+            )?;
             let menu = Menu::with_items(app, &[&quit])?;
 
             TrayIconBuilder::with_id("tray")

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,754 @@
+// Frontend locale: Settings stores auto / en / zh. Metric row labels from
+// Rust stay English in config.layout (stars, pins, Customize keys); only
+// the painted text switches.
+
+export type LocalePref = "auto" | "en" | "zh";
+export type Locale = "en" | "zh";
+
+type Dict = Record<string, string>;
+
+const en: Dict = {
+  "sidebar.theme": "Light / dark mode",
+  "sidebar.refresh": "Refresh now",
+  "sidebar.customize": "Customize",
+  "sidebar.settings": "Settings",
+  "sidebar.cards": "Card navigation",
+
+  "footer.starting": "Starting…",
+  "footer.refreshing": "Refreshing…",
+  "footer.updated": "Updated {time}",
+  "footer.refreshFailed": "Refresh failed: {err}",
+  "footer.keySaved": "{name} key saved",
+  "footer.keySaveFailed": "Could not save key: {err}",
+  "footer.shortcutSaved": "Shortcut saved",
+  "footer.shortcutCleared": "Shortcut cleared",
+  "footer.proxySaved": "Proxy saved — takes effect after restart",
+  "footer.autostartFailed": "Autostart failed: {err}",
+  "footer.copied": "Copied to clipboard",
+  "footer.shareFailed": "Share failed: {err}",
+  "footer.updateFailed": "Update failed: {err}",
+  "footer.openLinkFailed": "Could not open link: {err}",
+  "footer.twoStars": "Up to 2 stars per provider",
+  "footer.redeeming": "Redeeming reset credit…",
+  "footer.redeemFailed": "Redeem failed: {err}",
+
+  "update.check": "Checking for updates…",
+  "update.to": "⬆ Update to v{version}",
+  "update.installing": "Installing…",
+  "update.retry": "⬆ Update to v{version} — retry",
+
+  "settings.done": "← Done",
+  "settings.title": "Settings",
+  "settings.general": "General",
+  "settings.language": "Language",
+  "settings.langAuto": "Auto",
+  "settings.langEn": "English",
+  "settings.langZh": "中文",
+  "settings.refreshEvery": "Refresh every",
+  "settings.min": "min",
+  "settings.startWithWindows": "Start with Windows",
+  "settings.pacing": "Always show pacing",
+  "settings.trayShows": "Tray icon shows",
+  "settings.pinAuto": "Auto (first live metric)",
+  "settings.pinOption": "{name} — {label}",
+  "settings.timeFormat": "Time format",
+  "settings.timeAuto": "Auto",
+  "settings.time12": "12-hour",
+  "settings.time24": "24-hour",
+  "settings.appearance": "Appearance",
+  "settings.appearSystem": "System",
+  "settings.appearLight": "Light",
+  "settings.appearDark": "Dark",
+  "settings.compact": "Compact layout",
+  "settings.glass": "Liquid glass effects",
+  "settings.glassTip":
+    "Turn off on slower PCs — replaces the glass refraction with a simple solid look",
+  "settings.reduceAnim": "Reduce animations",
+  "settings.reduceAnimTip":
+    "Skip card entrance motion and the day/night wipe. Windows' own 'Animation effects' setting is still respected.",
+  "settings.showSpend": "Show Total Spend card",
+  "settings.shortcut": "Global shortcut",
+  "settings.shortcutPh": "e.g. Ctrl+Shift+U",
+
+  "settings.notifications": "Notifications",
+  "settings.notifyNote":
+    "Windows toasts when a quota worsens — once per metric per reset period.",
+  "settings.notifyAlmost": "Almost out (<10% left)",
+  "settings.notifyClose": "Cutting it close",
+  "settings.notifyRunout": "Will run out",
+
+  "settings.privacy": "Privacy",
+  "settings.privacyNote":
+    'One anonymous "alive today" ping and per-provider success/failure counts, once a day, under a random ID attached to nothing. No usage amounts, no spend, no IPs stored. Full details in docs/privacy.md.',
+  "settings.telemetry": "Share anonymous usage statistics",
+  "settings.hideSharing": "Hide tray numbers while screen sharing",
+  "settings.hideSharingTip":
+    "During Presentation Settings, exclusive fullscreen, or remote control, tray percentages hide. The Pane icon and starred provider logos stay. A Teams/Zoom window share is not detected. Off by default.",
+
+  "settings.network": "Network",
+  "settings.useProxy": "Use proxy",
+  "settings.proxyUrl": "Proxy URL",
+  "settings.networkNote":
+    "Applies after the app restarts. Local usage API always runs at http://127.0.0.1:6736/v1/usage",
+
+  "settings.apiKeys": "API keys",
+  "settings.apiKeysNote":
+    "Stored only on this PC (%APPDATA%\\Pane). Leave empty and save to remove.",
+  "settings.save": "Save",
+  "settings.keyPlaceholder": "API key",
+  "settings.keyPhMinimax": "API key (auto-detected from CLI)",
+  "settings.keyPhMoonshot": "sk-… (platform.kimi.ai key)",
+  "settings.keyPhCodebuff": "API key (auto-detected from CLI)",
+  "settings.keyPhKilo": "API key (auto-detected from CLI)",
+  "settings.keyPhAihubmix": "sk-… (auto-detected from OpenCode)",
+  "settings.keyPhQwen": "sk-sp-… (auto-detected from env)",
+
+  "settings.advanced": "Advanced",
+  "settings.advancedNote":
+    "Restores every preference to its default and re-detects installed tools. API keys and your usage history stay. Proxy changes still need a restart.",
+  "settings.resetAll": "Reset all settings",
+  "settings.changelog": "What's new · Changelog",
+  "settings.customizeHint":
+    "Providers, row order, and tray-strip stars live in Customize (☰ in the sidebar). Star up to 2 metrics per provider there to show them as tray icons.",
+
+  "settings.resetTitle": "Reset all settings?",
+  "settings.resetBody":
+    "Theme, density, notifications, shortcut, proxy, pacing, tray stars, and card layouts go back to defaults. Installed tools are re-detected. API keys and usage history stay. A proxy change still needs a restart.",
+  "settings.resetConfirm": "Reset all",
+
+  "dialog.cancel": "Cancel",
+  "dialog.gotIt": "Got it",
+  "dialog.changelog": "Changelog",
+  "dialog.whatsNew": "What's new in v{version}",
+
+  "card.notConnected": "Not connected",
+  "card.outdated": "⚠ Outdated",
+  "card.showMore": "Show more",
+  "card.showLess": "Show less",
+  "card.share": "Copy card as image",
+  "card.drag": "Drag to reorder",
+  "card.notStarted": "Not started",
+  "card.notStartedTip": "Sessions start after you send your first message.",
+  "card.resetsSoon": "Resets soon",
+  "card.resetsIn": "Resets in {time}",
+  "card.resetsAt": "Resets {when}",
+  "card.expires": "Expires {when}",
+  "card.available": "Available",
+  "card.use": "Use",
+  "card.useTip": "Spend this credit to reset your Codex rate limits now",
+  "card.creditDying": "This credit expires in {time} — use it or lose it.",
+  "card.pctUsed": "{n}% used",
+  "card.pctLeft": "{n}% left",
+  "card.noData": "No data",
+  "card.tokens": "{n} tokens",
+  "card.tokensEst": "{cost} · {n} tokens · estimated",
+  "card.tokensPlain": "{cost} · {n} tokens",
+
+  "pace.limitReached": "🔥 Limit reached",
+  "pace.limitReachedTitle": "Limit reached",
+  "pace.limitAt": "Limit {when}",
+  "pace.limitIn": "Limit in {time}",
+  "pace.overReset": "~{n}% over limit at reset",
+  "pace.fullReset": "~100% used at reset",
+  "pace.spare": "~{n}% spare",
+  "pace.usedReset": "~{n}% used at reset",
+  "pace.leftReset": "~{n}% left at reset",
+
+  "time.today": "today at {time}",
+  "time.tomorrow": "tomorrow at {time}",
+  "time.dateAt": "{date} at {time}",
+  "time.daysHours": "{d}d {h}h",
+  "time.hoursMins": "{h}h {m}m",
+  "time.mins": "{m}m",
+
+  "stale.lastFailed": "The last refresh failed",
+  "stale.reloginDefault":
+    "add the API key again in Settings (or sign in with the tool once)",
+  "stale.fixRetry": "Pane keeps retrying automatically — nothing to do unless this persists.",
+  "stale.fixDone": "Pane recovers automatically once that's done.",
+  "stale.fixRelogin": "Fix: {how} — Pane picks it up on the next refresh.",
+  "stale.fix429":
+    "The vendor is rate-limiting; Pane waits exactly as long as it asked, then retries by itself.",
+  "stale.fix5xx":
+    "The vendor's API is having trouble; Pane retries automatically until it recovers.",
+  "stale.fixNet":
+    "Pane couldn't reach the vendor — check your internet connection (or the proxy in Settings).",
+  "stale.tail": "Showing the last good data meanwhile.",
+  "stale.relogin.claude": "run `claude` in a terminal and sign in",
+  "stale.relogin.codex": "run `codex login` in a terminal",
+  "stale.relogin.grok": "run `grok` in a terminal and sign in",
+  "stale.relogin.copilot": "run `gh auth login` in a terminal",
+  "stale.relogin.cursor": "open Cursor and sign in again",
+  "stale.relogin.devin": "run `devin` in a terminal and sign in",
+  "stale.relogin.opencode": "run `opencode auth login` in a terminal",
+  "stale.relogin.antigravity": "open Antigravity and sign in again",
+  "stale.relogin.ollama": "make sure Ollama is running",
+  "stale.relogin.hermes":
+    "open the Hermes desktop app once so it writes its local ledger",
+  "stale.relogin.kimi": "run `kimi login` in a terminal",
+
+  "unpriced.tip":
+    "{n} requests ran on models with no public pricing ({models}). Their tokens are included, but they can't be turned into dollars — so the real cost is a little higher than shown.",
+
+  "spend.title": "Total Spend",
+  "spend.scanning": "Scanning session logs…",
+  "spend.emptyFirst":
+    "No spend data yet — appears once Claude Code, Codex, or another CLI logs some usage on this PC.",
+  "spend.emptyPeriod": "No spend in this period.",
+  "spend.emptyPeriodTip": "No spend recorded in this period.",
+  "spend.info":
+    "Fed by: {names}. All figures are local estimates from each tool's own logs.",
+  "spend.clickTip":
+    "{exact} — computed locally from session logs. Click to show {next}.",
+  "spend.today": "Today",
+  "spend.yesterday": "Yesterday",
+  "spend.days30": "30 Days",
+  "spend.last30": "Last 30 Days",
+  "spend.trend": "Usage Trend",
+  "spend.trendTip":
+    "Last 30 days ({from} – {to}) · peak {tokens} tokens on {peak} · from local logs",
+  "spend.others": "Others",
+  "spend.underEach": "Under ${limit} each:",
+  "spend.metric.cost": "dollars",
+  "spend.metric.mtok": "cost per MTok",
+  "spend.metric.tokens": "tokens",
+  "spend.centerTokens": "tokens",
+  "spend.noUsage": "No usage",
+  "spend.of30": "{n}% of the last 30 days",
+  "spend.noModelData": "No model data for this period.",
+
+  "metric.session": "Session",
+  "metric.weekly": "Weekly",
+  "metric.monthly": "Monthly",
+  "metric.daily": "Daily",
+  "metric.usage": "Usage",
+  "metric.credits": "Credits",
+  "metric.creditsUsed": "Credits used",
+  "metric.api": "API",
+  "metric.balance": "Balance",
+  "metric.vouchers": "Vouchers",
+  "metric.cash": "Cash",
+  "metric.limit": "Limit",
+  "metric.used": "Used",
+  "metric.onDemand": "On-demand",
+  "metric.cursorModels": "Cursor Models",
+  "metric.otherModels": "Other Models",
+  "metric.totalUsage": "Total usage",
+  "metric.bonus": "Bonus",
+  "metric.extraUsage": "Extra usage",
+  "metric.extraCredits": "Extra credits",
+  "metric.resetCredits": "Reset credits",
+  "metric.extraBalance": "Extra balance",
+  "metric.kiloPass": "Kilo Pass",
+  "metric.reqToday": "Requests today",
+  "metric.reqMonth": "Requests this month",
+  "metric.reqCycle": "Requests this cycle",
+  "metric.lastUsed": "Last used",
+  "metric.via": "Via",
+  "metric.sessions": "Sessions",
+  "metric.modelWeekly": "{model} weekly",
+
+  "link.Status": "Status",
+  "link.Dashboard": "Dashboard",
+  "link.Usage": "Usage",
+  "link.Credits": "Credits",
+  "link.Platform": "Platform",
+  "link.Activity": "Activity",
+  "link.API Keys": "API Keys",
+  "link.Console": "Console",
+  "link.Coding Plan": "Coding Plan",
+  "link.Library": "Library",
+  "link.Site": "Site",
+  "link.Quota": "Quota",
+  "link.API": "API",
+
+  "welcome.title": "Welcome 👋",
+  "welcome.body":
+    "You're set up with the AI tools found on this PC. Arrange cards, star tray metrics, and hide rows in Customize.",
+  "welcome.open": "Open Customize",
+  "welcome.dismiss": "Dismiss",
+
+  "customize.done": "← Done",
+  "customize.starred": "{n} starred · drag ⠿ to reorder",
+  "customize.resetAll": "↺ Reset all",
+  "customize.resetAllTip":
+    "Restore all cards' default layouts — does not touch your usage limits",
+  "customize.resetLayout": "Reset layout",
+  "customize.resetLayoutTip":
+    "Restore this card's default layout — does not touch your usage limits",
+  "customize.enable": "Enable provider",
+  "customize.expand": "Expand",
+  "customize.collapse": "Collapse",
+  "customize.dragRows": "Drag to reorder",
+  "customize.dragProviders": "Drag to reorder providers",
+  "customize.star": "Star for tray strip (max 2)",
+  "customize.onDemand": "On Demand — behind the card's caret",
+  "customize.noData": "No data yet — refresh with this provider enabled first.",
+  "customize.resetTitle": "Reset all layouts?",
+  "customize.resetBody":
+    "Order, stars, and hidden rows go back to defaults, and installed AI tools are re-detected. Your usage limits are not affected.",
+  "customize.resetConfirm": "Reset all",
+
+  "redeem.title": "Use a reset credit?",
+  "redeem.body":
+    "This resets your Codex rate-limit windows immediately and cannot be undone. The refreshed windows can take a couple of minutes to appear.",
+  "redeem.confirm": "Use credit",
+
+  "share.tagline": "Monitor Your AI Subscriptions with Pane",
+  "tray.left": "{label}: {n}% left",
+
+  "detail.unlimited": "Unlimited",
+  "detail.moneyOfLeft": "{a} of {b} left",
+  "detail.moneyOfLeftCredits": "{a} of {b} left · {n} credits",
+  "detail.moneyLeftOf": "{a} left of {b}",
+  "detail.moneyOfUsed": "{a} of {b} used",
+  "detail.moneyOfLimit": "{a} of {b} limit",
+  "detail.moneyOf": "{a} of {b}",
+  "detail.moneyCredits": "{a} · {n} credits",
+  "detail.countCreditsUsed": "{a} of {b} credits used",
+  "detail.countOfLeft": "{a} of {b} left",
+  "detail.countOfUsed": "{a} of {b} used",
+};
+
+const zh: Dict = {
+  "sidebar.theme": "浅色 / 深色模式",
+  "sidebar.refresh": "立即刷新",
+  "sidebar.customize": "自定义",
+  "sidebar.settings": "设置",
+  "sidebar.cards": "卡片导航",
+
+  "footer.starting": "正在启动…",
+  "footer.refreshing": "正在刷新…",
+  "footer.updated": "已更新 {time}",
+  "footer.refreshFailed": "刷新失败：{err}",
+  "footer.keySaved": "已保存 {name} 密钥",
+  "footer.keySaveFailed": "无法保存密钥：{err}",
+  "footer.shortcutSaved": "快捷键已保存",
+  "footer.shortcutCleared": "快捷键已清除",
+  "footer.proxySaved": "代理已保存 — 重启后生效",
+  "footer.autostartFailed": "开机启动失败：{err}",
+  "footer.copied": "已复制到剪贴板",
+  "footer.shareFailed": "分享失败：{err}",
+  "footer.updateFailed": "更新失败：{err}",
+  "footer.openLinkFailed": "无法打开链接：{err}",
+  "footer.twoStars": "每个服务最多加星 2 项",
+  "footer.redeeming": "正在兑换重置额度…",
+  "footer.redeemFailed": "兑换失败：{err}",
+
+  "update.check": "正在检查更新…",
+  "update.to": "⬆ 更新到 v{version}",
+  "update.installing": "正在安装…",
+  "update.retry": "⬆ 更新到 v{version} — 重试",
+
+  "settings.done": "← 完成",
+  "settings.title": "设置",
+  "settings.general": "常规",
+  "settings.language": "语言",
+  "settings.langAuto": "自动",
+  "settings.langEn": "English",
+  "settings.langZh": "中文",
+  "settings.refreshEvery": "刷新间隔",
+  "settings.min": "分钟",
+  "settings.startWithWindows": "开机启动",
+  "settings.pacing": "始终显示消耗速度",
+  "settings.trayShows": "托盘图标显示",
+  "settings.pinAuto": "自动（第一个可用指标）",
+  "settings.pinOption": "{name} — {label}",
+  "settings.timeFormat": "时间格式",
+  "settings.timeAuto": "自动",
+  "settings.time12": "12 小时",
+  "settings.time24": "24 小时",
+  "settings.appearance": "外观",
+  "settings.appearSystem": "跟随系统",
+  "settings.appearLight": "浅色",
+  "settings.appearDark": "深色",
+  "settings.compact": "紧凑布局",
+  "settings.glass": "液态玻璃效果",
+  "settings.glassTip": "较慢的电脑可以关掉 — 会改成简单的纯色背景",
+  "settings.reduceAnim": "减少动画",
+  "settings.reduceAnimTip":
+    "跳过卡片入场动画和日夜切换过渡。仍会遵守 Windows 自己的“动画效果”设置。",
+  "settings.showSpend": "显示总花费卡片",
+  "settings.shortcut": "全局快捷键",
+  "settings.shortcutPh": "例如 Ctrl+Shift+U",
+
+  "settings.notifications": "通知",
+  "settings.notifyNote": "额度变差时弹出 Windows 提醒 — 每个指标在每个重置周期只提醒一次。",
+  "settings.notifyAlmost": "即将用完（剩余不足 10%）",
+  "settings.notifyClose": "余量紧张",
+  "settings.notifyRunout": "将会用完",
+
+  "settings.privacy": "隐私",
+  "settings.privacyNote":
+    "每天一次匿名的“今天还活着”心跳，以及各服务成功/失败次数，使用一个不绑定任何身份的随机 ID。不上传用量、花费或 IP。详情见 docs/privacy.md。",
+  "settings.telemetry": "分享匿名使用统计",
+  "settings.hideSharing": "共享屏幕时隐藏托盘数字",
+  "settings.hideSharingTip":
+    "演示设置、独占全屏或远程控制时，托盘百分比会隐藏。Pane 图标和已加星的服务标志仍在。检测不到 Teams/Zoom 的窗口共享。默认关闭。",
+
+  "settings.network": "网络",
+  "settings.useProxy": "使用代理",
+  "settings.proxyUrl": "代理地址",
+  "settings.networkNote":
+    "重启应用后生效。本机用量接口始终运行在 http://127.0.0.1:6736/v1/usage",
+
+  "settings.apiKeys": "API 密钥",
+  "settings.apiKeysNote":
+    "只存在这台电脑上（%APPDATA%\\Pane）。留空再保存即可删除。",
+  "settings.save": "保存",
+  "settings.keyPlaceholder": "API 密钥",
+  "settings.keyPhMinimax": "API 密钥（可从 CLI 自动读取）",
+  "settings.keyPhMoonshot": "sk-…（platform.kimi.ai 密钥）",
+  "settings.keyPhCodebuff": "API 密钥（可从 CLI 自动读取）",
+  "settings.keyPhKilo": "API 密钥（可从 CLI 自动读取）",
+  "settings.keyPhAihubmix": "sk-…（可从 OpenCode 自动读取）",
+  "settings.keyPhQwen": "sk-sp-…（可从环境变量自动读取）",
+
+  "settings.advanced": "高级",
+  "settings.advancedNote":
+    "把所有偏好恢复成默认值，并重新检测已安装的工具。API 密钥和用量记录会保留。代理更改仍需重启。",
+  "settings.resetAll": "重置全部设置",
+  "settings.changelog": "更新说明 · 更新日志",
+  "settings.customizeHint":
+    "服务开关、行顺序和托盘加星在「自定义」里（侧栏的 ☰）。每个服务最多加星 2 项，作为托盘图标。",
+
+  "settings.resetTitle": "重置全部设置？",
+  "settings.resetBody":
+    "主题、密度、通知、快捷键、代理、消耗速度、托盘加星和卡片布局都会回到默认。会重新检测已安装的工具。API 密钥和用量记录保留。代理更改仍需重启。",
+  "settings.resetConfirm": "全部重置",
+
+  "dialog.cancel": "取消",
+  "dialog.gotIt": "知道了",
+  "dialog.changelog": "更新日志",
+  "dialog.whatsNew": "v{version} 有什么新内容",
+
+  "card.notConnected": "未连接",
+  "card.outdated": "⚠ 数据过时",
+  "card.showMore": "显示更多",
+  "card.showLess": "收起",
+  "card.share": "复制卡片为图片",
+  "card.drag": "拖动以排序",
+  "card.notStarted": "尚未开始",
+  "card.notStartedTip": "发送第一条消息后，会话窗口才会开始计时。",
+  "card.resetsSoon": "即将重置",
+  "card.resetsIn": "{time}后重置",
+  "card.resetsAt": "{when} 重置",
+  "card.expires": "{when} 过期",
+  "card.available": "可用",
+  "card.use": "使用",
+  "card.useTip": "立刻用掉这张额度，重置 Codex 速率限制",
+  "card.creditDying": "这张额度将在 {time}后过期 — 不用就作废。",
+  "card.pctUsed": "已用 {n}%",
+  "card.pctLeft": "剩余 {n}%",
+  "card.noData": "暂无数据",
+  "card.tokens": "{n} tokens",
+  "card.tokensEst": "{cost} · {n} tokens · 估算",
+  "card.tokensPlain": "{cost} · {n} tokens",
+
+  "pace.limitReached": "🔥 已达上限",
+  "pace.limitReachedTitle": "已达上限",
+  "pace.limitAt": "{when} 达上限",
+  "pace.limitIn": "{time}后达上限",
+  "pace.overReset": "重置时大约超出上限 {n}%",
+  "pace.fullReset": "重置时大约用满",
+  "pace.spare": "大约剩 {n}% 余量",
+  "pace.usedReset": "重置时大约用掉 {n}%",
+  "pace.leftReset": "重置时大约剩 {n}%",
+
+  "time.today": "今天 {time}",
+  "time.tomorrow": "明天 {time}",
+  "time.dateAt": "{date} {time}",
+  "time.daysHours": "{d} 天 {h} 小时",
+  "time.hoursMins": "{h} 小时 {m} 分",
+  "time.mins": "{m} 分钟",
+
+  "stale.lastFailed": "上次刷新失败",
+  "stale.reloginDefault": "在设置里重新粘贴 API 密钥（或用该工具登录一次）",
+  "stale.fixRetry": "Pane 会自动重试 — 除非一直失败，否则不用动手。",
+  "stale.fixDone": "完成后 Pane 会自动恢复。",
+  "stale.fixRelogin": "解决方法：{how} — 下次刷新时 Pane 会接上。",
+  "stale.fix429": "对方在限流；Pane 会按对方要求的时间等待，然后自己重试。",
+  "stale.fix5xx": "对方的接口出了问题；Pane 会自动重试直到恢复。",
+  "stale.fixNet": "连不上对方 — 请检查网络（或设置里的代理）。",
+  "stale.tail": "期间显示上次成功的数据。",
+  "stale.relogin.claude": "在终端运行 `claude` 并登录",
+  "stale.relogin.codex": "在终端运行 `codex login`",
+  "stale.relogin.grok": "在终端运行 `grok` 并登录",
+  "stale.relogin.copilot": "在终端运行 `gh auth login`",
+  "stale.relogin.cursor": "打开 Cursor 并重新登录",
+  "stale.relogin.devin": "在终端运行 `devin` 并登录",
+  "stale.relogin.opencode": "在终端运行 `opencode auth login`",
+  "stale.relogin.antigravity": "打开 Antigravity 并重新登录",
+  "stale.relogin.ollama": "确认 Ollama 正在运行",
+  "stale.relogin.hermes": "打开一次 Hermes 桌面应用，让它写本地账本",
+  "stale.relogin.kimi": "在终端运行 `kimi login`",
+
+  "unpriced.tip":
+    "有 {n} 次请求用了没有公开定价的模型（{models}）。tokens 已计入，但无法换成美元 — 所以真实花费会比显示的略高。",
+
+  "spend.title": "总花费",
+  "spend.scanning": "正在扫描会话日志…",
+  "spend.emptyFirst":
+    "还没有花费数据 — 等这台电脑上的 Claude Code、Codex 或其他 CLI 记下用量后就会出现。",
+  "spend.emptyPeriod": "这段时间没有花费。",
+  "spend.emptyPeriodTip": "这段时间没有记录花费。",
+  "spend.info": "数据来自：{names}。都是根据各工具本地日志估算的。",
+  "spend.clickTip": "{exact} — 根据本地会话日志计算。点击可改为显示{next}。",
+  "spend.today": "今天",
+  "spend.yesterday": "昨天",
+  "spend.days30": "30 天",
+  "spend.last30": "最近 30 天",
+  "spend.trend": "用量趋势",
+  "spend.trendTip":
+    "最近 30 天（{from} – {to}）· 峰值 {tokens} tokens，在 {peak} · 来自本地日志",
+  "spend.others": "其他",
+  "spend.underEach": "每项低于 ${limit}：",
+  "spend.metric.cost": "美元",
+  "spend.metric.mtok": "每百万 tokens 成本",
+  "spend.metric.tokens": "tokens",
+  "spend.centerTokens": "tokens",
+  "spend.noUsage": "无用量",
+  "spend.of30": "占最近 30 天的 {n}%",
+  "spend.noModelData": "这段时间没有按模型拆分的数据。",
+
+  "metric.session": "会话",
+  "metric.weekly": "每周",
+  "metric.monthly": "每月",
+  "metric.daily": "每天",
+  "metric.usage": "用量",
+  "metric.credits": "额度",
+  "metric.creditsUsed": "已用额度",
+  "metric.api": "API",
+  "metric.balance": "余额",
+  "metric.vouchers": "代金券",
+  "metric.cash": "现金",
+  "metric.limit": "上限",
+  "metric.used": "已用",
+  "metric.onDemand": "按量",
+  "metric.cursorModels": "Cursor 模型",
+  "metric.otherModels": "其他模型",
+  "metric.totalUsage": "总用量",
+  "metric.bonus": "赠送",
+  "metric.extraUsage": "额外用量",
+  "metric.extraCredits": "额外额度",
+  "metric.resetCredits": "重置额度",
+  "metric.extraBalance": "额外余额",
+  "metric.kiloPass": "Kilo Pass",
+  "metric.reqToday": "今日请求",
+  "metric.reqMonth": "本月请求",
+  "metric.reqCycle": "本周期请求",
+  "metric.lastUsed": "上次使用",
+  "metric.via": "经由",
+  "metric.sessions": "会话数",
+  "metric.modelWeekly": "{model} 每周",
+
+  "link.Status": "状态",
+  "link.Dashboard": "控制台",
+  "link.Usage": "用量",
+  "link.Credits": "额度",
+  "link.Platform": "平台",
+  "link.Activity": "活动",
+  "link.API Keys": "API 密钥",
+  "link.Console": "控制台",
+  "link.Coding Plan": "编程套餐",
+  "link.Library": "模型库",
+  "link.Site": "网站",
+  "link.Quota": "配额",
+  "link.API": "API",
+
+  "welcome.title": "欢迎 👋",
+  "welcome.body":
+    "已根据这台电脑上的 AI 工具完成设置。可在「自定义」里排列卡片、给托盘指标加星，或隐藏某些行。",
+  "welcome.open": "打开自定义",
+  "welcome.dismiss": "关闭",
+
+  "customize.done": "← 完成",
+  "customize.starred": "已加星 {n} 项 · 拖动 ⠿ 排序",
+  "customize.resetAll": "↺ 全部重置",
+  "customize.resetAllTip": "恢复所有卡片的默认布局 — 不影响你的用量上限",
+  "customize.resetLayout": "重置布局",
+  "customize.resetLayoutTip": "恢复这张卡片的默认布局 — 不影响你的用量上限",
+  "customize.enable": "启用此服务",
+  "customize.expand": "展开",
+  "customize.collapse": "收起",
+  "customize.dragRows": "拖动以排序",
+  "customize.dragProviders": "拖动以调整服务顺序",
+  "customize.star": "加星到托盘（最多 2 项）",
+  "customize.onDemand": "更多 — 藏在卡片的下拉箭头后面",
+  "customize.noData": "还没有数据 — 先启用此服务并刷新。",
+  "customize.resetTitle": "重置全部布局？",
+  "customize.resetBody":
+    "顺序、加星和隐藏的行会回到默认，并重新检测已安装的 AI 工具。你的用量上限不受影响。",
+  "customize.resetConfirm": "全部重置",
+
+  "redeem.title": "使用一张重置额度？",
+  "redeem.body":
+    "这会立刻重置 Codex 的速率限制窗口，而且不能撤销。刷新后的窗口可能要一两分钟才显示出来。",
+  "redeem.confirm": "使用额度",
+
+  "share.tagline": "用 Pane 盯紧你的 AI 订阅",
+  "tray.left": "{label}：剩余 {n}%",
+
+  "detail.unlimited": "无限制",
+  "detail.moneyOfLeft": "{a} / {b} 剩余",
+  "detail.moneyOfLeftCredits": "{a} / {b} 剩余 · {n} 额度",
+  "detail.moneyLeftOf": "{a} / {b} 剩余",
+  "detail.moneyOfUsed": "已用 {a} / {b}",
+  "detail.moneyOfLimit": "{a} / {b} 上限",
+  "detail.moneyOf": "{a} / {b}",
+  "detail.moneyCredits": "{a} · {n} 额度",
+  "detail.countCreditsUsed": "已用 {a} / {b} 额度",
+  "detail.countOfLeft": "{a} / {b} 剩余",
+  "detail.countOfUsed": "已用 {a} / {b}",
+};
+
+const METRIC_KEYS: Record<string, string> = {
+  Session: "metric.session",
+  Weekly: "metric.weekly",
+  Monthly: "metric.monthly",
+  Daily: "metric.daily",
+  Usage: "metric.usage",
+  Credits: "metric.credits",
+  "Credits used": "metric.creditsUsed",
+  API: "metric.api",
+  Balance: "metric.balance",
+  Vouchers: "metric.vouchers",
+  Cash: "metric.cash",
+  Limit: "metric.limit",
+  Used: "metric.used",
+  "On-demand": "metric.onDemand",
+  "Cursor Models": "metric.cursorModels",
+  "Other Models": "metric.otherModels",
+  "Total usage": "metric.totalUsage",
+  Bonus: "metric.bonus",
+  "Extra usage": "metric.extraUsage",
+  "Extra credits": "metric.extraCredits",
+  "Reset credits": "metric.resetCredits",
+  "Extra balance": "metric.extraBalance",
+  "Kilo Pass": "metric.kiloPass",
+  "Requests today": "metric.reqToday",
+  "Requests this month": "metric.reqMonth",
+  "Requests this cycle": "metric.reqCycle",
+  "Last used": "metric.lastUsed",
+  Via: "metric.via",
+  Sessions: "metric.sessions",
+  "Usage Trend": "spend.trend",
+  Today: "spend.today",
+  Yesterday: "spend.yesterday",
+  "Last 30 Days": "spend.last30",
+  Others: "spend.others",
+};
+
+let active: Locale = "en";
+
+export function detectSystemLocale(): Locale {
+  return (navigator.language || "").toLowerCase().startsWith("zh") ? "zh" : "en";
+}
+
+export function resolveLocale(pref: string | undefined): Locale {
+  if (pref === "zh" || pref === "en") return pref;
+  return detectSystemLocale();
+}
+
+export function normalizeLocalePref(raw: unknown): LocalePref {
+  return raw === "en" || raw === "zh" || raw === "auto" ? raw : "auto";
+}
+
+export function setActiveLocale(locale: Locale): void {
+  active = locale;
+}
+
+export function getLocale(): Locale {
+  return active;
+}
+
+export function localeTag(): string {
+  return active === "zh" ? "zh-CN" : "en-US";
+}
+
+export function t(key: string, vars?: Record<string, string | number>): string {
+  const dict = active === "zh" ? zh : en;
+  let s = dict[key] ?? en[key] ?? key;
+  if (vars) {
+    for (const [k, v] of Object.entries(vars)) {
+      s = s.split(`{${k}}`).join(String(v));
+    }
+  }
+  return s;
+}
+
+export function displayMetricLabel(label: string): string {
+  const key = METRIC_KEYS[label];
+  if (key) return t(key);
+  if (label.endsWith(" weekly")) {
+    return t("metric.modelWeekly", { model: label.slice(0, -7) });
+  }
+  return label;
+}
+
+export function displayLinkLabel(label: string): string {
+  const key = `link.${label}`;
+  const translated = t(key);
+  return translated === key ? label : translated;
+}
+
+/// Rust still emits English captions ("$21.80 of $79.56 left · 545 credits").
+/// Translate the known shapes at paint time so layout keys stay English.
+export function displayMetricDetail(text: string): string {
+  if (getLocale() !== "zh" || !text) return text;
+  const money = "\\$[\\d,]+(?:\\.\\d+)?K?";
+  const num = "[\\d,]+(?:\\.\\d+)?";
+  let m = text.match(new RegExp(`^(${money}) of (${money}) left(?: · (\\d+) credits)?$`, "i"));
+  if (m) {
+    return m[3]
+      ? t("detail.moneyOfLeftCredits", { a: m[1], b: m[2], n: m[3] })
+      : t("detail.moneyOfLeft", { a: m[1], b: m[2] });
+  }
+  m = text.match(new RegExp(`^(${money}) left of (${money})$`, "i"));
+  if (m) return t("detail.moneyLeftOf", { a: m[1], b: m[2] });
+  m = text.match(new RegExp(`^(${money}) of (${money}) used$`, "i"));
+  if (m) return t("detail.moneyOfUsed", { a: m[1], b: m[2] });
+  m = text.match(new RegExp(`^(${money}) of (${money}) limit$`, "i"));
+  if (m) return t("detail.moneyOfLimit", { a: m[1], b: m[2] });
+  m = text.match(new RegExp(`^(${money}) of (${money})$`, "i"));
+  if (m) return t("detail.moneyOf", { a: m[1], b: m[2] });
+  m = text.match(new RegExp(`^(${money}) · (\\d+) credits$`, "i"));
+  if (m) return t("detail.moneyCredits", { a: m[1], n: m[2] });
+  m = text.match(new RegExp(`^(${num}) of (${num}) credits used$`, "i"));
+  if (m) return t("detail.countCreditsUsed", { a: m[1], b: m[2] });
+  m = text.match(new RegExp(`^(${num}) of (${num}) used$`, "i"));
+  if (m) return t("detail.countOfUsed", { a: m[1], b: m[2] });
+  m = text.match(new RegExp(`^(${num}) of (${num}) left$`, "i"));
+  if (m) return t("detail.countOfLeft", { a: m[1], b: m[2] });
+  if (/^unlimited$/i.test(text.trim())) return t("detail.unlimited");
+  return text;
+}
+
+export function applyStaticI18n(): void {
+  document.documentElement.lang = active === "zh" ? "zh-CN" : "en";
+  document.querySelectorAll<HTMLElement>("[data-i18n]").forEach((el) => {
+    const key = el.dataset.i18n;
+    if (key) el.textContent = t(key);
+  });
+  document.querySelectorAll<HTMLElement>("[data-i18n-html]").forEach((el) => {
+    const key = el.dataset.i18nHtml;
+    if (key) el.innerHTML = t(key);
+  });
+  document.querySelectorAll<HTMLElement>("[data-i18n-title]").forEach((el) => {
+    const key = el.dataset.i18nTitle;
+    if (key) {
+      el.title = t(key);
+      delete el.dataset.tip;
+    }
+  });
+  document.querySelectorAll<HTMLElement>("[data-i18n-placeholder]").forEach((el) => {
+    const key = el.dataset.i18nPlaceholder;
+    if (key && "placeholder" in el) {
+      (el as HTMLInputElement).placeholder = t(key);
+    }
+  });
+  document.querySelectorAll<HTMLElement>("[data-i18n-aria]").forEach((el) => {
+    const key = el.dataset.i18nAria;
+    if (key) el.setAttribute("aria-label", t(key));
+  });
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -644,14 +644,20 @@ const METRIC_KEYS: Record<string, string> = {
 };
 
 let active: Locale = "en";
+/// Filled from Rust `system_ui_locale` so Auto matches tray/toasts.
+let systemLocale: Locale | null = null;
 
 export function detectSystemLocale(): Locale {
   return (navigator.language || "").toLowerCase().startsWith("zh") ? "zh" : "en";
 }
 
+export function setSystemLocale(locale: Locale): void {
+  systemLocale = locale;
+}
+
 export function resolveLocale(pref: string | undefined): Locale {
   if (pref === "zh" || pref === "en") return pref;
-  return detectSystemLocale();
+  return systemLocale ?? detectSystemLocale();
 }
 
 export function normalizeLocalePref(raw: unknown): LocalePref {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -9,6 +9,8 @@ type Dict = Record<string, string>;
 
 const en: Dict = {
   "sidebar.theme": "Light / dark mode",
+  "sidebar.themeToDark": "Switch to dark mode",
+  "sidebar.themeToLight": "Switch to light mode",
   "sidebar.refresh": "Refresh now",
   "sidebar.customize": "Customize",
   "sidebar.settings": "Settings",
@@ -312,6 +314,8 @@ const en: Dict = {
 
 const zh: Dict = {
   "sidebar.theme": "浅色 / 深色模式",
+  "sidebar.themeToDark": "切换到深色模式",
+  "sidebar.themeToLight": "切换到浅色模式",
   "sidebar.refresh": "立即刷新",
   "sidebar.customize": "自定义",
   "sidebar.settings": "设置",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2001,7 +2001,8 @@ function applyAppearance(): void {
   const btn = document.querySelector<HTMLElement>("#theme-btn");
   if (btn) {
     btn.textContent = mode === "light" ? "☾" : "☀";
-    btn.title = mode === "light" ? "Switch to dark mode" : "Switch to light mode";
+    btn.title = mode === "light" ? t("sidebar.themeToDark") : t("sidebar.themeToLight");
+    delete btn.dataset.tip;
   }
 }
 
@@ -2900,6 +2901,7 @@ function applyLocale(): void {
   config.locale = normalizeLocalePref(config.locale);
   setActiveLocale(resolveLocale(config.locale));
   applyStaticI18n();
+  applyAppearance();
   const status = document.querySelector("#status");
   if (status) {
     if (lastSnapshots.length) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,18 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getVersion } from "@tauri-apps/api/app";
+import {
+  applyStaticI18n,
+  displayLinkLabel,
+  displayMetricDetail,
+  displayMetricLabel,
+  localeTag,
+  normalizeLocalePref,
+  resolveLocale,
+  setActiveLocale,
+  t,
+  type LocalePref,
+} from "./i18n";
 
 // Injected by vite.config.ts at build time, e.g. "0707.1432".
 declare const __BUILD_STAMP__: string;
@@ -95,18 +107,18 @@ interface ProviderSpend {
 }
 
 /// How to get each provider signed in again, for the ⚠ Outdated tooltip.
-const RELOGIN: Record<string, string> = {
-  claude: "run `claude` in a terminal and sign in",
-  codex: "run `codex login` in a terminal",
-  grok: "run `grok` in a terminal and sign in",
-  copilot: "run `gh auth login` in a terminal",
-  cursor: "open Cursor and sign in again",
-  devin: "run `devin` in a terminal and sign in",
-  opencode: "run `opencode auth login` in a terminal",
-  antigravity: "open Antigravity and sign in again",
-  ollama: "make sure Ollama is running",
-  hermes: "open the Hermes desktop app once so it writes its local ledger",
-  kimi: "run `kimi login` in a terminal",
+const RELOGIN_KEYS: Record<string, string> = {
+  claude: "stale.relogin.claude",
+  codex: "stale.relogin.codex",
+  grok: "stale.relogin.grok",
+  copilot: "stale.relogin.copilot",
+  cursor: "stale.relogin.cursor",
+  devin: "stale.relogin.devin",
+  opencode: "stale.relogin.opencode",
+  antigravity: "stale.relogin.antigravity",
+  ollama: "stale.relogin.ollama",
+  hermes: "stale.relogin.hermes",
+  kimi: "stale.relogin.kimi",
 };
 
 /// The ⚠ Outdated tooltip: what went wrong, what fixes it, and the
@@ -114,24 +126,23 @@ const RELOGIN: Record<string, string> = {
 /// classified into sign-in / rate-limit / vendor-outage / connection
 /// buckets so the fix is concrete instead of a bare HTTP code.
 function staleHelp(s: Snapshot): string {
-  const w = (s.warning ?? "The last refresh failed").replace(/[.\s]+$/, "");
+  const w = (s.warning ?? t("stale.lastFailed")).replace(/[.\s]+$/, "");
   const lw = w.toLowerCase();
-  const relogin =
-    RELOGIN[s.id] ?? "add the API key again in Settings (or sign in with the tool once)";
-  let fix = "Pane keeps retrying automatically — nothing to do unless this persists.";
+  const relogin = RELOGIN_KEYS[s.id] ? t(RELOGIN_KEYS[s.id]) : t("stale.reloginDefault");
+  let fix = t("stale.fixRetry");
   if (/run `|open the/.test(lw)) {
     // The provider's own message already says what to do.
-    fix = "Pane recovers automatically once that's done.";
+    fix = t("stale.fixDone");
   } else if (/http 40[13]|invalid_grant|expired|no refresh token|sign[- ]?in|log ?in|credentials/.test(lw)) {
-    fix = `Fix: ${relogin} — Pane picks it up on the next refresh.`;
+    fix = t("stale.fixRelogin", { how: relogin });
   } else if (/http 429|rate limit/.test(lw)) {
-    fix = "The vendor is rate-limiting; Pane waits exactly as long as it asked, then retries by itself.";
+    fix = t("stale.fix429");
   } else if (/http 5\d\d/.test(lw)) {
-    fix = "The vendor's API is having trouble; Pane retries automatically until it recovers.";
+    fix = t("stale.fix5xx");
   } else if (/error sending request|timed? ?out|connect|network|dns|proxy/.test(lw)) {
-    fix = "Pane couldn't reach the vendor — check your internet connection (or the proxy in Settings).";
+    fix = t("stale.fixNet");
   }
-  return `${w}.\n${fix}\nShowing the last good data meanwhile.`;
+  return `${w}.\n${fix}\n${t("stale.tail")}`;
 }
 
 /// ⚠ shown when some events have no known model price — their tokens are
@@ -140,9 +151,7 @@ function unpricedWarn(sp: ProviderSpend | undefined): string {
   if (!sp || sp.unpriced <= 0) return "";
   const models = sp.unpriced_models.join(", ") || "unknown models";
   return `<span class="stale" title="${escapeHtml(
-    `${sp.unpriced} requests ran on models with no public pricing (${models}). ` +
-      `Their tokens are included, but they can't be turned into dollars — ` +
-      `so the real cost is a little higher than shown.`,
+    t("unpriced.tip", { n: sp.unpriced, models }),
   )}">⚠</span>`;
 }
 
@@ -192,6 +201,7 @@ interface Config {
   lastSeenVersion: string;
   reduceAnimations: boolean;
   hideUsageWhileSharing: boolean;
+  locale: LocalePref;
 }
 
 const ALL_PROVIDERS: [string, string][] = [
@@ -343,6 +353,7 @@ let config: Config = {
   lastSeenVersion: "",
   reduceAnimations: false,
   hideUsageWhileSharing: false,
+  locale: "auto",
 };
 let lastFetch = 0;
 let refreshing = false;
@@ -418,9 +429,9 @@ function fmtDuration(ms: number): string {
   const days = Math.floor(mins / 1440);
   const hours = Math.floor((mins % 1440) / 60);
   const rem = mins % 60;
-  if (days > 0) return `${days}d ${hours}h`;
-  if (hours > 0) return `${hours}h ${String(rem).padStart(2, "0")}m`;
-  return `${rem}m`;
+  if (days > 0) return t("time.daysHours", { d: days, h: hours });
+  if (hours > 0) return t("time.hoursMins", { h: hours, m: String(rem).padStart(2, "0") });
+  return t("time.mins", { m: rem });
 }
 
 // "today at 6:38 PM" / "tomorrow at 18:38" / "Sat, Jul 11 at 9:00 AM",
@@ -430,12 +441,14 @@ function fmtExact(ts: number): string {
   const now = new Date();
   const hour12 =
     config.timeFormat === "12" ? true : config.timeFormat === "24" ? false : undefined;
-  const time = d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit", hour12 });
+  const tag = localeTag();
+  const time = d.toLocaleTimeString(tag, { hour: "numeric", minute: "2-digit", hour12 });
   const dayStart = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
   const diffDays = Math.round((dayStart(d) - dayStart(now)) / 86400000);
-  if (diffDays === 0) return `today at ${time}`;
-  if (diffDays === 1) return `tomorrow at ${time}`;
-  return `${d.toLocaleDateString([], { weekday: "short", month: "short", day: "numeric" })} at ${time}`;
+  if (diffDays === 0) return t("time.today", { time });
+  if (diffDays === 1) return t("time.tomorrow", { time });
+  const date = d.toLocaleDateString(tag, { weekday: "short", month: "short", day: "numeric" });
+  return t("time.dateAt", { date, time });
 }
 
 async function patchConfig(patch: Partial<Config>): Promise<void> {
@@ -744,12 +757,12 @@ function computePace(m: Metric): Pace {
   const none: Pace = { cls: "", note: "", noteClass: "", title: "", tick: null };
 
   if (left < 0.5) {
-    return { cls: "low", note: "🔥 Limit reached", noteClass: "danger", title: "Limit reached", tick: null };
+    return { cls: "low", note: t("pace.limitReached"), noteClass: "danger", title: t("pace.limitReachedTitle"), tick: null };
   }
 
   const byLevel = (): Pace => {
-    if (left <= 10) return { ...none, cls: "low", title: `${Math.round(left)}% left` };
-    if (used >= 80) return { ...none, cls: "warn", title: `${Math.round(used)}% used` };
+    if (left <= 10) return { ...none, cls: "low", title: t("card.pctLeft", { n: Math.round(left) }) };
+    if (used >= 80) return { ...none, cls: "warn", title: t("card.pctUsed", { n: Math.round(used) }) };
     return none;
   };
   if (!m.resets_at || !m.period_ms) return byLevel();
@@ -772,28 +785,28 @@ function computePace(m: Metric): Pace {
     const runOutAt = now + (left * elapsedMs) / used;
     if (runOutAt < m.resets_at - 60000) {
       const when = config.resetExact
-        ? `Limit ${fmtExact(runOutAt)}`
-        : `Limit in ${fmtDuration(runOutAt - now)}`;
-      return { cls: "low", note: `🔥 ${when}`, noteClass: "danger", title: `~${over}% over limit at reset`, tick };
+        ? t("pace.limitAt", { when: fmtExact(runOutAt) })
+        : t("pace.limitIn", { time: fmtDuration(runOutAt - now) });
+      return { cls: "low", note: `🔥 ${when}`, noteClass: "danger", title: t("pace.overReset", { n: over }), tick };
     }
-    return { cls: "low", note: "🔥", noteClass: "danger", title: "~100% used at reset", tick };
+    return { cls: "low", note: "🔥", noteClass: "danger", title: t("pace.fullReset"), tick };
   }
 
   const spare = Math.max(1, Math.round(100 - projected));
   if (projected >= 90) {
     return {
       cls: "warn",
-      note: `~${spare}% spare`,
+      note: t("pace.spare", { n: spare }),
       noteClass: "warn",
-      title: `~${Math.round(projected)}% used at reset`,
+      title: t("pace.usedReset", { n: Math.round(projected) }),
       tick,
     };
   }
   return {
     cls: "",
-    note: config.pacingAlways ? `~${spare}% left at reset` : "",
+    note: config.pacingAlways ? t("pace.leftReset", { n: spare }) : "",
     noteClass: "",
-    title: `~${spare}% left at reset`,
+    title: t("pace.leftReset", { n: spare }),
     tick: config.pacingAlways ? tick : null,
   };
 }
@@ -814,8 +827,8 @@ function renderMetric(m: Metric): string {
     const note = pace.note
       ? `<span class="pace-note ${pace.noteClass}" title="${escapeHtml(pace.title)}">${escapeHtml(pace.note)}</span>`
       : "";
-    const headline = config.showUsed ? `${Math.round(used)}% used` : `${left}% left`;
-    const headlineAlt = config.showUsed ? `${left}% left` : `${Math.round(used)}% used`;
+    const headline = config.showUsed ? t("card.pctUsed", { n: Math.round(used) }) : t("card.pctLeft", { n: left });
+    const headlineAlt = config.showUsed ? t("card.pctLeft", { n: left }) : t("card.pctUsed", { n: Math.round(used) });
 
     let resetHtml = "";
     if (m.resets_at !== null && m.resets_at > Date.now()) {
@@ -831,20 +844,20 @@ function renderMetric(m: Metric): string {
         notStarted = m.resets_at - Date.now() >= m.period_ms - grace;
       }
       if (notStarted) {
-        resetHtml = `<span title="Sessions start after you send your first message.">Not started</span>`;
+        resetHtml = `<span title="${escapeHtml(t("card.notStartedTip"))}">${escapeHtml(t("card.notStarted"))}</span>`;
       } else {
         const remain = m.resets_at - Date.now();
-        const countdown = remain < 60_000 ? "Resets soon" : `Resets in ${fmtDuration(remain)}`;
-        const exact = `Resets ${fmtExact(m.resets_at)}`;
+        const countdown = remain < 60_000 ? t("card.resetsSoon") : t("card.resetsIn", { time: fmtDuration(remain) });
+        const exact = t("card.resetsAt", { when: fmtExact(m.resets_at) });
         const [text, alt] = config.resetExact ? [exact, countdown] : [countdown, exact];
         resetHtml = `<span class="clickable" data-flip="reset" title="${escapeHtml(alt)}">${escapeHtml(text)}</span>`;
       }
     }
-    const detailHtml = [m.detail ? escapeHtml(m.detail) : "", resetHtml].filter(Boolean).join(" · ");
+    const detailHtml = [m.detail ? escapeHtml(displayMetricDetail(m.detail)) : "", resetHtml].filter(Boolean).join(" · ");
     return `
       <div class="metric">
         <div class="metric-head">
-          <span class="metric-label">${escapeHtml(m.label)}</span>
+          <span class="metric-label">${escapeHtml(displayMetricLabel(m.label))}</span>
           ${note}
         </div>
         <div class="bar" title="${escapeHtml(pace.title)}">
@@ -863,25 +876,25 @@ function renderMetric(m: Metric): string {
   if (m.kind === "action" && m.detail) {
     const expiry =
       m.resets_at !== null
-        ? `Expires ${fmtExact(m.resets_at)}`
-        : (m.value ?? "Available");
+        ? t("card.expires", { when: fmtExact(m.resets_at) })
+        : displayMetricDetail(m.value ?? t("card.available"));
     const soon =
       m.resets_at !== null && m.resets_at - Date.now() < 86_400_000
-        ? `<span class="warn-dot" title="${escapeHtml(`This credit expires in ${fmtDuration(Math.max(0, m.resets_at - Date.now()))} — use it or lose it.`)}">●</span> `
+        ? `<span class="warn-dot" title="${escapeHtml(t("card.creditDying", { time: fmtDuration(Math.max(0, m.resets_at - Date.now())) }))}">●</span> `
         : "";
     return `
       <div class="metric-text action-row">
-        <span>${soon}${escapeHtml(m.label)}</span>
+        <span>${soon}${escapeHtml(displayMetricLabel(m.label))}</span>
         <span class="action-right">
           <span class="detail">${escapeHtml(expiry)}</span>
-          <button class="redeem-btn" data-redeem="${escapeHtml(m.detail)}" title="Spend this credit to reset your Codex rate limits now">Use</button>
+          <button class="redeem-btn" data-redeem="${escapeHtml(m.detail)}" title="${escapeHtml(t("card.useTip"))}">${escapeHtml(t("card.use"))}</button>
         </span>
       </div>`;
   }
   return `
     <div class="metric-text">
-      <span>${escapeHtml(m.label)}</span>
-      <span class="detail">${escapeHtml(m.value ?? "")}</span>
+      <span>${escapeHtml(displayMetricLabel(m.label))}</span>
+      <span class="detail">${escapeHtml(displayMetricDetail(m.value ?? ""))}</span>
     </div>`;
 }
 
@@ -891,7 +904,7 @@ function renderTrend(spend: ProviderSpend): string {
   const peakIdx = spend.trend.indexOf(max);
   const dayMs = 86_400_000;
   const dateOf = (i: number) =>
-    new Date(Date.now() - (29 - i) * dayMs).toLocaleDateString([], { month: "short", day: "numeric" });
+    new Date(Date.now() - (29 - i) * dayMs).toLocaleDateString(localeTag(), { month: "short", day: "numeric" });
   // Each day is a group: the visible bar plus a full-height invisible hit
   // area so thin bars are easy to hover; [data-trend] drives the tooltip.
   const bars = spend.trend
@@ -903,10 +916,15 @@ function renderTrend(spend: ProviderSpend): string {
       </g>`;
     })
     .join("");
-  const title = `Last 30 days (${dateOf(0)} – ${dateOf(29)}) · peak ${fmtTokens(max)} tokens on ${dateOf(peakIdx)} · from local logs`;
+  const title = t("spend.trendTip", {
+    from: dateOf(0),
+    to: dateOf(29),
+    tokens: fmtTokens(max),
+    peak: dateOf(peakIdx),
+  });
   return `
     <div class="metric trend">
-      <span class="metric-label" title="${escapeHtml(title)}">Usage Trend</span>
+      <span class="metric-label" title="${escapeHtml(title)}">${escapeHtml(t("spend.trend"))}</span>
       <svg class="trend-chart" viewBox="0 0 297 32" preserveAspectRatio="none">${bars}</svg>
     </div>`;
 }
@@ -919,15 +937,16 @@ function renderSpendRow(
   sp?: ProviderSpend,
 ): string {
   // Cursor's CSV aggregates requests, so its dollars are honest estimates.
-  const est = providerId === "cursor" ? " · estimated" : "";
   const text =
     w.tokens > 0 || w.cost > 0.005
-      ? `${fmtMoney(w.cost)} · ${fmtTokens(w.tokens)} tokens${est}`
-      : "No data";
+      ? providerId === "cursor"
+        ? t("card.tokensEst", { cost: fmtMoney(w.cost), n: fmtTokens(w.tokens) })
+        : t("card.tokensPlain", { cost: fmtMoney(w.cost), n: fmtTokens(w.tokens) })
+      : t("card.noData");
   const warn = key === "last30" ? unpricedWarn(sp) : "";
   return `
     <div class="metric-text spend-row" data-spend="${providerId}|${key}">
-      <span>${label} ${warn}</span>
+      <span>${escapeHtml(displayMetricLabel(label))} ${warn}</span>
       <span class="detail">${text}</span>
     </div>`;
 }
@@ -967,29 +986,29 @@ function renderCard(s: Snapshot): string {
     if (onDemandHtml.trim()) {
       const anim = L.expanded && animateExpandId === s.id ? " anim" : "";
       caret = `
-        <button class="card-caret" data-caret="${s.id}" title="${L.expanded ? "Show less" : "Show more"}">${L.expanded ? "⌃" : "⌄"}</button>
+        <button class="card-caret" data-caret="${s.id}" title="${L.expanded ? t("card.showLess") : t("card.showMore")}">${L.expanded ? "⌃" : "⌄"}</button>
         ${L.expanded ? `<div class="on-demand${anim}">${onDemandHtml}</div>` : ""}`;
     }
   } else {
-    body = `<p class="placeholder">${escapeHtml(s.error ?? "Not connected")}</p>`;
+    body = `<p class="placeholder">${escapeHtml(s.error ?? t("card.notConnected"))}</p>`;
   }
 
   const stale = s.stale
-    ? `<span class="stale" title="${escapeHtml(staleHelp(s))}">⚠ Outdated</span>`
+    ? `<span class="stale" title="${escapeHtml(staleHelp(s))}">${escapeHtml(t("card.outdated"))}</span>`
     : "";
   const links = (PROVIDER_LINKS[s.id] ?? PROVIDER_LINKS[providerFamily(s.id)] ?? [])
     .filter((l) => l.label !== "API" || s.metrics.some((m) => m.label === "API"))
-    .map((l) => `<button class="quick-link" data-link="${escapeHtml(l.url)}">${escapeHtml(l.label)}</button>`)
+    .map((l) => `<button class="quick-link" data-link="${escapeHtml(l.url)}">${escapeHtml(displayLinkLabel(l.label))}</button>`)
     .join("<span class='quick-sep'>·</span>");
   const linksRow = links ? `<div class="quick-links">${links}</div>` : "";
   const share =
     s.status === "ok"
-      ? `<button class="share-btn" data-share="${s.id}" title="Copy card as image">⧉</button>`
+      ? `<button class="share-btn" data-share="${s.id}" title="${escapeHtml(t("card.share"))}">⧉</button>`
       : "";
   return `
     <article class="provider${muted}" data-provider="${s.id}">
       <div class="provider-head">
-        <span class="drag-grip" title="Drag to reorder">⠿</span>
+        <span class="drag-grip" title="${escapeHtml(t("card.drag"))}">⠿</span>
         <span class="provider-name">${escapeHtml(s.name)}</span>
         ${plan}
         ${stale}
@@ -1070,7 +1089,7 @@ function donutEntries(tab: SpendTab): DonutEntry[] {
   const others: DonutEntry = {
     s: {
       id: OTHERS_ID,
-      name: "Others",
+      name: t("spend.others"),
     } as ProviderSpend,
     w: {
       cost: small.reduce((sum, e) => sum + e.w.cost, 0),
@@ -1108,11 +1127,11 @@ function spendCenter(entries: DonutEntry[]): { primary: string; sub: string; exa
     return { primary: fmtRate(rate), sub: "$/MTok", exact: `${fmtRate(rate)}/MTok average` };
   }
   if (config.spendMetric === "tokens") {
-    const t = entries.reduce((s, e) => s + e.w.tokens, 0);
-    return { primary: fmtTokens(t), sub: "tokens", exact: `${fmtTokens(t)} tokens` };
+    const tokens = entries.reduce((s, e) => s + e.w.tokens, 0);
+    return { primary: fmtTokens(tokens), sub: t("spend.centerTokens"), exact: t("card.tokens", { n: fmtTokens(tokens) }) };
   }
   const c = entries.reduce((s, e) => s + e.w.cost, 0);
-  return { primary: fmtMoney(c), sub: "dollars", exact: `$${c.toFixed(2)}` };
+  return { primary: fmtMoney(c), sub: t("spend.metric.cost"), exact: `$${c.toFixed(2)}` };
 }
 
 /// The metric a click (or right-click, reversed) moves to next — the Mac
@@ -1123,7 +1142,7 @@ function nextSpendMetric(back: boolean): "cost" | "tokens" | "mtok" {
   return order[(i + (back ? order.length - 1 : 1)) % order.length];
 }
 
-const METRIC_NAMES = { cost: "dollars", mtok: "cost per MTok", tokens: "tokens" } as const;
+const METRIC_NAMES = { cost: "spend.metric.cost", mtok: "spend.metric.mtok", tokens: "spend.metric.tokens" } as const;
 
 function fmtSpendVal(w: SpendWindow): string {
   if (config.spendMetric === "tokens") return fmtTokens(w.tokens);
@@ -1210,7 +1229,7 @@ function donutPop(g: { a0: number; a1: number }): { tx: string; ty: string } {
 function othersBreakdown(e: DonutEntry): string {
   if (!e.parts) return "";
   return (
-    `Under $${e.foldLimit ?? 1} each:\n` +
+    `${t("spend.underEach", { limit: e.foldLimit ?? 1 })}\n` +
     e.parts.map((p) => `${p.name}  ${fmtSpendVal(p.w)}`).join("\n")
   );
 }
@@ -1289,7 +1308,10 @@ function switchSpendTab(tab: SpendTab): void {
   });
   const wrap = card.querySelector<HTMLElement>(".donut-wrap");
   if (wrap) {
-    wrap.title = `${center.exact} — computed locally from session logs. Click to show ${METRIC_NAMES[nextSpendMetric(false)]}.`;
+    wrap.title = t("spend.clickTip", {
+      exact: center.exact,
+      next: t(`spend.metric.${nextSpendMetric(false)}`),
+    });
   }
 }
 
@@ -1299,13 +1321,11 @@ function renderTotalSpend(): string {
   if (lastSpend.length === 0) {
     // Quiet state instead of a missing card — on a fresh PC the donut only
     // appears after a CLI (Claude Code, Codex, Grok…) has logged some usage.
-    const note = spendLoaded
-      ? "No spend data yet — appears once Claude Code, Codex, or another CLI logs some usage on this PC."
-      : "Scanning session logs…";
+    const note = spendLoaded ? t("spend.emptyFirst") : t("spend.scanning");
     return `
       <article class="provider total-spend">
         <div class="provider-head">
-          <span class="provider-name">Total Spend</span>
+          <span class="provider-name">${escapeHtml(t("spend.title"))}</span>
         </div>
         <div class="card-panel"><p class="placeholder" style="margin:4px 0">${note}</p></div>
       </article>`;
@@ -1330,7 +1350,10 @@ function renderTotalSpend(): string {
     `<button class="tab${spendTab === id ? " active" : ""}" data-tab="${id}">${label}</button>`;
 
   const center = spendCenter(entries);
-  const exact = `${center.exact} — computed locally from session logs. Click to show ${METRIC_NAMES[nextSpendMetric(false)]}.`;
+  const exact = t("spend.clickTip", {
+    exact: center.exact,
+    next: t(METRIC_NAMES[nextSpendMetric(false)]),
+  });
   // An empty window still draws the ring — a zeroed track with $0.00 in the
   // center — so the card doesn't collapse to bare text between periods.
   const body = entries.length
@@ -1344,27 +1367,27 @@ function renderTotalSpend(): string {
         <div class="legend">${legend}</div>
       </div>`
     : `
-      <div class="donut-wrap donut-empty" title="No spend recorded in this period.">
+      <div class="donut-wrap donut-empty" title="${escapeHtml(t("spend.emptyPeriodTip"))}">
         <svg width="96" height="96" viewBox="0 0 96 96">
           <path class="seg donut-zero" data-full="1" fill-rule="evenodd" d="${sectorPath(0, TAU)}"/>
           <text class="donut-total" x="48" y="50" text-anchor="middle" font-size="14" font-weight="600">${center.primary}</text>
           <text class="donut-sub" x="48" y="62" text-anchor="middle" font-size="8">${center.sub}</text>
         </svg>
-        <div class="legend"><p class="placeholder" style="margin:0">No spend in this period.</p></div>
+        <div class="legend"><p class="placeholder" style="margin:0">${escapeHtml(t("spend.emptyPeriod"))}</p></div>
       </div>`;
 
   const contributors = lastSpend.map((s) => s.name).join(", ");
   return `
     <article class="provider total-spend">
       <div class="provider-head">
-        <span class="provider-name">Total Spend</span>
-        <span class="info" title="Fed by: ${escapeHtml(contributors)}. All figures are local estimates from each tool's own logs.">&#9432;</span>
+        <span class="provider-name">${escapeHtml(t("spend.title"))}</span>
+        <span class="info" title="${escapeHtml(t("spend.info", { names: contributors }))}">&#9432;</span>
         <span class="spacer"></span>
-        <button class="share-btn" data-share="__total__" title="Copy card as image">⧉</button>
+        <button class="share-btn" data-share="__total__" title="${escapeHtml(t("card.share"))}">⧉</button>
       </div>
       <div class="card-panel">
         <div class="tabs">
-          ${tab("today", "Today")}${tab("yesterday", "Yesterday")}${tab("last30", "30 Days")}
+          ${tab("today", t("spend.today"))}${tab("yesterday", t("spend.yesterday"))}${tab("last30", t("spend.days30"))}
         </div>
         ${body}
       </div>
@@ -1385,24 +1408,25 @@ function renderBuildInfo(): void {
   if (!el) return;
   if (updateVersion) {
     if (document.querySelector("#update-btn")) return;
+    const version = updateVersion;
     const btn = document.createElement("button");
     btn.id = "update-btn";
-    btn.textContent = `⬆ Update to v${updateVersion}`;
+    btn.textContent = t("update.to", { version });
     btn.addEventListener("click", () => {
-      btn.textContent = "Installing…";
+      btn.textContent = t("update.installing");
       btn.disabled = true;
       // On success the app restarts, so only the failure path matters:
       // re-enable the button and surface the reason.
       invoke("install_update").catch((err) => {
-        btn.textContent = `⬆ Update to v${updateVersion} — retry`;
+        btn.textContent = t("update.retry", { version });
         btn.disabled = false;
         const status = document.querySelector("#status");
-        if (status) status.textContent = `Update failed: ${err}`;
+        if (status) status.textContent = t("footer.updateFailed", { err: String(err) });
       });
     });
     el.replaceChildren(btn);
   } else {
-    el.textContent = checkingUpdate ? "Checking for updates…" : buildText;
+    el.textContent = checkingUpdate ? t("update.check") : buildText;
   }
 }
 
@@ -1456,7 +1480,7 @@ function appConfirm(opts: {
         <h3>${escapeHtml(opts.title)}</h3>
         <p>${escapeHtml(opts.message)}</p>
         <div id="confirm-actions">
-          <button id="confirm-cancel" type="button">Cancel</button>
+          <button id="confirm-cancel" type="button">${escapeHtml(t("dialog.cancel"))}</button>
           <button id="confirm-ok" type="button" class="${opts.danger ? "danger" : ""}">${escapeHtml(opts.confirmLabel)}</button>
         </div>
       </div>`;
@@ -1582,7 +1606,7 @@ function showChangelogDialog(title: string, sections: ChangelogSection[]): void 
       <h3>${escapeHtml(title)}</h3>
       <div id="whatsnew-body">${list}</div>
       <div id="whatsnew-actions">
-        <button id="whatsnew-ok" type="button">Got it</button>
+        <button id="whatsnew-ok" type="button">${escapeHtml(t("dialog.gotIt"))}</button>
       </div>
     </div>`;
   const done = () => {
@@ -1725,7 +1749,7 @@ async function shareCard(id: string): Promise<void> {
       // literal "]]>" inside CSS would end the section early, so split it.
       `<style><![CDATA[${css.split("]]>").join("]]]]><![CDATA[>")}]]></style>` +
       new XMLSerializer().serializeToString(clone) +
-      `<div id="snap-foot"><img src="${paneIcon}" alt="" /><span>Monitor Your AI Subscriptions with Pane</span></div>` +
+      `<div id="snap-foot"><img src="${paneIcon}" alt="" /><span>${escapeHtml(t("share.tagline"))}</span></div>` +
       `</div></foreignObject></svg>`;
 
     const img = new Image();
@@ -1741,9 +1765,9 @@ async function shareCard(id: string): Promise<void> {
     const dataUrl = canvas.toDataURL("image/png");
     const pngBase64 = dataUrl.slice(dataUrl.indexOf(",") + 1);
     await invoke("copy_share_image", { pngBase64 });
-    status.textContent = "Copied to clipboard";
+    status.textContent = t("footer.copied");
   } catch (err) {
-    status.textContent = `Share failed: ${err}`;
+    status.textContent = t("footer.shareFailed", { err: String(err) });
   }
 }
 
@@ -2074,10 +2098,10 @@ function renderCustomize(): string {
         const visible = !L.hidden.includes(key);
         return `
           <div class="cust-row" draggable="true" data-cust-row="${id}|${escapeHtml(key)}">
-            <span class="grip" title="Drag to reorder">⠿</span>
+            <span class="grip" title="${escapeHtml(t("customize.dragRows"))}">⠿</span>
             <label class="toggle mini"><input type="checkbox" data-visible="${id}|${escapeHtml(key)}"${visible ? " checked" : ""} /></label>
-            <span class="cust-label">${escapeHtml(key)}</span>
-            ${starrable ? `<button class="star${starred ? " on" : ""}" data-star="${id}|${escapeHtml(key)}" title="Star for tray strip (max 2)">★</button>` : ""}
+            <span class="cust-label">${escapeHtml(displayMetricLabel(key))}</span>
+            ${starrable ? `<button class="star${starred ? " on" : ""}" data-star="${id}|${escapeHtml(key)}" title="${escapeHtml(t("customize.star"))}">★</button>` : ""}
           </div>`;
       };
 
@@ -2085,22 +2109,22 @@ function renderCustomize(): string {
       const onDemand = L.metricOrder.filter((k) => L.onDemand.includes(k));
       const rows = L.metricOrder.length
         ? `${always.map(row).join("")}
-           <div class="cust-divider" data-divider="${id}">On Demand — behind the card's caret</div>
+           <div class="cust-divider" data-divider="${id}">${escapeHtml(t("customize.onDemand"))}</div>
            ${onDemand.map(row).join("")}`
-        : `<p class="placeholder">No data yet — refresh with this provider enabled first.</p>`;
+        : `<p class="placeholder">${escapeHtml(t("customize.noData"))}</p>`;
 
       const open = custExpanded.has(id);
       return `
         <article class="provider customize-block${enabled ? "" : " muted"}${open ? " open" : ""}" data-cust-provider="${id}" draggable="true">
           <div class="provider-head">
-            <span class="grip" title="Drag to reorder providers">⠿</span>
-            <button class="cust-expand" data-cust-expand="${id}" title="${open ? "Collapse" : "Expand"}">
+            <span class="grip" title="${escapeHtml(t("customize.dragProviders"))}">⠿</span>
+            <button class="cust-expand" data-cust-expand="${id}" title="${open ? t("customize.collapse") : t("customize.expand")}">
               <span class="provider-name">${escapeHtml(name)}</span>
               <span class="chev">⌄</span>
             </button>
             <span class="spacer"></span>
-            <button class="mini-btn" data-reset="${id}" title="Restore this card's default layout — does not touch your usage limits">Reset layout</button>
-            <label class="toggle mini" title="Enable provider"><input type="checkbox" data-enable="${id}"${enabled ? " checked" : ""} /></label>
+            <button class="mini-btn" data-reset="${id}" title="${escapeHtml(t("customize.resetLayoutTip"))}">${escapeHtml(t("customize.resetLayout"))}</button>
+            <label class="toggle mini" title="${escapeHtml(t("customize.enable"))}"><input type="checkbox" data-enable="${id}"${enabled ? " checked" : ""} /></label>
           </div>
           <div class="acc-body"><div class="acc-inner cust-rows">${rows}</div></div>
         </article>`;
@@ -2110,9 +2134,9 @@ function renderCustomize(): string {
   const starCount = Object.values(config.layout?.providers ?? {}).reduce((n, l) => n + l.starred.length, 0);
   return `
     <div class="customize-bar glass-bar">
-      <button class="dock-btn" data-customize-close>← Done</button>
-      <span class="detail">${starCount} starred · drag ⠿ to reorder</span>
-      <button class="dock-btn danger" data-reset-all title="Restore all cards' default layouts — does not touch your usage limits">↺ Reset all</button>
+      <button class="dock-btn" data-customize-close>${escapeHtml(t("customize.done"))}</button>
+      <span class="detail">${escapeHtml(t("customize.starred", { n: starCount }))}</span>
+      <button class="dock-btn danger" data-reset-all title="${escapeHtml(t("customize.resetAllTip"))}">${escapeHtml(t("customize.resetAll"))}</button>
     </div>
     ${blocks}`;
 }
@@ -2126,15 +2150,14 @@ function renderWelcome(): string {
   return `
     <article class="provider welcome-card">
       <div class="provider-head">
-        <span class="provider-name">Welcome 👋</span>
+        <span class="provider-name">${escapeHtml(t("welcome.title"))}</span>
         <span class="spacer"></span>
-        <button class="share-btn welcome-close" data-welcome-close title="Dismiss">✕</button>
+        <button class="share-btn welcome-close" data-welcome-close title="${escapeHtml(t("welcome.dismiss"))}">✕</button>
       </div>
       <p class="placeholder" style="margin:2px 0 8px">
-        You're set up with the AI tools found on this PC. Arrange cards, star
-        tray metrics, and hide rows in Customize.
+        ${escapeHtml(t("welcome.body"))}
       </p>
-      <button class="mini-btn" data-welcome-customize>Open Customize</button>
+      <button class="mini-btn" data-welcome-customize>${escapeHtml(t("welcome.open"))}</button>
     </article>`;
 }
 
@@ -2258,16 +2281,16 @@ function showTrendTip(el: HTMLElement): void {
   const tokens = spend.trend[i] ?? 0;
   const total = spend.trend.reduce((a, b) => a + b, 0);
   const share = total > 0 ? (tokens / total) * 100 : 0;
-  const date = new Date(Date.now() - (29 - i) * 86_400_000).toLocaleDateString([], {
+  const date = new Date(Date.now() - (29 - i) * 86_400_000).toLocaleDateString(localeTag(), {
     weekday: "short",
     month: "short",
     day: "numeric",
   });
   tip.innerHTML = `
     <div class="tip-line"><span class="tip-name">${escapeHtml(date)}</span><span>${
-      tokens > 0 ? `${fmtTokens(tokens)} tokens` : "No usage"
+      tokens > 0 ? escapeHtml(t("card.tokens", { n: fmtTokens(tokens) })) : escapeHtml(t("spend.noUsage"))
     }</span></div>
-    ${tokens > 0 ? `<div class="tip-line detail"><span>${share < 1 ? "<1" : share.toFixed(0)}% of the last 30 days</span></div>` : ""}`;
+    ${tokens > 0 ? `<div class="tip-line detail"><span>${escapeHtml(t("spend.of30", { n: share < 1 ? "<1" : share.toFixed(0) }))}</span></div>` : ""}`;
 
   const rect = el.getBoundingClientRect();
   tip.hidden = false;
@@ -2284,7 +2307,7 @@ function showModelTip(row: HTMLElement): void {
   if (!w) return;
 
   if (!w.models.length) {
-    tip.innerHTML = `<p class="placeholder">No model data for this period.</p>`;
+    tip.innerHTML = `<p class="placeholder">${escapeHtml(t("spend.noModelData"))}</p>`;
   } else {
     tip.innerHTML = w.models
       .map((m) => {
@@ -2292,7 +2315,7 @@ function showModelTip(row: HTMLElement): void {
         return `
           <div class="tip-model">
             <div class="tip-line"><span class="tip-name">${escapeHtml(m.model)}</span><span>${fmtMoney(m.cost)}</span></div>
-            <div class="tip-line detail"><span>${share.toFixed(0)}%</span><span>${fmtTokens(m.tokens)} tokens</span></div>
+            <div class="tip-line detail"><span>${share.toFixed(0)}%</span><span>${escapeHtml(t("card.tokens", { n: fmtTokens(m.tokens) }))}</span></div>
             <div class="tip-bar"><div style="width:${Math.max(2, share)}%"></div></div>
           </div>`;
       })
@@ -2372,7 +2395,7 @@ async function refresh(force = false): Promise<void> {
       refreshQueued = true;
       // The save message (or a stale "Updated") would otherwise sit on
       // the footer until the in-flight fetch ends, and Refresh looks dead.
-      document.querySelector("#status")!.textContent = "Refreshing…";
+      document.querySelector("#status")!.textContent = t("footer.refreshing");
     }
     return;
   }
@@ -2380,7 +2403,7 @@ async function refresh(force = false): Promise<void> {
   setRefreshLock(true);
   const myGen = ++refreshGeneration;
   const status = document.querySelector("#status")!;
-  status.textContent = "Refreshing…";
+  status.textContent = t("footer.refreshing");
   // The spend scan re-reads every session log on a cold start and can take
   // tens of seconds — it must never hold up the usage cards' first paint,
   // or the Refresh button (the lock used to stay on until spend finished).
@@ -2473,10 +2496,10 @@ async function refresh(force = false): Promise<void> {
     renderIfVisible();
     if (firstData && !customizeOpen && !document.hidden) playReveal();
     void updateTrayStrip();
-    const time = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-    status.textContent = `Updated ${time}`;
+    const time = new Date().toLocaleTimeString(localeTag(), { hour: "2-digit", minute: "2-digit" });
+    status.textContent = t("footer.updated", { time });
   } catch (err) {
-    status.textContent = `Refresh failed: ${err}`;
+    status.textContent = t("footer.refreshFailed", { err: String(err) });
   } finally {
     setRefreshLock(false);
     if (refreshQueued) {
@@ -2561,7 +2584,12 @@ async function updateTrayStrip(): Promise<void> {
     if (!logo) continue;
     const values = starredMetrics.map((m) => Math.round(100 - clampPercent(m.used_percent ?? 0)));
     const tooltip = `${snap.name}\n${starredMetrics
-      .map((m) => `${m.label}: ${Math.round(100 - clampPercent(m.used_percent ?? 0))}% left`)
+      .map((m) =>
+        t("tray.left", {
+          label: displayMetricLabel(m.label),
+          n: Math.round(100 - clampPercent(m.used_percent ?? 0)),
+        }),
+      )
       .join("\n")}`;
     entries.push({ id, logo, values, tooltip });
   }
@@ -2620,10 +2648,9 @@ function handleCustomizeClick(target: HTMLElement): boolean {
   const resetAll = target.closest("[data-reset-all]");
   if (resetAll) {
     void appConfirm({
-      title: "Reset all layouts?",
-      message:
-        "Order, stars, and hidden rows go back to defaults, and installed AI tools are re-detected. Your usage limits are not affected.",
-      confirmLabel: "Reset all",
+      title: t("customize.resetTitle"),
+      message: t("customize.resetBody"),
+      confirmLabel: t("customize.resetConfirm"),
       danger: true,
     }).then((ok) => {
       if (!ok) return;
@@ -2657,7 +2684,7 @@ function handleCustomizeClick(target: HTMLElement): boolean {
     if (L.starred.includes(key)) {
       L.starred = L.starred.filter((k) => k !== key);
     } else if (L.starred.length >= 2) {
-      document.querySelector("#status")!.textContent = "Up to 2 stars per provider";
+      document.querySelector("#status")!.textContent = t("footer.twoStars");
       return true;
     } else {
       L.starred.push(key);
@@ -2840,30 +2867,60 @@ async function saveApiKey(provider: string): Promise<void> {
       }).catch(() => {});
     }
     const name = providerDisplayName(provider);
-    status.textContent = `${name} key saved`;
+    status.textContent = t("footer.keySaved", { name });
     await refresh(true);
   } catch (err) {
     recentlyKeyed.delete(provider);
-    status.textContent = `Could not save key: ${err}`;
+    status.textContent = t("footer.keySaveFailed", { err: String(err) });
   }
 }
 
 function populatePinnedOptions(): void {
   const select = document.querySelector<HTMLSelectElement>("#pinned")!;
   const current = config.pinned ? `${config.pinned.provider}::${config.pinned.label}` : "";
-  select.replaceChildren(new Option("Auto (first live metric)", ""));
+  select.replaceChildren(new Option(t("settings.pinAuto"), ""));
   for (const s of lastSnapshots) {
     if (s.status !== "ok") continue;
     for (const m of s.metrics) {
       if (m.kind !== "progress") continue;
       const value = `${s.id}::${m.label}`;
-      select.add(new Option(`${s.name} — ${m.label}`, value, false, value === current));
+      select.add(
+        new Option(
+          t("settings.pinOption", { name: s.name, label: displayMetricLabel(m.label) }),
+          value,
+          false,
+          value === current,
+        ),
+      );
     }
   }
 }
 
+function applyLocale(): void {
+  config.locale = normalizeLocalePref(config.locale);
+  setActiveLocale(resolveLocale(config.locale));
+  applyStaticI18n();
+  const status = document.querySelector("#status");
+  if (status) {
+    if (lastSnapshots.length) {
+      const time = new Date().toLocaleTimeString(localeTag(), {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+      status.textContent = t("footer.updated", { time });
+    } else {
+      status.textContent = t("footer.starting");
+    }
+  }
+  if (lastSnapshots.length) renderIfVisible();
+  populatePinnedOptions();
+  renderBuildInfo();
+}
+
 async function initSettings(): Promise<void> {
   config = await invoke<Config>("get_config");
+  config.locale = normalizeLocalePref(config.locale);
+  applyLocale();
   if (["today", "yesterday", "last30"].includes(config.spendTab)) {
     spendTab = config.spendTab;
   }
@@ -2880,7 +2937,7 @@ async function initSettings(): Promise<void> {
   autostart.checked = await invoke<boolean>("get_autostart");
   autostart.addEventListener("change", () => {
     void invoke("set_autostart", { enabled: autostart.checked }).catch((err) => {
-      document.querySelector("#status")!.textContent = `Autostart failed: ${err}`;
+      document.querySelector("#status")!.textContent = t("footer.autostartFailed", { err: String(err) });
       autostart.checked = !autostart.checked;
     });
   });
@@ -2895,6 +2952,16 @@ async function initSettings(): Promise<void> {
   timeFormat.value = config.timeFormat;
   timeFormat.addEventListener("change", () => {
     void patchConfig({ timeFormat: timeFormat.value as Config["timeFormat"] }).then(renderAll);
+  });
+
+  const localeSel = document.querySelector<HTMLSelectElement>("#locale")!;
+  localeSel.value = config.locale;
+  localeSel.addEventListener("change", () => {
+    const next = normalizeLocalePref(localeSel.value);
+    void patchConfig({ locale: next }).then(() => {
+      applyLocale();
+      void updateTrayStrip();
+    });
   });
 
   const notifyToggles: [string, keyof Config][] = [
@@ -2964,7 +3031,7 @@ async function initSettings(): Promise<void> {
     try {
       await invoke("set_shortcut", { shortcut: shortcut.value });
       await patchConfig({ shortcut: shortcut.value });
-      status.textContent = shortcut.value.trim() ? "Shortcut saved" : "Shortcut cleared";
+      status.textContent = shortcut.value.trim() ? t("footer.shortcutSaved") : t("footer.shortcutCleared");
     } catch (err) {
       status.textContent = `${err}`;
     }
@@ -2977,7 +3044,7 @@ async function initSettings(): Promise<void> {
   const saveProxy = () => {
     void patchConfig({ proxy: { enabled: proxyEnabled.checked, url: proxyUrl.value.trim() } }).then(
       () => {
-        document.querySelector("#status")!.textContent = "Proxy saved — takes effect after restart";
+        document.querySelector("#status")!.textContent = t("footer.proxySaved");
       },
     );
   };
@@ -2996,10 +3063,9 @@ async function initSettings(): Promise<void> {
 /// "settings"; What's-new shouldn't pop again).
 async function resetAllSettings(): Promise<void> {
   const ok = await appConfirm({
-    title: "Reset all settings?",
-    message:
-      "Theme, density, notifications, shortcut, proxy, pacing, tray stars, and card layouts go back to defaults. Installed tools are re-detected. API keys and usage history stay. A proxy change still needs a restart.",
-    confirmLabel: "Reset all",
+    title: t("settings.resetTitle"),
+    message: t("settings.resetBody"),
+    confirmLabel: t("settings.resetConfirm"),
     danger: true,
   });
   if (!ok) return;
@@ -3037,8 +3103,10 @@ async function resetAllSettings(): Promise<void> {
     showTotalSpend: true,
     reduceAnimations: false,
     hideUsageWhileSharing: false,
+    locale: "auto",
   });
   spendTab = "today";
+  applyLocale();
   syncSettingsControls();
   scheduleAutoRefresh();
   applyAppearance();
@@ -3065,6 +3133,7 @@ function syncSettingsControls(): void {
   setNum("#interval", String(config.refreshMinutes));
   setCheck("#pacing", config.pacingAlways);
   setSelect("#timeformat", config.timeFormat);
+  setSelect("#locale", config.locale);
   setCheck("#notify-almost", config.notifyAlmostOut);
   setCheck("#notify-close", config.notifyCuttingClose);
   setCheck("#notify-runout", config.notifyWillRunOut);
@@ -3145,7 +3214,7 @@ window.addEventListener("DOMContentLoaded", () => {
   document.querySelector("#settings-close")!.addEventListener("click", () => setSettings(false));
   document.querySelector("#changelog-btn")!.addEventListener("click", () => {
     setSettings(false);
-    showChangelogDialog("Changelog", parseChangelog());
+    showChangelogDialog(t("dialog.changelog"), parseChangelog());
   });
   document.querySelectorAll<HTMLElement>(".acc-head").forEach((head) => {
     head.addEventListener("click", () => head.parentElement!.classList.toggle("open"));
@@ -3253,7 +3322,7 @@ window.addEventListener("DOMContentLoaded", () => {
     const link = target.closest<HTMLElement>("[data-link]");
     if (link) {
       void invoke("open_link", { url: link.dataset.link }).catch((err) => {
-        document.querySelector("#status")!.textContent = `Could not open link: ${err}`;
+        document.querySelector("#status")!.textContent = t("footer.openLinkFailed", { err: String(err) });
       });
       return;
     }
@@ -3287,21 +3356,20 @@ window.addEventListener("DOMContentLoaded", () => {
       const providerId =
         redeem.closest<HTMLElement>("article.provider")?.dataset.provider ?? "codex";
       void appConfirm({
-        title: "Use a reset credit?",
-        message:
-          "This resets your Codex rate-limit windows immediately and cannot be undone. The refreshed windows can take a couple of minutes to appear.",
-        confirmLabel: "Use credit",
+        title: t("redeem.title"),
+        message: t("redeem.body"),
+        confirmLabel: t("redeem.confirm"),
       }).then((ok) => {
         if (!ok) return;
         const status = document.querySelector("#status")!;
-        status.textContent = "Redeeming reset credit…";
+        status.textContent = t("footer.redeeming");
         void invoke<string>("codex_redeem_credit", { creditId, providerId })
           .then((msg) => {
             status.textContent = msg;
             void refresh(true);
           })
           .catch((err) => {
-            status.textContent = `Redeem failed: ${err}`;
+            status.textContent = t("footer.redeemFailed", { err: String(err) });
           });
       });
       return;
@@ -3389,7 +3457,7 @@ window.addEventListener("DOMContentLoaded", () => {
     dismissWhatsNew?.();
     // A fresh update's notes present on the first open after launch.
     if (pendingWhatsNew) {
-      showChangelogDialog(`What's new in v${appVersion}`, pendingWhatsNew);
+      showChangelogDialog(t("dialog.whatsNew", { version: appVersion }), pendingWhatsNew);
       pendingWhatsNew = null;
     }
     // Replay any renders skipped while hidden, before the reveal plays.

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
   normalizeLocalePref,
   resolveLocale,
   setActiveLocale,
+  setSystemLocale,
   t,
   type LocalePref,
 } from "./i18n";
@@ -2922,6 +2923,12 @@ function applyLocale(): void {
 async function initSettings(): Promise<void> {
   config = await invoke<Config>("get_config");
   config.locale = normalizeLocalePref(config.locale);
+  try {
+    const sys = await invoke<string>("system_ui_locale");
+    setSystemLocale(sys === "zh" ? "zh" : "en");
+  } catch {
+    // Dev / missing command — fall back to navigator.language.
+  }
   applyLocale();
   if (["today", "yesterday", "last30"].includes(config.spendTab)) {
     spendTab = config.spendTab;


### PR DESCRIPTION
## Summary
- Settings → Language: Auto / English / 中文. Auto follows the PC.
- Popover, Customize, tray tooltip, Quit, and quota toasts switch immediately.
- Metric row names and money captions (`$21.80 of $79.56 left`) are translated at paint time. Layout keys stay English so stars and pins do not break.
- Provider names, plan names, changelog, and vendor connect-me errors stay English.

## Test plan
- [ ] Settings → Language → 中文: cards, Settings, Customize, footer flip immediately
- [ ] Auto on a Chinese Windows install lands on 中文; English is explicit
- [ ] Stars / pins / Customize order survive a language switch
- [ ] Codex Extra credits caption reads like `$21.80 / $79.56 剩余 · 545 额度`
- [ ] Tray right-click says 退出 Pane; quota toast titles match Settings toggles
- [ ] Switch back to English: UI returns to the original wording

Made with Cursor

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->