### PR TITLE
feat: show Grok reset credits

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -119,13 +119,14 @@ Ground rules that apply to every provider:
 
 - **Reads:** `%USERPROFILE%\.grok\auth.json`.
 - **Calls:** `cli-chat-proxy.grok.com/v1/billing`,
-  `/v1/settings`, and `/v1/user?include=subscription`; `auth.x.ai`
-  token refresh (written back).
+  `/v1/settings`, and `/v1/user?include=subscription`;
+  `grok.com/prod_mc_billing.ConsumerUiSvc/GetRemainingResets`;
+  `auth.x.ai` token refresh (written back).
 - **Plan:** prefers `subscription_tier_display` from settings, then maps
   `subscriptionTier` from the user endpoint. Plan lookup failures do not
   hide otherwise valid usage data.
-- **Shows:** subscription plan, weekly pool, pay-as-you-go cap badge;
-  local spend from `~\.grok\logs\`.
+- **Shows:** subscription plan, weekly pool, pay-as-you-go cap badge,
+  remaining reset credits; local spend from `~\.grok\logs\`.
 
 ## Devin (Devin CLI)
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -979,6 +979,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +2004,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,6 +2716,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "dirs 6.0.0",
+ "prost",
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
@@ -3002,6 +3018,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ dirs = "6"
 rusqlite = { version = "0.32", features = ["bundled", "backup"] }
 toml = "0.8"
 regex = "1"
+prost = "0.13" # Grok GetRemainingResets protobuf codec
 webview2-com = "0.38"
 windows-core = "0.61"
 windows = { version = "0.61", features = ["Win32_Foundation", "Win32_Globalization", "Win32_Security_Credentials", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -1,10 +1,17 @@
 use super::{http, Metric, Snapshot};
 use chrono::{DateTime, Duration, Utc};
+use prost::Message;
 use serde_json::Value;
 use std::path::PathBuf;
 
 const ID: &str = "grok";
 const NAME: &str = "Grok";
+const REMAINING_RESETS_URL: &str =
+    "https://grok.com/prod_mc_billing.ConsumerUiSvc/GetRemainingResets";
+const EMPTY_GRPC_WEB_MESSAGE: [u8; 5] = [0, 0, 0, 0, 0];
+const MAX_RESET_CREDITS_BODY: usize = 64 * 1024;
+const PROTO_TIMESTAMP_MIN_SECONDS: i64 = -62_135_596_800;
+const PROTO_TIMESTAMP_MAX_SECONDS: i64 = 253_402_300_799;
 
 fn auth_path() -> PathBuf {
     dirs::home_dir().unwrap_or_default().join(".grok").join("auth.json")
@@ -133,8 +140,9 @@ async fn fetch() -> Result<Snapshot, String> {
         .get("https://cli-chat-proxy.grok.com/v1/user?include=subscription")
         .bearer_auth(&token)
         .send();
-    let (billing_resp, settings_resp, user_resp) =
-        tokio::join!(billing_req, settings_req, user_req);
+    let resets_req = remaining_reset_metrics(&token);
+    let (billing_resp, settings_resp, user_resp, resets_result) =
+        tokio::join!(billing_req, settings_req, user_req, resets_req);
 
     let billing_resp = billing_resp.map_err(|e| format!("billing request: {e}"))?;
     if billing_resp.status().as_u16() == 401 || billing_resp.status().as_u16() == 403 {
@@ -173,6 +181,10 @@ async fn fetch() -> Result<Snapshot, String> {
         "Extra usage",
         if cap > 0.0 { format!("{cap:.0} cap") } else { "Disabled".to_string() },
     ));
+    match resets_result {
+        Ok(credits) => metrics.extend(credits),
+        Err(err) => eprintln!("[pane] grok reset credits: {}", err.category()),
+    }
 
     let settings = match settings_resp {
         Ok(resp) if resp.status().is_success() => resp.json::<Value>().await.ok(),
@@ -293,6 +305,210 @@ fn collect_billing_metrics(node: &Value, parent_key: &str, metrics: &mut Vec<Met
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ResetCreditError {
+    Transport,
+    HttpStatus,
+    Oversized,
+    Framing,
+    TrailerStatus,
+    Decode,
+}
+
+impl ResetCreditError {
+    fn category(self) -> &'static str {
+        match self {
+            Self::Transport => "transport",
+            Self::HttpStatus => "HTTP status",
+            Self::Oversized => "oversized body",
+            Self::Framing => "framing",
+            Self::TrailerStatus => "trailer status",
+            Self::Decode => "protobuf decode",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct RemainingResets {
+    #[prost(message, repeated, tag = "10")]
+    tokens: Vec<ResetToken>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct ResetToken {
+    #[prost(message, optional, tag = "30")]
+    validity_end: Option<ProtoTimestamp>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct ProtoTimestamp {
+    #[prost(int64, tag = "1")]
+    seconds: i64,
+    #[prost(int32, tag = "2")]
+    nanos: i32,
+}
+
+async fn remaining_reset_metrics(token: &str) -> Result<Vec<Metric>, ResetCreditError> {
+    let resp = http()
+        .post(REMAINING_RESETS_URL)
+        .bearer_auth(token)
+        .header("Content-Type", "application/grpc-web+proto")
+        .header("X-Grpc-Web", "1")
+        .header("Origin", "https://grok.com")
+        .body(EMPTY_GRPC_WEB_MESSAGE.to_vec())
+        .send()
+        .await
+        .map_err(|_| ResetCreditError::Transport)?;
+    if !resp.status().is_success() {
+        return Err(ResetCreditError::HttpStatus);
+    }
+    let body = limited_response_body(resp).await?;
+    reset_credit_metrics(&body)
+}
+
+/// Cap the read itself — Content-Length alone does not bound a chunked
+/// or lying response (same approach as the pricing catalog fetch).
+async fn limited_response_body(mut resp: reqwest::Response) -> Result<Vec<u8>, ResetCreditError> {
+    if let Some(content_length) = resp.content_length() {
+        ensure_reset_credit_body_size(content_length)?;
+    }
+    let mut body = Vec::new();
+    while let Some(chunk) = resp.chunk().await.map_err(|_| ResetCreditError::Transport)? {
+        accept_reset_credit_chunk(&mut body, &chunk)?;
+    }
+    Ok(body)
+}
+
+fn accept_reset_credit_chunk(body: &mut Vec<u8>, chunk: &[u8]) -> Result<(), ResetCreditError> {
+    if body.len().saturating_add(chunk.len()) > MAX_RESET_CREDITS_BODY {
+        return Err(ResetCreditError::Oversized);
+    }
+    body.extend_from_slice(chunk);
+    Ok(())
+}
+
+fn ensure_reset_credit_body_size(size: u64) -> Result<(), ResetCreditError> {
+    if size > MAX_RESET_CREDITS_BODY as u64 {
+        return Err(ResetCreditError::Oversized);
+    }
+    Ok(())
+}
+
+fn reset_credit_metrics(body: &[u8]) -> Result<Vec<Metric>, ResetCreditError> {
+    ensure_reset_credit_body_size(body.len() as u64)?;
+    let payload = parse_unary_grpc_web(body)?;
+    let decoded = RemainingResets::decode(payload).map_err(|_| ResetCreditError::Decode)?;
+    Ok(metrics_from_tokens(decoded.tokens))
+}
+
+fn parse_unary_grpc_web(body: &[u8]) -> Result<&[u8], ResetCreditError> {
+    let mut offset = 0;
+    let mut data: Option<&[u8]> = None;
+    let mut saw_trailer = false;
+    while offset < body.len() {
+        if saw_trailer {
+            return Err(ResetCreditError::Framing);
+        }
+        if body.len() - offset < 5 {
+            return Err(ResetCreditError::Framing);
+        }
+        let flags = body[offset];
+        let frame_len = u32::from_be_bytes([
+            body[offset + 1],
+            body[offset + 2],
+            body[offset + 3],
+            body[offset + 4],
+        ]) as usize;
+        offset += 5;
+        if body.len() - offset < frame_len {
+            return Err(ResetCreditError::Framing);
+        }
+        let payload = &body[offset..offset + frame_len];
+        offset += frame_len;
+
+        const COMPRESSED: u8 = 0x01;
+        const TRAILER: u8 = 0x80;
+        if flags & !(COMPRESSED | TRAILER) != 0 || flags & COMPRESSED != 0 {
+            return Err(ResetCreditError::Framing);
+        }
+        if flags & TRAILER != 0 {
+            if data.is_none() {
+                return Err(ResetCreditError::Framing);
+            }
+            if grpc_trailer_status(payload)? != 0 {
+                return Err(ResetCreditError::TrailerStatus);
+            }
+            saw_trailer = true;
+        } else if data.is_some() {
+            return Err(ResetCreditError::Framing);
+        } else {
+            data = Some(payload);
+        }
+    }
+    data.ok_or(ResetCreditError::Framing)
+}
+
+fn grpc_trailer_status(payload: &[u8]) -> Result<i32, ResetCreditError> {
+    let text = std::str::from_utf8(payload).map_err(|_| ResetCreditError::Framing)?;
+    let mut status = None;
+    for line in text.split('\n') {
+        let line = line.trim_end_matches('\r').trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(ResetCreditError::Framing);
+        };
+        if name.eq_ignore_ascii_case("grpc-status") {
+            if status.is_some() {
+                return Err(ResetCreditError::TrailerStatus);
+            }
+            status = Some(
+                value
+                    .trim()
+                    .parse::<i32>()
+                    .map_err(|_| ResetCreditError::TrailerStatus)?,
+            );
+        }
+    }
+    status.ok_or(ResetCreditError::TrailerStatus)
+}
+
+fn proto_timestamp_millis(ts: &ProtoTimestamp) -> Option<i64> {
+    if !(PROTO_TIMESTAMP_MIN_SECONDS..=PROTO_TIMESTAMP_MAX_SECONDS).contains(&ts.seconds)
+        || !(0..1_000_000_000).contains(&ts.nanos)
+    {
+        return None;
+    }
+    let nanos_ms = i64::from(ts.nanos / 1_000_000);
+    ts.seconds.checked_mul(1000)?.checked_add(nanos_ms)
+}
+
+fn metrics_from_tokens(tokens: Vec<ResetToken>) -> Vec<Metric> {
+    let mut credits: Vec<Option<i64>> = tokens
+        .into_iter()
+        .map(|token| token.validity_end.as_ref().and_then(proto_timestamp_millis))
+        .collect();
+    credits.sort_by_key(|expiry| expiry.unwrap_or(i64::MAX));
+    let many = credits.len() > 1;
+    credits
+        .into_iter()
+        .enumerate()
+        .map(|(i, resets_at)| Metric {
+            label: if many {
+                format!("Reset credit {}", i + 1)
+            } else {
+                "Reset credit".into()
+            },
+            kind: "action".into(),
+            used_percent: None,
+            detail: None,
+            value: Some("Available".into()),
+            resets_at,
+            period_ms: None,
+        })
+        .collect()
+}
 
 #[cfg(test)]
 mod tests {
@@ -388,5 +604,389 @@ mod tests {
             resolve_subscription_plan(Some(&settings), Some(&user)),
             None
         );
+    }
+
+    const TOKEN_ID: &str = "secret-reset-token-xyz";
+    const EARLIER_SECS: i64 = 1_777_000_000;
+    const FUTURE_SECS: i64 = 1_777_086_400;
+
+    fn varint(mut n: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        while n >= 0x80 {
+            out.push((n as u8) | 0x80);
+            n >>= 7;
+        }
+        out.push(n as u8);
+        out
+    }
+
+    fn key(field: u32, wire: u32) -> Vec<u8> {
+        varint(((field << 3) | wire) as u64)
+    }
+
+    fn delimited(field: u32, payload: &[u8]) -> Vec<u8> {
+        let mut out = key(field, 2);
+        out.extend(varint(payload.len() as u64));
+        out.extend_from_slice(payload);
+        out
+    }
+
+    fn timestamp(seconds: i64, nanos: i32) -> Vec<u8> {
+        let mut out = key(1, 0);
+        out.extend(varint(seconds as u64));
+        if nanos != 0 {
+            out.extend(key(2, 0));
+            out.extend(varint(nanos as u64));
+        }
+        out
+    }
+
+    fn reset_token(id: &str, end: Option<(i64, i32)>) -> Vec<u8> {
+        let mut tok = delimited(10, id.as_bytes());
+        if let Some((seconds, nanos)) = end {
+            tok.extend(delimited(30, &timestamp(seconds, nanos)));
+        }
+        tok
+    }
+
+    fn remaining_resets_proto(tokens: &[Vec<u8>]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for token in tokens {
+            out.extend(delimited(10, token));
+        }
+        out
+    }
+
+    fn grpc_web_frame(flags: u8, payload: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(5 + payload.len());
+        out.push(flags);
+        out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        out.extend_from_slice(payload);
+        out
+    }
+
+    fn grpc_web_unary(payload: &[u8], trailer_status: Option<i32>) -> Vec<u8> {
+        let mut out = grpc_web_frame(0x00, payload);
+        if let Some(status) = trailer_status {
+            let trailers = format!("grpc-status: {status}\r\n");
+            out.extend(grpc_web_frame(0x80, trailers.as_bytes()));
+        }
+        out
+    }
+
+    #[test]
+    fn one_future_token_becomes_unnumbered_reset_credit() {
+        let proto = remaining_resets_proto(&[reset_token(TOKEN_ID, Some((FUTURE_SECS, 5_000_000)))]);
+        let body = grpc_web_unary(&proto, Some(0));
+
+        let metrics = reset_credit_metrics(&body).expect("one future credit");
+        assert_eq!(metrics.len(), 1);
+        let metric = &metrics[0];
+        assert_eq!(metric.label, "Reset credit");
+        assert_eq!(metric.kind, "action");
+        assert_eq!(metric.detail, None);
+        assert_eq!(metric.value.as_deref(), Some("Available"));
+        assert_eq!(metric.resets_at, Some(FUTURE_SECS * 1000 + 5));
+        assert_eq!(metric.period_ms, None);
+
+        let serialized = serde_json::to_string(metric).unwrap();
+        assert!(!serialized.contains(TOKEN_ID), "token id leaked: {serialized}");
+        assert!(
+            serialized.contains("\"detail\":null"),
+            "redeem detail must stay empty: {serialized}"
+        );
+    }
+
+    fn assert_no_token_ids(metrics: &[Metric], ids: &[&str]) {
+        let serialized = serde_json::to_string(metrics).unwrap();
+        for id in ids {
+            assert!(!serialized.contains(id), "token id leaked: {serialized}");
+        }
+        for metric in metrics {
+            assert_eq!(metric.kind, "action");
+            assert_eq!(metric.detail, None);
+            assert!(!metric.label.contains("Usage"));
+        }
+    }
+
+    #[test]
+    fn multiple_future_tokens_are_numbered_earliest_first() {
+        let proto = remaining_resets_proto(&[
+            reset_token("tok-late", Some((FUTURE_SECS + 86_400, 0))),
+            reset_token("tok-soon", Some((FUTURE_SECS, 0))),
+        ]);
+        let metrics = reset_credit_metrics(&grpc_web_unary(&proto, Some(0)))
+            .expect("two future credits");
+        assert_eq!(
+            metrics
+                .iter()
+                .map(|m| (m.label.as_str(), m.resets_at))
+                .collect::<Vec<_>>(),
+            vec![
+                ("Reset credit 1", Some(FUTURE_SECS * 1000)),
+                ("Reset credit 2", Some((FUTURE_SECS + 86_400) * 1000)),
+            ]
+        );
+        assert_no_token_ids(&metrics, &["tok-late", "tok-soon"]);
+    }
+
+    #[test]
+    fn endpoint_tokens_are_not_filtered_by_local_expiry() {
+        let proto = remaining_resets_proto(&[
+            reset_token("tok-past", Some((EARLIER_SECS - 1, 0))),
+            reset_token("tok-earlier", Some((EARLIER_SECS, 0))),
+            reset_token("tok-future", Some((FUTURE_SECS, 0))),
+        ]);
+        let metrics = reset_credit_metrics(&grpc_web_unary(&proto, Some(0)))
+            .expect("trust endpoint collection");
+        assert_eq!(
+            metrics
+                .iter()
+                .map(|m| (m.label.as_str(), m.resets_at))
+                .collect::<Vec<_>>(),
+            vec![
+                ("Reset credit 1", Some((EARLIER_SECS - 1) * 1000)),
+                ("Reset credit 2", Some(EARLIER_SECS * 1000)),
+                ("Reset credit 3", Some(FUTURE_SECS * 1000)),
+            ]
+        );
+        assert_no_token_ids(&metrics, &["tok-past", "tok-earlier", "tok-future"]);
+    }
+
+    #[test]
+    fn empty_collection_emits_no_metrics_but_past_dated_token_remains() {
+        let empty = reset_credit_metrics(&grpc_web_unary(
+            &remaining_resets_proto(&[]),
+            Some(0),
+        ))
+        .expect("empty");
+        assert!(empty.is_empty());
+
+        let past_dated =
+            remaining_resets_proto(&[reset_token("tok-old", Some((EARLIER_SECS, 0)))]);
+        let metrics = reset_credit_metrics(&grpc_web_unary(&past_dated, Some(0)))
+            .expect("past-dated token");
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].label, "Reset credit");
+        assert_eq!(metrics[0].resets_at, Some(EARLIER_SECS * 1000));
+        let serialized = serde_json::to_string(&metrics).unwrap();
+        assert!(!serialized.contains("tok-old"));
+        assert!(!serialized.contains("Reset credits"));
+    }
+
+    #[test]
+    fn undated_and_invalid_expiry_stay_available_after_dated() {
+        let proto = remaining_resets_proto(&[
+            reset_token("tok-undated", None),
+            reset_token("tok-overflow", Some((i64::MAX, 0))),
+            reset_token("tok-negative-nanos", Some((FUTURE_SECS, -1))),
+            reset_token("tok-large-nanos", Some((FUTURE_SECS, 1_000_000_000))),
+            reset_token("tok-before-min", Some((-62_135_596_801, 0))),
+            reset_token("tok-after-max", Some((253_402_300_800, 0))),
+            reset_token("tok-dated", Some((FUTURE_SECS, 0))),
+            reset_token("tok-undated-2", None),
+        ]);
+        let metrics = reset_credit_metrics(&grpc_web_unary(&proto, Some(0)))
+            .expect("undated credits");
+        assert_eq!(metrics.len(), 8);
+        assert_eq!(metrics[0].label, "Reset credit 1");
+        assert_eq!(metrics[0].resets_at, Some(FUTURE_SECS * 1000));
+        for (index, metric) in metrics.iter().enumerate().skip(1) {
+            assert_eq!(metric.label, format!("Reset credit {}", index + 1));
+            assert_eq!(metric.resets_at, None);
+            assert_eq!(metric.value.as_deref(), Some("Available"));
+        }
+        assert_no_token_ids(
+            &metrics,
+            &[
+                "tok-undated",
+                "tok-overflow",
+                "tok-negative-nanos",
+                "tok-large-nanos",
+                "tok-before-min",
+                "tok-after-max",
+                "tok-dated",
+                "tok-undated-2",
+            ],
+        );
+    }
+
+    #[test]
+    fn equal_expiry_preserves_protobuf_order() {
+        let proto = remaining_resets_proto(&[
+            reset_token("tok-a", Some((FUTURE_SECS, 0))),
+            reset_token("tok-b", Some((FUTURE_SECS, 0))),
+        ]);
+        let metrics = reset_credit_metrics(&grpc_web_unary(&proto, Some(0)))
+            .expect("equal expiry");
+        assert_eq!(metrics[0].label, "Reset credit 1");
+        assert_eq!(metrics[1].label, "Reset credit 2");
+        assert_eq!(metrics[0].resets_at, metrics[1].resets_at);
+        assert_no_token_ids(&metrics, &["tok-a", "tok-b"]);
+    }
+
+    fn future_proto() -> Vec<u8> {
+        remaining_resets_proto(&[reset_token(TOKEN_ID, Some((FUTURE_SECS, 0)))])
+    }
+
+    fn assert_category(body: &[u8], want: ResetCreditError) {
+        match reset_credit_metrics(body) {
+            Err(err) => {
+                assert_eq!(err, want);
+                assert_eq!(err.category(), want.category());
+                assert!(!err.category().contains(TOKEN_ID));
+                assert!(!err.category().contains("Bearer"));
+            }
+            Ok(_) => panic!("expected {want:?}, got metrics"),
+        }
+    }
+
+    #[test]
+    fn unary_parser_accepts_data_with_or_without_successful_trailer() {
+        let proto = future_proto();
+        let with_trailer = reset_credit_metrics(&grpc_web_unary(&proto, Some(0)))
+            .expect("data + trailer");
+        let without = reset_credit_metrics(&grpc_web_unary(&proto, None))
+            .expect("data only");
+        assert_eq!(with_trailer.len(), 1);
+        assert_eq!(without.len(), 1);
+        assert_eq!(with_trailer[0].resets_at, without[0].resets_at);
+    }
+
+    #[test]
+    fn unknown_protobuf_fields_do_not_block_known_credits() {
+        let mut token = reset_token(TOKEN_ID, Some((FUTURE_SECS, 0)));
+        token.extend(delimited(11, b"unknown-token-field"));
+        let mut proto = delimited(1, b"unknown-envelope-field");
+        proto.extend(delimited(10, &token));
+        let metrics = reset_credit_metrics(&grpc_web_unary(&proto, Some(0)))
+            .expect("unknown fields");
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].label, "Reset credit");
+        assert_eq!(metrics[0].resets_at, Some(FUTURE_SECS * 1000));
+        assert_no_token_ids(&metrics, &[TOKEN_ID, "unknown-token-field"]);
+    }
+
+    #[test]
+    fn truncated_header_is_framing() {
+        assert_category(&[0, 0, 0, 0], ResetCreditError::Framing);
+        let trailers = b"grpc-status: 0\r\n";
+        assert_category(&grpc_web_frame(0x80, trailers), ResetCreditError::Framing);
+    }
+
+    #[test]
+    fn mismatched_frame_length_is_framing() {
+        let mut body = vec![0, 0, 0, 0, 20];
+        body.extend_from_slice(&[1, 2, 3]);
+        assert_category(&body, ResetCreditError::Framing);
+    }
+
+    #[test]
+    fn unsupported_flags_are_framing() {
+        let proto = future_proto();
+        assert_category(&grpc_web_frame(0x01, &proto), ResetCreditError::Framing);
+        assert_category(&grpc_web_frame(0x02, &proto), ResetCreditError::Framing);
+        assert_category(&grpc_web_frame(0x81, &proto), ResetCreditError::Framing);
+    }
+
+    #[test]
+    fn duplicate_data_frames_are_framing() {
+        let frame = grpc_web_frame(0x00, &future_proto());
+        let mut body = frame.clone();
+        body.extend_from_slice(&frame);
+        assert_category(&body, ResetCreditError::Framing);
+    }
+
+    #[test]
+    fn extra_bytes_after_trailer_are_framing() {
+        let mut body = grpc_web_unary(&future_proto(), Some(0));
+        body.push(0);
+        assert_category(&body, ResetCreditError::Framing);
+    }
+
+    #[test]
+    fn non_zero_trailer_status_is_rejected() {
+        assert_category(
+            &grpc_web_unary(&future_proto(), Some(2)),
+            ResetCreditError::TrailerStatus,
+        );
+    }
+
+    #[test]
+    fn trailer_requires_exactly_one_grpc_status() {
+        let mut missing = grpc_web_frame(0x00, &future_proto());
+        missing.extend(grpc_web_frame(0x80, b"grpc-message: ok\r\n"));
+        assert_category(&missing, ResetCreditError::TrailerStatus);
+
+        let mut duplicate = grpc_web_frame(0x00, &future_proto());
+        duplicate.extend(grpc_web_frame(
+            0x80,
+            b"grpc-status: 2\r\ngrpc-status: 0\r\n",
+        ));
+        assert_category(&duplicate, ResetCreditError::TrailerStatus);
+    }
+
+    #[test]
+    fn malformed_protobuf_payload_is_decode() {
+        let mut bad = key(10, 2);
+        bad.extend(varint(10));
+        bad.push(0x01);
+        assert_category(&grpc_web_unary(&bad, Some(0)), ResetCreditError::Decode);
+    }
+
+    #[test]
+    fn body_over_64kib_is_oversized() {
+        assert_category(
+            &vec![0; MAX_RESET_CREDITS_BODY + 1],
+            ResetCreditError::Oversized,
+        );
+        assert_eq!(
+            ensure_reset_credit_body_size((MAX_RESET_CREDITS_BODY as u64) + 1),
+            Err(ResetCreditError::Oversized)
+        );
+        let proto = future_proto();
+        let body = grpc_web_unary(&proto, Some(0));
+        assert!(body.len() <= MAX_RESET_CREDITS_BODY);
+        ensure_reset_credit_body_size(MAX_RESET_CREDITS_BODY as u64).expect("at-limit length");
+        reset_credit_metrics(&body).expect("at-limit body");
+    }
+
+    #[test]
+    fn streamed_chunks_stop_at_64kib() {
+        let mut body = vec![0; MAX_RESET_CREDITS_BODY];
+        assert_eq!(
+            accept_reset_credit_chunk(&mut body, &[0]),
+            Err(ResetCreditError::Oversized)
+        );
+        assert_eq!(body.len(), MAX_RESET_CREDITS_BODY);
+
+        let mut under = vec![0; MAX_RESET_CREDITS_BODY - 1];
+        accept_reset_credit_chunk(&mut under, &[0]).expect("exact cap");
+        assert_eq!(under.len(), MAX_RESET_CREDITS_BODY);
+    }
+
+    #[test]
+    fn failure_categories_never_include_sensitive_values() {
+        for err in [
+            ResetCreditError::Transport,
+            ResetCreditError::HttpStatus,
+            ResetCreditError::Oversized,
+            ResetCreditError::Framing,
+            ResetCreditError::TrailerStatus,
+            ResetCreditError::Decode,
+        ] {
+            let category = err.category();
+            assert!(!category.is_empty());
+            assert!(!category.contains(TOKEN_ID));
+            assert!(!category.contains("Bearer"));
+            assert!(!category.contains("authorization"));
+            assert!(!category.contains("grpc-status"));
+        }
+        assert_eq!(ResetCreditError::Transport.category(), "transport");
+        assert_eq!(ResetCreditError::HttpStatus.category(), "HTTP status");
+        assert_eq!(ResetCreditError::Oversized.category(), "oversized body");
+        assert_eq!(ResetCreditError::Framing.category(), "framing");
+        assert_eq!(ResetCreditError::TrailerStatus.category(), "trailer status");
+        assert_eq!(ResetCreditError::Decode.category(), "protobuf decode");
     }
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -239,6 +239,8 @@ const en: Dict = {
   "metric.bonus": "Bonus",
   "metric.extraUsage": "Extra usage",
   "metric.extraCredits": "Extra credits",
+  "metric.resetCredit": "Reset credit",
+  "metric.resetCreditNumbered": "Reset credit {n}",
   "metric.resetCredits": "Reset credits",
   "metric.extraBalance": "Extra balance",
   "metric.kiloPass": "Kilo Pass",
@@ -535,6 +537,8 @@ const zh: Dict = {
   "metric.bonus": "赠送",
   "metric.extraUsage": "额外用量",
   "metric.extraCredits": "额外额度",
+  "metric.resetCredit": "重置额度",
+  "metric.resetCreditNumbered": "重置额度 {n}",
   "metric.resetCredits": "重置额度",
   "metric.extraBalance": "额外余额",
   "metric.kiloPass": "Kilo Pass",
@@ -690,6 +694,12 @@ export function t(key: string, vars?: Record<string, string | number>): string {
 export function displayMetricLabel(label: string): string {
   const key = METRIC_KEYS[label];
   if (key) return t(key);
+  const resetCredit = label.match(/^Reset credit(?: (\d+))?$/);
+  if (resetCredit) {
+    return resetCredit[1]
+      ? t("metric.resetCreditNumbered", { n: resetCredit[1] })
+      : t("metric.resetCredit");
+  }
   if (label.endsWith(" weekly")) {
     return t("metric.modelWeekly", { model: label.slice(0, -7) });
   }
@@ -730,6 +740,7 @@ export function displayMetricDetail(text: string): string {
   if (m) return t("detail.countOfUsed", { a: m[1], b: m[2] });
   m = text.match(new RegExp(`^(${num}) of (${num}) left$`, "i"));
   if (m) return t("detail.countOfLeft", { a: m[1], b: m[2] });
+  if (/^available$/i.test(text.trim())) return t("card.available");
   if (/^unlimited$/i.test(text.trim())) return t("detail.unlimited");
   return text;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -881,8 +881,8 @@ function renderMetric(m: Metric): string {
         : displayMetricDetail(m.value ?? t("card.available"));
     const remaining = m.resets_at === null ? null : m.resets_at - Date.now();
     const soon =
-      remaining !== null && remaining < 86_400_000
-        ? `<span class="warn-dot" title="${escapeHtml(t("card.creditDying", { time: fmtDuration(Math.max(0, remaining)) }))}">●</span> `
+      remaining !== null && remaining > 0 && remaining < 86_400_000
+        ? `<span class="warn-dot" title="${escapeHtml(t("card.creditDying", { time: fmtDuration(remaining) }))}">●</span> `
         : "";
     const useBtn = m.detail
       ? `<button class="redeem-btn" data-redeem="${escapeHtml(m.detail)}" title="${escapeHtml(t("card.useTip"))}">${escapeHtml(t("card.use"))}</button>`

--- a/src/main.ts
+++ b/src/main.ts
@@ -871,24 +871,28 @@ function renderMetric(m: Metric): string {
         </div>
       </div>`;
   }
-  // Actionable row (Codex reset credits): exact expiry + a Use button that
-  // spends the credit after a confirm. A credit dying within 24h gets an
+  // Action row (reset credits): exact expiry, plus a Use button only when
+  // the metric carries redeem detail. A credit dying within 24h gets an
   // amber dot so it isn't wasted.
-  if (m.kind === "action" && m.detail) {
+  if (m.kind === "action") {
     const expiry =
       m.resets_at !== null
         ? t("card.expires", { when: fmtExact(m.resets_at) })
         : displayMetricDetail(m.value ?? t("card.available"));
+    const remaining = m.resets_at === null ? null : m.resets_at - Date.now();
     const soon =
-      m.resets_at !== null && m.resets_at - Date.now() < 86_400_000
-        ? `<span class="warn-dot" title="${escapeHtml(t("card.creditDying", { time: fmtDuration(Math.max(0, m.resets_at - Date.now())) }))}">●</span> `
+      remaining !== null && remaining < 86_400_000
+        ? `<span class="warn-dot" title="${escapeHtml(t("card.creditDying", { time: fmtDuration(Math.max(0, remaining)) }))}">●</span> `
         : "";
+    const useBtn = m.detail
+      ? `<button class="redeem-btn" data-redeem="${escapeHtml(m.detail)}" title="${escapeHtml(t("card.useTip"))}">${escapeHtml(t("card.use"))}</button>`
+      : "";
     return `
       <div class="metric-text action-row">
         <span>${soon}${escapeHtml(displayMetricLabel(m.label))}</span>
         <span class="action-right">
           <span class="detail">${escapeHtml(expiry)}</span>
-          <button class="redeem-btn" data-redeem="${escapeHtml(m.detail)}" title="${escapeHtml(t("card.useTip"))}">${escapeHtml(t("card.use"))}</button>
+          ${useBtn}
         </span>
       </div>`;
   }


### PR DESCRIPTION
## Summary

- Fetch Grok GetRemainingResets concurrently with the existing provider requests.
- Strictly parse a bounded 64 KiB gRPC-Web protobuf response and degrade safely on optional endpoint failures.
- Trust the provider-returned collection, keep missing or invalid expiries as Available, and sort dated credits by expiry.
- Render localized read-only reset-credit rows without exposing token IDs or adding a Use action.
- Document the additional Grok endpoint and displayed data.

## Testing

- cargo test providers::grok --lib: 27 passed
- git diff --check: passed
- npm run build: blocked by the existing scheduleAutoRefresh TypeScript error where Timeout is not assignable to number
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->