### PR TITLE
feat: add Grok status page link

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -254,7 +254,10 @@ const PROVIDER_LINKS: Record<string, { label: string; url: string }[]> = {
     { label: "Status", url: "https://www.githubstatus.com/" },
     { label: "Dashboard", url: "https://github.com/settings/billing" },
   ],
-  grok: [{ label: "Usage", url: "https://grok.com/?_s=usage" }],
+  grok: [
+    { label: "Status", url: "https://status.x.ai" },
+    { label: "Usage", url: "https://grok.com/?_s=usage" },
+  ],
   devin: [{ label: "Dashboard", url: "https://app.devin.ai/settings/plans" }],
   minimax: [{ label: "Platform", url: "https://platform.minimax.io/" }],
   openrouter: [


### PR DESCRIPTION
## Summary

- Add a Status quick link on the Grok card pointing to https://status.x.ai
- Keep the existing Usage link to https://grok.com/?_s=usage

## Testing

- Matches the Status + dashboard/usage pattern used by Claude, Codex, and other providers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->