### PR TITLE
feat: sync provider config to tray surfaces

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1049,7 +1049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2347,7 +2347,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3078,7 +3078,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3373,7 +3373,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3430,7 +3430,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3833,7 +3833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4438,7 +4438,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4820,9 +4820,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
+checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -4837,7 +4837,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4866,7 +4866,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5275,7 +5275,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod pricing;
 mod providers;
 mod spend;
 mod telemetry;
+mod tray_projection;
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -343,83 +344,48 @@ fn draw_tray_numbers(values: &[u32]) -> Vec<u8> {
     rgba
 }
 
-/// Picks up to two metrics for the tray icon (like the Mac's stacked pair):
-/// the pinned provider's pinned metric first, then its next progress metric.
-fn pick_tray_metrics<'a>(
-    snapshots: &'a [providers::Snapshot],
-    pinned: &Value,
-) -> Vec<&'a providers::Metric> {
-    let pinned_provider = pinned.get("provider").and_then(Value::as_str);
-    let pinned_label = pinned.get("label").and_then(Value::as_str);
-
-    let provider = snapshots
-        .iter()
-        .find(|s| s.status == "ok" && Some(s.id.as_str()) == pinned_provider)
-        .or_else(|| {
-            snapshots
-                .iter()
-                .find(|s| s.status == "ok" && s.metrics.iter().any(|m| m.kind == "progress"))
-        });
-    let Some(provider) = provider else { return Vec::new() };
-
-    let mut metrics: Vec<&providers::Metric> =
-        provider.metrics.iter().filter(|m| m.kind == "progress").collect();
-    if let Some(label) = pinned_label {
-        if let Some(pos) = metrics.iter().position(|m| m.label == label) {
-            metrics.rotate_left(pos);
-        }
-    }
-    metrics.truncate(2);
-    metrics
-}
-
-fn update_tray(app: &tauri::AppHandle, snapshots: &[providers::Snapshot], cfg: &Value) {
-    let mut tooltip = String::from("Pane");
-    for s in snapshots.iter().filter(|s| s.status == "ok").take(6) {
-        if let Some(m) = s.metrics.iter().find(|m| m.kind == "progress") {
-            let left = (100.0 - m.used_percent.unwrap_or(0.0)).clamp(0.0, 100.0).round();
-            tooltip.push('\n');
-            tooltip.push_str(&i18n::pct_left(cfg, &s.name, &m.label, left));
-        }
-    }
-
-    // When the Mac-style tray strip is active it carries the numbers, so the
-    // main icon stays the app logo (the strip icons are per-provider).
-    let strip_active = cfg
-        .get("trayProviders")
-        .and_then(Value::as_array)
-        .is_some_and(|a| !a.is_empty());
-    let lefts: Vec<u32> = if strip_active {
-        Vec::new()
-    } else {
-        pick_tray_metrics(snapshots, cfg.get("pinned").unwrap_or(&Value::Null))
-            .iter()
-            .map(|m| (100.0 - m.used_percent.unwrap_or(0.0)).clamp(0.0, 100.0).round() as u32)
-            .collect()
-    };
+fn apply_main_tray_projection(
+    app: &tauri::AppHandle,
+    projection: &tray_projection::MainTrayProjection,
+) -> Result<(), String> {
     if let Ok(mut slot) = last_main_tray().lock() {
-        slot.lefts = lefts.clone();
-        slot.tooltip = tooltip.clone();
+        slot.lefts = projection.remaining_percentages.clone();
+        slot.tooltip = projection.tooltip.clone();
     }
 
+    let tray = app
+        .tray_by_id("tray")
+        .ok_or_else(|| "main tray icon is unavailable".to_string())?;
     if HIDE_STRIP.load(Ordering::Relaxed) {
-        set_main_tray_logo(app);
-        return;
+        let default = app
+            .default_window_icon()
+            .ok_or_else(|| "default Pane icon is unavailable".to_string())?;
+        tray.set_icon(Some(default.clone()))
+            .map_err(|error| format!("set hidden main tray icon: {error}"))?;
+        tray.set_tooltip(Some("Pane"))
+            .map_err(|error| format!("set hidden main tray tooltip: {error}"))?;
+        return Ok(());
     }
 
-    let Some(tray) = app.tray_by_id("tray") else {
-        return;
-    };
-    let _ = tray.set_tooltip(Some(&tooltip));
-    if strip_active {
-        if let Some(default) = app.default_window_icon() {
-            let _ = tray.set_icon(Some(default.clone()));
+    tray.set_tooltip(Some(&projection.tooltip))
+        .map_err(|error| format!("set main tray tooltip: {error}"))?;
+    match projection.icon_mode {
+        tray_projection::MainTrayIconMode::Logo => {
+            let default = app
+                .default_window_icon()
+                .ok_or_else(|| "default Pane icon is unavailable".to_string())?;
+            tray.set_icon(Some(default.clone()))
+                .map_err(|error| format!("set main tray logo: {error}"))
         }
-        return;
-    }
-    if !lefts.is_empty() {
-        let icon = tauri::image::Image::new_owned(draw_tray_numbers(&lefts), 32, 32);
-        let _ = tray.set_icon(Some(icon));
+        tray_projection::MainTrayIconMode::Numbers => {
+            let icon = tauri::image::Image::new_owned(
+                draw_tray_numbers(&projection.remaining_percentages),
+                32,
+                32,
+            );
+            tray.set_icon(Some(icon))
+                .map_err(|error| format!("set main tray numbers: {error}"))
+        }
     }
 }
 
@@ -452,6 +418,11 @@ fn last_main_tray() -> &'static Mutex<LastMainTray> {
 fn last_strip() -> &'static Mutex<Vec<StripEntry>> {
     static S: OnceLock<Mutex<Vec<StripEntry>>> = OnceLock::new();
     S.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn tray_strip_apply_lock() -> &'static tauri::async_runtime::Mutex<()> {
+    static LOCK: OnceLock<tauri::async_runtime::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tauri::async_runtime::Mutex::new(()))
 }
 
 fn hide_usage_flag(cfg: &Value) -> bool {
@@ -535,16 +506,17 @@ fn spawn_share_watcher(app: tauri::AppHandle) {
                 continue;
             }
             was_hidden = hide;
-            let cached = last_strip()
-                .lock()
-                .map(|g| g.clone())
-                .unwrap_or_default();
+            let _guard = tray_strip_apply_lock().lock().await;
+            let cached = last_strip().lock().map(|g| g.clone()).unwrap_or_default();
+            if let Err(error) = apply_tray_strip(app.clone(), cached, hide, Vec::new(), false).await
+            {
+                let action = if hide { "hide" } else { "restore" };
+                eprintln!("[pane] {action} tray strip: {error}");
+            }
             if hide {
-                let _ = apply_tray_strip(app.clone(), cached, true);
                 let handle = app.clone();
                 let _ = app.run_on_main_thread(move || set_main_tray_logo(&handle));
             } else {
-                let _ = apply_tray_strip(app.clone(), cached, false);
                 let handle = app.clone();
                 let _ = app.run_on_main_thread(move || paint_cached_main_tray(&handle));
                 let _ = app.emit("tray-strip-restore", ());
@@ -561,10 +533,10 @@ struct StripEntry {
     tooltip: String,
 }
 
-/// Every provider id that may appear in the tray strip. Doubles as the
-/// allowlist for update_tray_strip: ids from the frontend are validated
-/// against this before being spliced into tray icon ids, and stale strip
-/// icons are removed for exactly this set.
+/// Every provider family that may appear in the tray strip. Frontend
+/// strip ids are validated against this before becoming tray icon ids,
+/// including `family@account` cards. Stale family-level strip icons are
+/// removed for exactly this set.
 const STRIP_PROVIDER_IDS: [&str; 21] = [
     "claude",
     "codex",
@@ -589,93 +561,217 @@ const STRIP_PROVIDER_IDS: [&str; 21] = [
     "kimi",
 ];
 
-#[tauri::command]
-fn update_tray_strip(app: tauri::AppHandle, entries: Vec<StripEntry>) -> Result<(), String> {
-    if let Ok(mut slot) = last_strip().lock() {
-        *slot = entries.clone();
-    }
-    apply_tray_strip(app, entries, HIDE_STRIP.load(Ordering::Relaxed))
+async fn update_tray_strip(app: tauri::AppHandle, entries: Vec<StripEntry>) -> Result<(), String> {
+    validate_strip_entries(&entries)?;
+    let _guard = tray_strip_apply_lock().lock().await;
+    let reset_ids = last_strip()
+        .lock()
+        .map(|slot| strip_reset_ids(&slot, &entries))
+        .unwrap_or_default();
+    let rebuild_order = !reset_ids.is_empty();
+    let result = apply_tray_strip(
+        app,
+        entries.clone(),
+        HIDE_STRIP.load(Ordering::Relaxed),
+        reset_ids,
+        rebuild_order,
+    )
+    .await;
+    let Ok(mut slot) = last_strip().lock() else {
+        return result;
+    };
+    commit_strip_state_after_apply(&mut slot, &entries, result)
 }
 
-fn apply_tray_strip(
+fn commit_strip_state_after_apply(
+    current: &mut Vec<StripEntry>,
+    next: &[StripEntry],
+    result: Result<(), String>,
+) -> Result<(), String> {
+    result?;
+    *current = next.to_vec();
+    Ok(())
+}
+
+#[tauri::command]
+async fn sync_tray_surfaces(
+    app: tauri::AppHandle,
+    snapshots: Vec<providers::Snapshot>,
+    projection: tray_projection::TrayProjectionConfig,
+    entries: Vec<StripEntry>,
+) -> Result<(), String> {
+    let main = tray_projection::project_main_tray(&snapshots, &projection, !entries.is_empty());
+    let main_result = apply_main_tray_projection(&app, &main);
+    let strip_result = update_tray_strip(app, entries).await;
+    match (main_result, strip_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(main_error), Err(strip_error)) => Err(format!("{main_error}; {strip_error}")),
+    }
+}
+
+fn validate_strip_entries(entries: &[StripEntry]) -> Result<(), String> {
+    if entries.len() > 4 {
+        return Err("tray strip accepts at most 4 providers".into());
+    }
+    for (index, entry) in entries.iter().enumerate() {
+        if !strip_provider_id_is_allowed(&entry.id) {
+            return Err(format!("invalid tray strip provider id: {}", entry.id));
+        }
+        if entries[..index].iter().any(|seen| seen.id == entry.id) {
+            return Err(format!("duplicate tray strip provider id: {}", entry.id));
+        }
+        if entry.logo.len() != 32 * 32 * 4 {
+            return Err(format!("invalid tray strip logo for {}", entry.id));
+        }
+        if entry.values.is_empty() || entry.values.len() > 2 {
+            return Err(format!("invalid tray strip values for {}", entry.id));
+        }
+    }
+    Ok(())
+}
+
+fn strip_provider_id_is_allowed(id: &str) -> bool {
+    match id.split_once('@') {
+        None => STRIP_PROVIDER_IDS.contains(&id),
+        Some((family, account)) => {
+            STRIP_PROVIDER_IDS.contains(&family)
+                && !account.is_empty()
+                && account
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
+        }
+    }
+}
+
+fn strip_tray_key(id: &str) -> String {
+    id.replace('@', "--")
+}
+
+fn strip_reset_ids(previous: &[StripEntry], next: &[StripEntry]) -> Vec<String> {
+    let same_order = previous.len() == next.len()
+        && previous.iter().zip(next).all(|(old, new)| old.id == new.id);
+    if same_order {
+        return Vec::new();
+    }
+
+    let mut ids = Vec::new();
+    for entry in previous.iter().chain(next) {
+        if !ids.contains(&entry.id) {
+            ids.push(entry.id.clone());
+        }
+    }
+    ids
+}
+
+fn strip_entry_application_order(entries: &[StripEntry], rebuild_order: bool) -> Vec<&StripEntry> {
+    let mut ordered: Vec<&StripEntry> = entries.iter().collect();
+    if rebuild_order {
+        // Windows inserts each new tray icon to the left. Rebuild Provider
+        // pairs from right to left so their visible order matches providerOrder.
+        ordered.reverse();
+    }
+    ordered
+}
+
+async fn apply_tray_strip(
     app: tauri::AppHandle,
     entries: Vec<StripEntry>,
     hide_numbers: bool,
+    reset_ids: Vec<String>,
+    rebuild_order: bool,
 ) -> Result<(), String> {
     let handle = app.clone();
+    let (sender, mut receiver) = tauri::async_runtime::channel(1);
     app.run_on_main_thread(move || {
-        // Remove strip icons for providers no longer selected.
-        for id in STRIP_PROVIDER_IDS {
-            if !entries.iter().any(|e| e.id == id) {
-                let _ = handle.remove_tray_by_id(&format!("strip-logo-{id}"));
-                let _ = handle.remove_tray_by_id(&format!("strip-num-{id}"));
-            }
-        }
-
-        for entry in &entries {
-            // Only known provider ids may reach the tray icon namespace.
-            if !STRIP_PROVIDER_IDS.contains(&entry.id.as_str()) {
-                continue;
-            }
-            if entry.logo.len() != 32 * 32 * 4 {
-                continue;
-            }
-            let logo_id = format!("strip-logo-{}", entry.id);
-            let num_id = format!("strip-num-{}", entry.id);
-            let logo_icon = tauri::image::Image::new_owned(entry.logo.clone(), 32, 32);
-            let num_icon = tauri::image::Image::new_owned(
-                if hide_numbers {
-                    vec![0u8; 32 * 32 * 4]
-                } else {
-                    draw_tray_numbers(&entry.values)
-                },
-                32,
-                32,
-            );
-            let tooltip = if hide_numbers {
-                entry
-                    .tooltip
-                    .split('\n')
-                    .next()
-                    .unwrap_or("Pane")
-                    .to_string()
-            } else {
-                entry.tooltip.clone()
-            };
-
-            if let Some(tray) = handle.tray_by_id(&num_id) {
-                let _ = tray.set_icon(Some(num_icon));
-                let _ = tray.set_tooltip(Some(&tooltip));
-                if let Some(logo_tray) = handle.tray_by_id(&logo_id) {
-                    let _ = logo_tray.set_tooltip(Some(&tooltip));
+        let result = (|| -> Result<(), String> {
+            // Removal returns None when an icon is already absent; that is
+            // the desired end state rather than an update failure.
+            for id in STRIP_PROVIDER_IDS {
+                if !entries.iter().any(|entry| entry.id == id) {
+                    handle.remove_tray_by_id(&format!("strip-logo-{id}"));
+                    handle.remove_tray_by_id(&format!("strip-num-{id}"));
                 }
-                continue;
+            }
+            for id in &reset_ids {
+                let key = strip_tray_key(id);
+                handle.remove_tray_by_id(&format!("strip-logo-{key}"));
+                handle.remove_tray_by_id(&format!("strip-num-{key}"));
             }
 
-            // New pair — numbers first: Windows inserts each new tray icon
-            // to the LEFT of the previous one, so creating numbers → logo
-            // lands as "logo | numbers" left-to-right, like the Mac strip.
-            for (tray_id, icon) in [(num_id, num_icon), (logo_id, logo_icon)] {
-                let _ = TrayIconBuilder::with_id(tray_id)
-                    .icon(icon)
-                    .tooltip(&tooltip)
-                    .show_menu_on_left_click(false)
-                    .on_tray_icon_event(|tray, event| {
-                        if let TrayIconEvent::Click {
-                            button: MouseButton::Left,
-                            button_state: MouseButtonState::Up,
-                            position,
-                            ..
-                        } = event
-                        {
-                            toggle_popover(tray.app_handle(), position);
-                        }
-                    })
-                    .build(&handle);
+            for entry in strip_entry_application_order(&entries, rebuild_order) {
+                let tray_key = strip_tray_key(&entry.id);
+                let logo_id = format!("strip-logo-{tray_key}");
+                let num_id = format!("strip-num-{tray_key}");
+                let logo_icon = tauri::image::Image::new_owned(entry.logo.clone(), 32, 32);
+                let num_icon = tauri::image::Image::new_owned(
+                    if hide_numbers {
+                        vec![0u8; 32 * 32 * 4]
+                    } else {
+                        draw_tray_numbers(&entry.values)
+                    },
+                    32,
+                    32,
+                );
+                let tooltip = if hide_numbers {
+                    entry
+                        .tooltip
+                        .split('\n')
+                        .next()
+                        .unwrap_or("Pane")
+                        .to_string()
+                } else {
+                    entry.tooltip.clone()
+                };
+
+                let new_trays = if let Some(tray) = handle.tray_by_id(&num_id) {
+                    tray.set_icon(Some(num_icon))
+                        .map_err(|error| format!("set {} strip numbers: {error}", entry.id))?;
+                    tray.set_tooltip(Some(&tooltip))
+                        .map_err(|error| format!("set {} strip tooltip: {error}", entry.id))?;
+                    if let Some(logo_tray) = handle.tray_by_id(&logo_id) {
+                        logo_tray.set_tooltip(Some(&tooltip)).map_err(|error| {
+                            format!("set {} strip logo tooltip: {error}", entry.id)
+                        })?;
+                        Vec::new()
+                    } else {
+                        vec![(logo_id, logo_icon)]
+                    }
+                } else {
+                    vec![(num_id, num_icon), (logo_id, logo_icon)]
+                };
+
+                // New pairs are numbers first: Windows inserts each new tray
+                // icon to the left, yielding "logo | numbers" on screen.
+                for (tray_id, icon) in new_trays {
+                    TrayIconBuilder::with_id(tray_id)
+                        .icon(icon)
+                        .tooltip(&tooltip)
+                        .show_menu_on_left_click(false)
+                        .on_tray_icon_event(|tray, event| {
+                            if let TrayIconEvent::Click {
+                                button: MouseButton::Left,
+                                button_state: MouseButtonState::Up,
+                                position,
+                                ..
+                            } = event
+                            {
+                                toggle_popover(tray.app_handle(), position);
+                            }
+                        })
+                        .build(&handle)
+                        .map_err(|error| format!("build {} strip icon: {error}", entry.id))?;
+                }
             }
-        }
+            Ok(())
+        })();
+        let _ = sender.blocking_send(result);
     })
-    .map_err(|e| e.to_string())
+    .map_err(|error| error.to_string())?;
+    receiver
+        .recv()
+        .await
+        .ok_or_else(|| "tray strip update ended before reporting a result".to_string())?
 }
 
 // ---------------------------------------------------------------------------
@@ -817,16 +913,35 @@ fn restore_kimi_wallet_rows(current: &mut providers::Snapshot, previous: &provid
     }
 }
 
+fn restore_last_success_after_error(
+    current: &mut providers::Snapshot,
+    previous: &providers::Snapshot,
+    age_ms: i64,
+) -> bool {
+    if current.status != "error" || age_ms > SNAPSHOT_CACHE_MS {
+        return false;
+    }
+    let warning = current.error.clone();
+    *current = previous.clone();
+    current.stale = true;
+    current.warning = warning;
+    true
+}
+
 /// Called by the UI. Refreshes every enabled provider at the same time and
 /// returns whatever each one found — data, "not signed in", or an error.
 #[tauri::command]
-async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
+async fn fetch_usage(
+    app: tauri::AppHandle,
+    disabled: Option<Vec<String>>,
+) -> Vec<providers::Snapshot> {
     let cfg = config_with_defaults(load_config());
-    let disabled: Vec<String> = cfg
-        .get("disabled")
-        .and_then(Value::as_array)
-        .map(|a| a.iter().filter_map(Value::as_str).map(str::to_string).collect())
-        .unwrap_or_default();
+    let disabled = disabled.unwrap_or_else(|| {
+        cfg.get("disabled")
+            .and_then(Value::as_array)
+            .map(|a| a.iter().filter_map(Value::as_str).map(str::to_string).collect())
+            .unwrap_or_default()
+    });
 
     // Each provider future is boxed onto the heap and spawned as its own
     // task. A single tokio::join! over 28 inlined futures builds one huge
@@ -1059,14 +1174,7 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
                 } else if s.status == "error" {
                     if let Some(previous) = map.get(&s.id) {
                         let age = now_ms - previous.at;
-                        if age <= SNAPSHOT_CACHE_MS {
-                            let warning = s.error.clone();
-                            *s = previous.snap.clone();
-                            if age > STALE_GRACE_MS {
-                                s.stale = true;
-                                s.warning = warning;
-                            }
-                        }
+                        restore_last_success_after_error(s, &previous.snap, age);
                     }
                 }
             }
@@ -1084,8 +1192,6 @@ async fn fetch_usage(app: tauri::AppHandle) -> Vec<providers::Snapshot> {
     fold_moonshot_into_kimi(&mut all);
 
     httpapi::publish(&all);
-    update_tray(&app, &all, &cfg);
-
     // Anonymous daily-rollup telemetry (Settings → "Share anonymous usage
     // statistics"). Fire-and-forget: it must never delay or fail a refresh.
     {
@@ -1587,7 +1693,7 @@ pub fn run() {
             system_ui_locale,
             get_autostart,
             set_autostart,
-            update_tray_strip,
+            sync_tray_surfaces,
             open_link,
             copy_share_image,
             set_shortcut,
@@ -1684,11 +1790,21 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::{
-        cached_kimi_ok_from, fold_moonshot_into_kimi, is_kimi_wallet_label, restore_kimi_wallet_rows,
-        SNAPSHOT_CACHE_MS,
+        cached_kimi_ok_from, commit_strip_state_after_apply, fold_moonshot_into_kimi,
+        is_kimi_wallet_label, restore_kimi_wallet_rows, restore_last_success_after_error,
+        strip_entry_application_order, strip_reset_ids, StripEntry, SNAPSHOT_CACHE_MS,
     };
     use crate::providers::{Metric, Snapshot};
     use serde_json::json;
+
+    fn strip_entry(id: &str, value: u32) -> StripEntry {
+        StripEntry {
+            id: id.into(),
+            logo: vec![0; 32 * 32 * 4],
+            values: vec![value],
+            tooltip: id.into(),
+        }
+    }
 
     #[test]
     fn kimi_wallet_labels() {
@@ -1754,6 +1870,90 @@ mod tests {
         let err = json!({"kimi": {"at": now, "snap": {"status": "error"}}});
         assert!(!cached_kimi_ok_from(&err, now));
         assert!(!cached_kimi_ok_from(&json!({}), now));
+    }
+
+    #[test]
+    fn tray_strip_order_change_rebuilds_all_pairs_right_to_left() {
+        let previous = vec![strip_entry("claude", 50), strip_entry("codex", 60)];
+        let next = vec![strip_entry("codex", 60), strip_entry("claude", 50)];
+
+        let reset_ids = strip_reset_ids(&previous, &next);
+        let application_ids: Vec<&str> = strip_entry_application_order(&next, true)
+            .into_iter()
+            .map(|entry| entry.id.as_str())
+            .collect();
+
+        assert_eq!(reset_ids, vec!["claude", "codex"]);
+        assert_eq!(application_ids, vec!["claude", "codex"]);
+    }
+
+    #[test]
+    fn tray_strip_value_change_keeps_existing_pairs() {
+        let previous = vec![strip_entry("claude", 50), strip_entry("codex", 60)];
+        let next = vec![strip_entry("claude", 40), strip_entry("codex", 30)];
+
+        assert!(strip_reset_ids(&previous, &next).is_empty());
+    }
+
+    #[test]
+    fn failed_tray_strip_apply_keeps_the_last_applied_state_for_retry() {
+        let previous = vec![strip_entry("claude", 50), strip_entry("codex", 60)];
+        let next = vec![strip_entry("codex", 60), strip_entry("claude", 50)];
+        let mut cached = previous.clone();
+
+        let result: Result<(), String> = Err("native tray update failed".into());
+        assert!(commit_strip_state_after_apply(&mut cached, &next, result).is_err());
+        assert_eq!(
+            strip_reset_ids(&cached, &next),
+            vec!["claude", "codex"],
+            "an identical retry must still rebuild the changed order"
+        );
+    }
+
+    #[test]
+    fn successful_tray_strip_apply_commits_the_new_state() {
+        let previous = vec![strip_entry("claude", 50), strip_entry("codex", 60)];
+        let next = vec![strip_entry("codex", 60), strip_entry("claude", 50)];
+        let mut cached = previous;
+
+        assert!(commit_strip_state_after_apply(&mut cached, &next, Ok(())).is_ok());
+        assert!(strip_reset_ids(&cached, &next).is_empty());
+    }
+
+    #[test]
+    fn recent_error_fallback_is_immediately_marked_stale() {
+        let previous = Snapshot::ok(
+            "codex",
+            "Codex",
+            None,
+            vec![Metric::progress("Weekly", 25.0, None)],
+        );
+        let mut current = Snapshot::error("codex", "Codex", "timeout".into());
+
+        assert!(restore_last_success_after_error(&mut current, &previous, 1_000));
+        assert_eq!(current.status, "ok");
+        assert!(current.stale);
+        assert_eq!(current.warning.as_deref(), Some("timeout"));
+        assert_eq!(current.metrics[0].used_percent, Some(25.0));
+    }
+
+    #[test]
+    fn expired_error_fallback_is_not_restored() {
+        let previous = Snapshot::ok(
+            "codex",
+            "Codex",
+            None,
+            vec![Metric::progress("Weekly", 25.0, None)],
+        );
+        let mut current = Snapshot::error("codex", "Codex", "timeout".into());
+
+        assert!(!restore_last_success_after_error(
+            &mut current,
+            &previous,
+            SNAPSHOT_CACHE_MS + 1,
+        ));
+        assert_eq!(current.status, "error");
+        assert!(!current.stale);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -578,7 +578,12 @@ async fn update_tray_strip(app: tauri::AppHandle, entries: Vec<StripEntry>) -> R
     )
     .await;
     if result.is_err() {
-        let _ = clear_tray_strip_icons(app, &previous, &entries).await;
+        if clear_tray_strip_icons(app, &previous, &entries).await.is_ok() {
+            if let Ok(mut slot) = last_strip().lock() {
+                slot.clear();
+            }
+        }
+        return result;
     }
     let Ok(mut slot) = last_strip().lock() else {
         return result;
@@ -1943,18 +1948,18 @@ mod tests {
     }
 
     #[test]
-    fn failed_tray_strip_apply_keeps_the_last_applied_state_for_retry() {
+    fn failed_tray_strip_clear_invalidates_cache_so_retry_rebuilds() {
         let previous = vec![strip_entry("claude", 50), strip_entry("codex", 60)];
-        let next = vec![strip_entry("codex", 60), strip_entry("claude", 50)];
+        let same_order = previous.clone();
+        let reordered = vec![strip_entry("codex", 60), strip_entry("claude", 50)];
         let mut cached = previous.clone();
 
         let result: Result<(), String> = Err("native tray update failed".into());
-        assert!(commit_strip_state_after_apply(&mut cached, &next, result).is_err());
-        assert_eq!(
-            strip_reset_ids(&cached, &next),
-            vec!["claude", "codex"],
-            "an identical retry must still rebuild the changed order"
-        );
+        assert!(commit_strip_state_after_apply(&mut cached, &same_order, result).is_err());
+        cached.clear();
+
+        assert!(!strip_reset_ids(&cached, &same_order).is_empty());
+        assert!(!strip_reset_ids(&cached, &reordered).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -348,11 +348,6 @@ fn apply_main_tray_projection(
     app: &tauri::AppHandle,
     projection: &tray_projection::MainTrayProjection,
 ) -> Result<(), String> {
-    if let Ok(mut slot) = last_main_tray().lock() {
-        slot.lefts = projection.remaining_percentages.clone();
-        slot.tooltip = projection.tooltip.clone();
-    }
-
     let tray = app
         .tray_by_id("tray")
         .ok_or_else(|| "main tray icon is unavailable".to_string())?;
@@ -364,29 +359,33 @@ fn apply_main_tray_projection(
             .map_err(|error| format!("set hidden main tray icon: {error}"))?;
         tray.set_tooltip(Some("Pane"))
             .map_err(|error| format!("set hidden main tray tooltip: {error}"))?;
-        return Ok(());
-    }
-
-    tray.set_tooltip(Some(&projection.tooltip))
-        .map_err(|error| format!("set main tray tooltip: {error}"))?;
-    match projection.icon_mode {
-        tray_projection::MainTrayIconMode::Logo => {
-            let default = app
-                .default_window_icon()
-                .ok_or_else(|| "default Pane icon is unavailable".to_string())?;
-            tray.set_icon(Some(default.clone()))
-                .map_err(|error| format!("set main tray logo: {error}"))
+    } else {
+        tray.set_tooltip(Some(&projection.tooltip))
+            .map_err(|error| format!("set main tray tooltip: {error}"))?;
+        match projection.icon_mode {
+            tray_projection::MainTrayIconMode::Logo => {
+                let default = app
+                    .default_window_icon()
+                    .ok_or_else(|| "default Pane icon is unavailable".to_string())?;
+                tray.set_icon(Some(default.clone()))
+                    .map_err(|error| format!("set main tray logo: {error}"))?;
+            }
+            tray_projection::MainTrayIconMode::Numbers => {
+                let icon = tauri::image::Image::new_owned(
+                    draw_tray_numbers(&projection.remaining_percentages),
+                    32,
+                    32,
+                );
+                tray.set_icon(Some(icon))
+                    .map_err(|error| format!("set main tray numbers: {error}"))?;
+            }
         }
-        tray_projection::MainTrayIconMode::Numbers => {
-            let icon = tauri::image::Image::new_owned(
-                draw_tray_numbers(&projection.remaining_percentages),
-                32,
-                32,
-            );
-            tray.set_icon(Some(icon))
-                .map_err(|error| format!("set main tray numbers: {error}"))
-        }
     }
+    if let Ok(mut slot) = last_main_tray().lock() {
+        slot.lefts = projection.remaining_percentages.clone();
+        slot.tooltip = projection.tooltip.clone();
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -564,19 +563,23 @@ const STRIP_PROVIDER_IDS: [&str; 21] = [
 async fn update_tray_strip(app: tauri::AppHandle, entries: Vec<StripEntry>) -> Result<(), String> {
     validate_strip_entries(&entries)?;
     let _guard = tray_strip_apply_lock().lock().await;
-    let reset_ids = last_strip()
+    let previous = last_strip()
         .lock()
-        .map(|slot| strip_reset_ids(&slot, &entries))
+        .map(|slot| slot.clone())
         .unwrap_or_default();
+    let reset_ids = strip_reset_ids(&previous, &entries);
     let rebuild_order = !reset_ids.is_empty();
     let result = apply_tray_strip(
-        app,
+        app.clone(),
         entries.clone(),
         HIDE_STRIP.load(Ordering::Relaxed),
         reset_ids,
         rebuild_order,
     )
     .await;
+    if result.is_err() {
+        let _ = clear_tray_strip_icons(app, &previous, &entries).await;
+    }
     let Ok(mut slot) = last_strip().lock() else {
         return result;
     };
@@ -593,6 +596,20 @@ fn commit_strip_state_after_apply(
     Ok(())
 }
 
+fn strip_is_active(strip_ok: bool, entries: &[StripEntry]) -> bool {
+    strip_ok && !entries.is_empty()
+}
+
+fn strip_icon_ids_to_clear(known: &[StripEntry], attempted: &[StripEntry]) -> Vec<String> {
+    let mut ids: Vec<String> = STRIP_PROVIDER_IDS.iter().map(|id| (*id).to_string()).collect();
+    for entry in known.iter().chain(attempted) {
+        if !ids.iter().any(|seen| seen == &entry.id) {
+            ids.push(entry.id.clone());
+        }
+    }
+    ids
+}
+
 #[tauri::command]
 async fn sync_tray_surfaces(
     app: tauri::AppHandle,
@@ -600,9 +617,13 @@ async fn sync_tray_surfaces(
     projection: tray_projection::TrayProjectionConfig,
     entries: Vec<StripEntry>,
 ) -> Result<(), String> {
-    let main = tray_projection::project_main_tray(&snapshots, &projection, !entries.is_empty());
+    let strip_result = update_tray_strip(app.clone(), entries.clone()).await;
+    let main = tray_projection::project_main_tray(
+        &snapshots,
+        &projection,
+        strip_is_active(strip_result.is_ok(), &entries),
+    );
     let main_result = apply_main_tray_projection(&app, &main);
-    let strip_result = update_tray_strip(app, entries).await;
     match (main_result, strip_result) {
         (Ok(()), Ok(())) => Ok(()),
         (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
@@ -672,6 +693,29 @@ fn strip_entry_application_order(entries: &[StripEntry], rebuild_order: bool) ->
         ordered.reverse();
     }
     ordered
+}
+
+async fn clear_tray_strip_icons(
+    app: tauri::AppHandle,
+    known: &[StripEntry],
+    attempted: &[StripEntry],
+) -> Result<(), String> {
+    let ids = strip_icon_ids_to_clear(known, attempted);
+    let handle = app.clone();
+    let (sender, mut receiver) = tauri::async_runtime::channel(1);
+    app.run_on_main_thread(move || {
+        for id in &ids {
+            let key = strip_tray_key(id);
+            handle.remove_tray_by_id(&format!("strip-logo-{key}"));
+            handle.remove_tray_by_id(&format!("strip-num-{key}"));
+        }
+        let _ = sender.blocking_send(());
+    })
+    .map_err(|error| error.to_string())?;
+    receiver
+        .recv()
+        .await
+        .ok_or_else(|| "tray strip clear ended before reporting a result".to_string())
 }
 
 async fn apply_tray_strip(
@@ -1794,8 +1838,8 @@ mod tests {
     use super::{
         cached_kimi_ok_from, commit_strip_state_after_apply, fold_moonshot_into_kimi,
         is_kimi_wallet_label, restore_kimi_wallet_rows, restore_last_success_after_error,
-        strip_entry_application_order, strip_reset_ids, StripEntry, SNAPSHOT_CACHE_MS,
-        STALE_GRACE_MS,
+        strip_entry_application_order, strip_icon_ids_to_clear, strip_is_active, strip_reset_ids,
+        StripEntry, SNAPSHOT_CACHE_MS, STALE_GRACE_MS,
     };
     use crate::providers::{Metric, Snapshot};
     use serde_json::json;
@@ -1921,6 +1965,32 @@ mod tests {
 
         assert!(commit_strip_state_after_apply(&mut cached, &next, Ok(())).is_ok());
         assert!(strip_reset_ids(&cached, &next).is_empty());
+    }
+
+    #[test]
+    fn strip_is_inactive_when_apply_failed() {
+        assert!(!strip_is_active(false, &[strip_entry("claude", 50)]));
+    }
+
+    #[test]
+    fn strip_is_inactive_when_entries_are_empty() {
+        assert!(!strip_is_active(true, &[]));
+        assert!(!strip_is_active(false, &[]));
+    }
+
+    #[test]
+    fn strip_is_active_when_apply_succeeded_with_entries() {
+        assert!(strip_is_active(true, &[strip_entry("claude", 50)]));
+    }
+
+    #[test]
+    fn strip_clear_ids_include_family_and_account_cards() {
+        let known = vec![strip_entry("claude@work", 50)];
+        let attempted = vec![strip_entry("codex", 40)];
+        let ids = strip_icon_ids_to_clear(&known, &attempted);
+        assert!(ids.contains(&"claude".into()));
+        assert!(ids.contains(&"claude@work".into()));
+        assert!(ids.contains(&"codex".into()));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -923,8 +923,10 @@ fn restore_last_success_after_error(
     }
     let warning = current.error.clone();
     *current = previous.clone();
-    current.stale = true;
-    current.warning = warning;
+    if age_ms > STALE_GRACE_MS {
+        current.stale = true;
+        current.warning = warning;
+    }
     true
 }
 
@@ -1793,6 +1795,7 @@ mod tests {
         cached_kimi_ok_from, commit_strip_state_after_apply, fold_moonshot_into_kimi,
         is_kimi_wallet_label, restore_kimi_wallet_rows, restore_last_success_after_error,
         strip_entry_application_order, strip_reset_ids, StripEntry, SNAPSHOT_CACHE_MS,
+        STALE_GRACE_MS,
     };
     use crate::providers::{Metric, Snapshot};
     use serde_json::json;
@@ -1921,7 +1924,7 @@ mod tests {
     }
 
     #[test]
-    fn recent_error_fallback_is_immediately_marked_stale() {
+    fn recent_error_fallback_within_grace_is_not_marked_stale() {
         let previous = Snapshot::ok(
             "codex",
             "Codex",
@@ -1931,6 +1934,27 @@ mod tests {
         let mut current = Snapshot::error("codex", "Codex", "timeout".into());
 
         assert!(restore_last_success_after_error(&mut current, &previous, 1_000));
+        assert_eq!(current.status, "ok");
+        assert!(!current.stale);
+        assert_eq!(current.warning, None);
+        assert_eq!(current.metrics[0].used_percent, Some(25.0));
+    }
+
+    #[test]
+    fn recent_error_fallback_after_grace_is_marked_stale() {
+        let previous = Snapshot::ok(
+            "codex",
+            "Codex",
+            None,
+            vec![Metric::progress("Weekly", 25.0, None)],
+        );
+        let mut current = Snapshot::error("codex", "Codex", "timeout".into());
+
+        assert!(restore_last_success_after_error(
+            &mut current,
+            &previous,
+            STALE_GRACE_MS + 1,
+        ));
         assert_eq!(current.status, "ok");
         assert!(current.stale);
         assert_eq!(current.warning.as_deref(), Some("timeout"));

--- a/src-tauri/src/tray_projection.rs
+++ b/src-tauri/src/tray_projection.rs
@@ -1,0 +1,736 @@
+use crate::providers;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TrayProjectionConfig {
+    pub disabled: Vec<String>,
+    pub provider_order: Vec<String>,
+    pub providers: HashMap<String, ProviderProjectionConfig>,
+    pub pinned: Option<PinnedMetric>,
+    pub locale: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ProviderProjectionConfig {
+    pub metric_order: Vec<String>,
+    pub hidden: Vec<String>,
+    pub starred: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct PinnedMetric {
+    pub provider: String,
+    pub label: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum MainTrayIconMode {
+    Logo,
+    Numbers,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct MainTrayProjection {
+    pub icon_mode: MainTrayIconMode,
+    pub remaining_percentages: Vec<u32>,
+    pub tooltip: String,
+}
+
+pub(crate) fn project_main_tray(
+    snapshots: &[providers::Snapshot],
+    config: &TrayProjectionConfig,
+    strip_active: bool,
+) -> MainTrayProjection {
+    let visible: Vec<&providers::Snapshot> = config
+        .provider_order
+        .iter()
+        .filter(|provider_id| !config.disabled.contains(provider_id))
+        .filter_map(|provider_id| {
+            snapshots
+                .iter()
+                .find(|snapshot| snapshot.id == *provider_id)
+        })
+        .filter(|snapshot| {
+            snapshot.status == "ok"
+                && snapshot
+                    .metrics
+                    .iter()
+                    .any(|metric| metric.kind == "progress")
+        })
+        .collect();
+    let active_pinned = config.pinned.as_ref().and_then(|pinned| {
+        let snapshot = visible
+            .iter()
+            .find(|snapshot| snapshot.id == pinned.provider)
+            .copied()?;
+        let metric = snapshot
+            .metrics
+            .iter()
+            .find(|metric| metric.kind == "progress" && metric.label == pinned.label)?;
+        Some((snapshot, metric))
+    });
+    let auto_provider = visible.iter().copied().find(|snapshot| {
+        !ordinary_metrics(snapshot, config.providers.get(&snapshot.id)).is_empty()
+    });
+    let Some(icon_provider) = active_pinned
+        .map(|(snapshot, _)| snapshot)
+        .or(auto_provider)
+    else {
+        return MainTrayProjection {
+            icon_mode: MainTrayIconMode::Logo,
+            remaining_percentages: Vec::new(),
+            tooltip: "Pane".into(),
+        };
+    };
+    let mut icon_metrics = ordinary_metrics(icon_provider, config.providers.get(&icon_provider.id));
+    if let Some((_, pinned_metric)) = active_pinned {
+        icon_metrics.retain(|metric| metric.label != pinned_metric.label);
+        icon_metrics.insert(0, pinned_metric);
+    }
+    icon_metrics.truncate(2);
+
+    let locale = serde_json::json!({ "locale": config.locale });
+    let pinned_provider_id = active_pinned.map(|(snapshot, _)| snapshot.id.as_str());
+    let displayable: Vec<&providers::Snapshot> = visible
+        .iter()
+        .copied()
+        .filter(|snapshot| {
+            Some(snapshot.id.as_str()) == pinned_provider_id
+                || !ordinary_metrics(snapshot, config.providers.get(&snapshot.id)).is_empty()
+        })
+        .collect();
+    let mut tooltip_providers: Vec<&providers::Snapshot> =
+        displayable.iter().copied().take(6).collect();
+    if let Some((pinned_provider, _)) = active_pinned {
+        if !tooltip_providers
+            .iter()
+            .any(|snapshot| snapshot.id == pinned_provider.id)
+        {
+            tooltip_providers.truncate(5);
+            tooltip_providers.push(pinned_provider);
+        }
+    }
+    let mut tooltip_lines: Vec<(&str, String)> = Vec::new();
+    for snapshot in tooltip_providers {
+        let mut metrics = if snapshot.id == icon_provider.id {
+            icon_metrics.clone()
+        } else {
+            ordinary_metrics(snapshot, config.providers.get(&snapshot.id))
+        };
+        metrics.truncate(if snapshot.id == icon_provider.id {
+            2
+        } else {
+            1
+        });
+        if metrics.is_empty() {
+            continue;
+        }
+        tooltip_lines.push((
+            &snapshot.id,
+            format_provider_line(snapshot, &metrics, &locale),
+        ));
+    }
+    while tooltip_utf16_len(&tooltip_lines) > 127 {
+        let pinned_id = active_pinned.map(|(snapshot, _)| snapshot.id.as_str());
+        let remove_at = tooltip_lines
+            .iter()
+            .rposition(|(provider_id, _)| Some(*provider_id) != pinned_id)
+            .or_else(|| tooltip_lines.len().checked_sub(1));
+        let Some(remove_at) = remove_at else { break };
+        tooltip_lines.remove(remove_at);
+    }
+    let tooltip = tooltip_from_lines(&tooltip_lines);
+    let icon_explained = tooltip_lines
+        .iter()
+        .any(|(provider_id, _)| *provider_id == icon_provider.id.as_str());
+    let show_numbers = !strip_active && icon_explained;
+
+    MainTrayProjection {
+        icon_mode: if show_numbers {
+            MainTrayIconMode::Numbers
+        } else {
+            MainTrayIconMode::Logo
+        },
+        remaining_percentages: if show_numbers {
+            icon_metrics
+                .into_iter()
+                .map(|metric| percent_left(metric) as u32)
+                .collect()
+        } else {
+            Vec::new()
+        },
+        tooltip,
+    }
+}
+
+fn tooltip_from_lines(lines: &[(&str, String)]) -> String {
+    let mut tooltip = String::from("Pane");
+    for (_, line) in lines {
+        tooltip.push('\n');
+        tooltip.push_str(line);
+    }
+    tooltip
+}
+
+fn tooltip_utf16_len(lines: &[(&str, String)]) -> usize {
+    4 + lines
+        .iter()
+        .map(|(_, line)| 1 + line.encode_utf16().count())
+        .sum::<usize>()
+}
+
+fn ordinary_metrics<'a>(
+    snapshot: &'a providers::Snapshot,
+    config: Option<&ProviderProjectionConfig>,
+) -> Vec<&'a providers::Metric> {
+    let hidden = config
+        .map(|value| value.hidden.as_slice())
+        .unwrap_or_default();
+    let mut labels: Vec<&str> = Vec::new();
+    if let Some(config) = config {
+        labels.extend(config.starred.iter().map(String::as_str));
+        labels.extend(config.metric_order.iter().map(String::as_str));
+    }
+    labels.extend(snapshot.metrics.iter().map(|metric| metric.label.as_str()));
+
+    let mut metrics = Vec::new();
+    for label in labels {
+        if hidden.iter().any(|hidden_label| hidden_label == label)
+            || metrics
+                .iter()
+                .any(|metric: &&providers::Metric| metric.label == label)
+        {
+            continue;
+        }
+        if let Some(metric) = snapshot
+            .metrics
+            .iter()
+            .find(|metric| metric.kind == "progress" && metric.label == label)
+        {
+            metrics.push(metric);
+        }
+    }
+    metrics
+}
+
+fn format_provider_line(
+    snapshot: &providers::Snapshot,
+    metrics: &[&providers::Metric],
+    locale: &serde_json::Value,
+) -> String {
+    let name = if snapshot.stale {
+        format!("⚠ {}", snapshot.name)
+    } else {
+        snapshot.name.clone()
+    };
+    let mut metrics = metrics.iter();
+    let Some(first) = metrics.next() else {
+        return name;
+    };
+    let mut line = crate::i18n::pct_left(locale, &name, &first.label, percent_left(first));
+    let separator = if crate::i18n::is_zh(locale) {
+        "，"
+    } else {
+        ", "
+    };
+    for metric in metrics {
+        let fragment = {
+            let label = crate::i18n::metric_label(locale, &metric.label);
+            if crate::i18n::is_zh(locale) {
+                format!("{label}: 剩余 {:.0}%", percent_left(metric))
+            } else {
+                format!("{label}: {:.0}% left", percent_left(metric))
+            }
+        };
+        line.push_str(separator);
+        line.push_str(&fragment);
+    }
+    line
+}
+
+fn percent_left(metric: &providers::Metric) -> f64 {
+    (100.0 - metric.used_percent.unwrap_or(0.0))
+        .clamp(0.0, 100.0)
+        .round()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::{Metric, Snapshot};
+
+    fn progress(label: &str, used: f64) -> Metric {
+        Metric::progress(label, used, None)
+    }
+
+    fn snapshot(id: &str, name: &str, metrics: Vec<Metric>) -> Snapshot {
+        Snapshot::ok(id, name, None, metrics)
+    }
+
+    fn provider(metric_order: &[&str]) -> ProviderProjectionConfig {
+        ProviderProjectionConfig {
+            metric_order: metric_order
+                .iter()
+                .map(|value| (*value).to_string())
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn config(order: &[&str]) -> TrayProjectionConfig {
+        TrayProjectionConfig {
+            disabled: Vec::new(),
+            provider_order: order.iter().map(|value| (*value).to_string()).collect(),
+            providers: HashMap::new(),
+            pinned: None,
+            locale: "en".into(),
+        }
+    }
+
+    #[test]
+    fn auto_projects_two_numbers_and_a_provider_tooltip() {
+        let snapshots = vec![snapshot(
+            "codex",
+            "Codex",
+            vec![progress("Session", 18.0), progress("Weekly", 63.0)],
+        )];
+        let mut cfg = config(&["codex"]);
+        cfg.providers
+            .insert("codex".into(), provider(&["Session", "Weekly"]));
+
+        let result = project_main_tray(&snapshots, &cfg, false);
+
+        assert_eq!(result.icon_mode, MainTrayIconMode::Numbers);
+        assert_eq!(result.remaining_percentages, vec![82, 37]);
+        assert_eq!(
+            result.tooltip,
+            "Pane\nCodex Session: 82% left, Weekly: 37% left"
+        );
+    }
+
+    #[test]
+    fn provider_order_drives_auto_numbers_and_tooltip_order() {
+        let snapshots = vec![
+            snapshot("claude", "Claude", vec![progress("Session", 70.0)]),
+            snapshot("codex", "Codex", vec![progress("Weekly", 15.0)]),
+        ];
+        let mut cfg = config(&["codex", "claude"]);
+        cfg.providers
+            .insert("claude".into(), provider(&["Session"]));
+        cfg.providers.insert("codex".into(), provider(&["Weekly"]));
+
+        let result = project_main_tray(&snapshots, &cfg, false);
+
+        assert_eq!(result.remaining_percentages, vec![85]);
+        assert_eq!(
+            result.tooltip,
+            "Pane\nCodex Weekly: 85% left\nClaude Session: 30% left"
+        );
+    }
+
+    #[test]
+    fn disabled_account_is_excluded_without_disabling_its_provider_family() {
+        let snapshots = vec![
+            snapshot(
+                "claude@home",
+                "Claude Home",
+                vec![progress("Session", 25.0)],
+            ),
+            snapshot(
+                "claude@work",
+                "Claude Work",
+                vec![progress("Session", 60.0)],
+            ),
+        ];
+        let mut cfg = config(&["claude@home", "claude@work"]);
+        cfg.disabled.push("claude@home".into());
+
+        let result = project_main_tray(&snapshots, &cfg, false);
+
+        assert_eq!(result.remaining_percentages, vec![40]);
+        assert_eq!(result.tooltip, "Pane\nClaude Work Session: 40% left");
+        assert_eq!(cfg.provider_order, vec!["claude@home", "claude@work"]);
+    }
+
+    #[test]
+    fn starred_then_visible_metric_order_drives_auto_selection() {
+        let snapshots = vec![snapshot(
+            "codex",
+            "Codex",
+            vec![
+                progress("Session", 20.0),
+                progress("Weekly", 40.0),
+                progress("Monthly", 60.0),
+                progress("New", 70.0),
+            ],
+        )];
+        let mut cfg = config(&["codex"]);
+        let mut layout = provider(&["Weekly", "Session"]);
+        layout.starred = vec!["Monthly".into()];
+        layout.hidden = vec!["Weekly".into()];
+        cfg.providers.insert("codex".into(), layout);
+
+        let result = project_main_tray(&snapshots, &cfg, false);
+
+        assert_eq!(result.remaining_percentages, vec![40, 80]);
+        assert_eq!(
+            result.tooltip,
+            "Pane\nCodex Monthly: 40% left, Session: 80% left"
+        );
+    }
+
+    #[test]
+    fn pinned_metric_overrides_hidden_and_starred_selection() {
+        let snapshots = vec![
+            snapshot("codex", "Codex", vec![progress("Session", 10.0)]),
+            snapshot(
+                "claude",
+                "Claude",
+                vec![progress("Session", 25.0), progress("Weekly", 55.0)],
+            ),
+        ];
+        let mut cfg = config(&["codex", "claude"]);
+        let mut claude = provider(&["Session", "Weekly"]);
+        claude.starred = vec!["Session".into()];
+        claude.hidden = vec!["Weekly".into()];
+        cfg.providers.insert("claude".into(), claude);
+        cfg.pinned = Some(PinnedMetric {
+            provider: "claude".into(),
+            label: "Weekly".into(),
+        });
+
+        let result = project_main_tray(&snapshots, &cfg, false);
+
+        assert_eq!(result.remaining_percentages, vec![45, 75]);
+        assert_eq!(
+            result.tooltip,
+            "Pane\nCodex Session: 90% left\nClaude Weekly: 45% left, Session: 75% left"
+        );
+    }
+
+    #[test]
+    fn pinned_provider_outside_first_six_replaces_the_last_normal_provider() {
+        let snapshots: Vec<Snapshot> = (1..=7)
+            .map(|n| {
+                snapshot(
+                    &format!("p{n}"),
+                    &format!("P{n}"),
+                    vec![progress("Usage", n as f64)],
+                )
+            })
+            .collect();
+        let order: Vec<String> = (1..=7).map(|n| format!("p{n}")).collect();
+        let order_refs: Vec<&str> = order.iter().map(String::as_str).collect();
+        let mut cfg = config(&order_refs);
+        cfg.pinned = Some(PinnedMetric {
+            provider: "p7".into(),
+            label: "Usage".into(),
+        });
+
+        let result = project_main_tray(&snapshots, &cfg, false);
+
+        assert_eq!(result.remaining_percentages, vec![93]);
+        assert!(result.tooltip.contains("\nP5 Usage: 95% left"));
+        assert!(!result.tooltip.contains("\nP6 Usage"));
+        assert!(result.tooltip.contains("\nP7 Usage: 93% left"));
+        assert_eq!(result.tooltip.lines().count(), 7);
+    }
+
+    #[test]
+    fn stale_last_success_keeps_numbers_and_marks_the_complete_provider_line() {
+        let mut stale = snapshot("codex", "Codex", vec![progress("Weekly", 34.0)]);
+        stale.stale = true;
+        stale.warning = Some("timeout".into());
+        let cfg = config(&["codex"]);
+
+        let result = project_main_tray(&[stale], &cfg, false);
+
+        assert_eq!(result.remaining_percentages, vec![66]);
+        assert_eq!(result.tooltip, "Pane\n⚠ Codex Weekly: 66% left");
+    }
+
+    #[test]
+    fn tooltip_capacity_counts_utf16_and_only_keeps_complete_lines() {
+        let snapshots: Vec<Snapshot> = (1..=6)
+            .map(|n| {
+                snapshot(
+                    &format!("p{n}"),
+                    &format!("供应商😀😀😀{n}"),
+                    vec![progress("Weekly", 50.0)],
+                )
+            })
+            .collect();
+        let order: Vec<String> = (1..=6).map(|n| format!("p{n}")).collect();
+        let order_refs: Vec<&str> = order.iter().map(String::as_str).collect();
+
+        let result = project_main_tray(&snapshots, &config(&order_refs), false);
+
+        assert!(result.tooltip.encode_utf16().count() <= 127);
+        for line in result.tooltip.lines().skip(1) {
+            assert!(line.ends_with("Weekly: 50% left"), "partial line: {line}");
+        }
+        assert!(result.tooltip.lines().count() < 7);
+    }
+
+    #[test]
+    fn tooltip_keeps_a_complete_line_at_the_exact_utf16_limit() {
+        let provider_name = "a".repeat(106);
+        let snapshots = vec![snapshot(
+            "p1",
+            &provider_name,
+            vec![progress("Usage", 50.0)],
+        )];
+
+        let result = project_main_tray(&snapshots, &config(&["p1"]), false);
+
+        assert_eq!(result.tooltip.encode_utf16().count(), 127);
+        assert!(result.tooltip.ends_with("Usage: 50% left"));
+    }
+
+    #[test]
+    fn tooltip_drops_a_whole_line_when_stale_marker_pushes_it_over_capacity() {
+        let mut stale = snapshot("p1", &"a".repeat(106), vec![progress("Usage", 50.0)]);
+        stale.stale = true;
+
+        let result = project_main_tray(&[stale], &config(&["p1"]), false);
+
+        assert_eq!(result.tooltip, "Pane");
+        assert_eq!(result.icon_mode, MainTrayIconMode::Logo);
+        assert!(result.remaining_percentages.is_empty());
+    }
+
+    #[test]
+    fn tooltip_capacity_keeps_a_complete_two_metric_line_at_the_utf16_limit() {
+        let snapshots = vec![snapshot(
+            "p1",
+            &"a".repeat(86),
+            vec![progress("Session", 50.0), progress("Weekly", 50.0)],
+        )];
+
+        let result = project_main_tray(&snapshots, &config(&["p1"]), false);
+
+        assert_eq!(result.tooltip.encode_utf16().count(), 127);
+        assert_eq!(
+            result.tooltip,
+            format!(
+                "Pane\n{} Session: 50% left, Weekly: 50% left",
+                "a".repeat(86)
+            )
+        );
+        assert_eq!(result.icon_mode, MainTrayIconMode::Numbers);
+        assert_eq!(result.remaining_percentages, vec![50, 50]);
+    }
+
+    #[test]
+    fn tooltip_capacity_drops_an_overlong_two_metric_line_and_hides_numbers() {
+        let snapshots = vec![snapshot(
+            "p1",
+            &"a".repeat(87),
+            vec![progress("Session", 50.0), progress("Weekly", 50.0)],
+        )];
+
+        let result = project_main_tray(&snapshots, &config(&["p1"]), false);
+
+        assert_eq!(result.tooltip, "Pane");
+        assert_eq!(result.icon_mode, MainTrayIconMode::Logo);
+        assert!(result.remaining_percentages.is_empty());
+    }
+
+    #[test]
+    fn tooltip_capacity_reserves_the_active_pinned_provider_line() {
+        let snapshots: Vec<Snapshot> = (1..=7)
+            .map(|n| {
+                snapshot(
+                    &format!("p{n}"),
+                    &format!("Provider-{n}-with-a-long-name"),
+                    vec![progress("Usage", 50.0)],
+                )
+            })
+            .collect();
+        let order: Vec<String> = (1..=7).map(|n| format!("p{n}")).collect();
+        let order_refs: Vec<&str> = order.iter().map(String::as_str).collect();
+        let mut cfg = config(&order_refs);
+        cfg.pinned = Some(PinnedMetric {
+            provider: "p7".into(),
+            label: "Usage".into(),
+        });
+
+        let result = project_main_tray(&snapshots, &cfg, false);
+
+        assert!(result
+            .tooltip
+            .contains("Provider-7-with-a-long-name Usage: 50% left"));
+        assert!(result.tooltip.encode_utf16().count() <= 127);
+    }
+
+    #[test]
+    fn locale_changes_text_without_changing_selection() {
+        let snapshots = vec![snapshot("codex", "Codex", vec![progress("Weekly", 23.0)])];
+        let en = project_main_tray(&snapshots, &config(&["codex"]), false);
+        let mut zh_config = config(&["codex"]);
+        zh_config.locale = "zh".into();
+
+        let zh = project_main_tray(&snapshots, &zh_config, false);
+
+        assert_eq!(en.remaining_percentages, zh.remaining_percentages);
+        assert_eq!(zh.tooltip, "Pane\nCodex 每周: 剩余 77%");
+    }
+
+    #[test]
+    fn actual_strip_entries_switch_main_icon_to_logo() {
+        let snapshots = vec![snapshot("codex", "Codex", vec![progress("Weekly", 23.0)])];
+
+        let result = project_main_tray(&snapshots, &config(&["codex"]), true);
+
+        assert_eq!(result.icon_mode, MainTrayIconMode::Logo);
+        assert!(result.remaining_percentages.is_empty());
+        assert_eq!(result.tooltip, "Pane\nCodex Weekly: 77% left");
+    }
+
+    #[test]
+    fn providers_without_a_usable_progress_snapshot_produce_the_empty_state() {
+        let snapshots = vec![
+            Snapshot::error("codex", "Codex", "offline".into()),
+            Snapshot::no_credentials("grok", "Grok", "login"),
+            snapshot("claude", "Claude", vec![Metric::text("Plan", "Pro".into())]),
+        ];
+
+        let result = project_main_tray(
+            &snapshots,
+            &config(&["codex", "grok", "claude"]),
+            false,
+        );
+
+        assert_eq!(result.icon_mode, MainTrayIconMode::Logo);
+        assert!(result.remaining_percentages.is_empty());
+        assert_eq!(result.tooltip, "Pane");
+    }
+
+    #[test]
+    fn inactive_pin_sleeps_while_disabled_and_restores_when_reenabled() {
+        let snapshots = vec![
+            snapshot("codex", "Codex", vec![progress("Session", 10.0)]),
+            snapshot("claude", "Claude", vec![progress("Weekly", 70.0)]),
+        ];
+        let mut cfg = config(&["codex", "claude"]);
+        cfg.pinned = Some(PinnedMetric {
+            provider: "claude".into(),
+            label: "Weekly".into(),
+        });
+        cfg.disabled.push("claude".into());
+
+        let sleeping = project_main_tray(&snapshots, &cfg, false);
+        cfg.disabled.clear();
+        let restored = project_main_tray(&snapshots, &cfg, false);
+
+        assert_eq!(sleeping.remaining_percentages, vec![90]);
+        assert_eq!(restored.remaining_percentages, vec![30]);
+        assert_eq!(cfg.pinned.as_ref().unwrap().provider, "claude");
+    }
+
+    #[test]
+    fn auto_skips_a_provider_when_all_of_its_metrics_are_hidden() {
+        let snapshots = vec![
+            snapshot("codex", "Codex", vec![progress("Session", 10.0)]),
+            snapshot("claude", "Claude", vec![progress("Weekly", 70.0)]),
+        ];
+        let mut cfg = config(&["codex", "claude"]);
+        let mut codex = provider(&["Session"]);
+        codex.hidden.push("Session".into());
+        cfg.providers.insert("codex".into(), codex);
+
+        let result = project_main_tray(&snapshots, &cfg, false);
+
+        assert_eq!(result.remaining_percentages, vec![30]);
+        assert_eq!(result.tooltip, "Pane\nClaude Weekly: 30% left");
+    }
+
+    #[test]
+    fn newly_seen_visible_progress_metric_follows_the_saved_visible_order() {
+        let snapshots = vec![snapshot(
+            "codex",
+            "Codex",
+            vec![progress("Old", 10.0), progress("New", 35.0)],
+        )];
+        let mut cfg = config(&["codex"]);
+        let mut codex = provider(&["Old"]);
+        codex.hidden.push("Old".into());
+        cfg.providers.insert("codex".into(), codex);
+
+        let result = project_main_tray(&snapshots, &cfg, false);
+
+        assert_eq!(result.remaining_percentages, vec![65]);
+        assert_eq!(result.tooltip, "Pane\nCodex New: 65% left");
+    }
+
+    #[test]
+    fn normal_tooltip_never_selects_more_than_six_providers() {
+        let snapshots: Vec<Snapshot> = (1..=7)
+            .map(|n| {
+                snapshot(
+                    &format!("p{n}"),
+                    &format!("P{n}"),
+                    vec![progress("Usage", 50.0)],
+                )
+            })
+            .collect();
+        let order: Vec<String> = (1..=7).map(|n| format!("p{n}")).collect();
+        let order_refs: Vec<&str> = order.iter().map(String::as_str).collect();
+
+        let result = project_main_tray(&snapshots, &config(&order_refs), false);
+
+        assert_eq!(result.tooltip.lines().count(), 7);
+        assert!(!result.tooltip.contains("\nP7 Usage"));
+    }
+
+    #[test]
+    fn reenabled_provider_returns_to_its_saved_position() {
+        let snapshots = vec![
+            snapshot("codex", "Codex", vec![progress("Session", 10.0)]),
+            snapshot("claude", "Claude", vec![progress("Weekly", 70.0)]),
+        ];
+        let mut cfg = config(&["codex", "claude"]);
+        cfg.disabled.push("codex".into());
+        let disabled = project_main_tray(&snapshots, &cfg, false);
+
+        cfg.disabled.clear();
+        let reenabled = project_main_tray(&snapshots, &cfg, false);
+
+        assert!(disabled.tooltip.starts_with("Pane\nClaude"));
+        assert!(reenabled.tooltip.starts_with("Pane\nCodex"));
+        assert_eq!(cfg.provider_order, vec!["codex", "claude"]);
+    }
+
+    #[test]
+    fn stale_marker_is_scoped_to_the_matching_multi_account_snapshot() {
+        let mut work = snapshot("claude@work", "Claude Work", vec![progress("Weekly", 30.0)]);
+        work.stale = true;
+        let snapshots = vec![
+            snapshot("claude@home", "Claude Home", vec![progress("Weekly", 20.0)]),
+            work,
+        ];
+
+        let result = project_main_tray(&snapshots, &config(&["claude@home", "claude@work"]), false);
+
+        assert!(result.tooltip.contains("\nClaude Home Weekly: 80% left"));
+        assert!(result.tooltip.contains("\n⚠ Claude Work Weekly: 70% left"));
+    }
+
+    #[test]
+    fn tooltip_keeps_a_complete_line_just_below_the_utf16_limit() {
+        let provider_name = "a".repeat(105);
+        let snapshots = vec![snapshot(
+            "p1",
+            &provider_name,
+            vec![progress("Usage", 50.0)],
+        )];
+
+        let result = project_main_tray(&snapshots, &config(&["p1"]), false);
+
+        assert_eq!(result.tooltip.encode_utf16().count(), 126);
+        assert!(result.tooltip.ends_with("Usage: 50% left"));
+    }
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -33,6 +33,8 @@ const en: Dict = {
   "footer.twoStars": "Up to 2 stars per provider",
   "footer.redeeming": "Redeeming reset credit…",
   "footer.redeemFailed": "Redeem failed: {err}",
+  "footer.configSaveFailed": "Settings were not saved and may be lost after restart: {err}",
+  "footer.traySyncFailed": "Tray display could not update; it will retry: {err}",
 
   "update.check": "Checking for updates…",
   "update.to": "⬆ Update to v{version}",
@@ -338,6 +340,8 @@ const zh: Dict = {
   "footer.twoStars": "每个服务最多加星 2 项",
   "footer.redeeming": "正在兑换重置额度…",
   "footer.redeemFailed": "兑换失败：{err}",
+  "footer.configSaveFailed": "配置未保存，重启后可能丢失：{err}",
+  "footer.traySyncFailed": "托盘显示更新失败，将自动重试：{err}",
 
   "update.check": "正在检查更新…",
   "update.to": "⬆ 更新到 v{version}",

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import {
   setActiveLocale,
   setSystemLocale,
   t,
+  type Locale,
   type LocalePref,
 } from "./i18n";
 
@@ -205,6 +206,27 @@ interface Config {
   locale: LocalePref;
 }
 
+interface TrayProjectionProvider {
+  metricOrder: string[];
+  hidden: string[];
+  starred: string[];
+}
+
+interface TrayProjectionConfig {
+  disabled: string[];
+  providerOrder: string[];
+  providers: Record<string, TrayProjectionProvider>;
+  pinned: Config["pinned"];
+  locale: Locale;
+}
+
+interface TrayStripEntry {
+  id: string;
+  logo: number[];
+  values: number[];
+  tooltip: string;
+}
+
 const ALL_PROVIDERS: [string, string][] = [
   ["claude", "Claude"],
   ["codex", "Codex"],
@@ -362,13 +384,34 @@ let refreshing = false;
 // API key races the auto-refresh timer). Dropping it would leave the new
 // state unfetched and the status line stuck on the save message.
 let refreshQueued = false;
+let refreshQueuedUsageOnly = true;
 // A key saved while the first refresh is still in flight. First-run (and
 // "new provider") auto-disable keys off that fetch's no_credentials list,
 // which can predate the save and park the provider we just turned on.
 // Value is the refresh generation that was in flight (or last completed)
 // at save time — the exemption lasts through that pass plus one more.
 const recentlyKeyed = new Map<string, number>();
+// Newly enabled providers stay out of every Tray projection until their
+// required forced usage attempt has completed. Value is the enable
+// generation that must finish before this id may appear.
+const pendingProviderEnables = new Map<string, number>();
+let providerEnableGeneration = 0;
+
+function markProviderEnablePending(id: string): number {
+  const generation = ++providerEnableGeneration;
+  pendingProviderEnables.set(id, generation);
+  return generation;
+}
+
+function finishProviderEnable(id: string, generation: number): void {
+  if (pendingProviderEnables.get(id) !== generation) return;
+  pendingProviderEnables.delete(id);
+  requestTraySync();
+}
+
 let refreshGeneration = 0;
+let completedRefreshGeneration = 0;
+const refreshAttemptWaiters: Array<{ generation: number; resolve: () => void }> = [];
 let lastAppliedSpendGen = 0;
 let refreshTimer: number | undefined;
 let lastSnapshots: Snapshot[] = [];
@@ -413,6 +456,10 @@ function clampPercent(value: number): number {
   return Math.min(100, Math.max(0, value));
 }
 
+function remainingPercent(metric: Metric): number {
+  return Math.round(100 - clampPercent(metric.used_percent ?? 0));
+}
+
 function fmtMoney(v: number): string {
   if (v >= 1000) return `$${(v / 1000).toFixed(1)}K`;
   return `$${v.toFixed(2)}`;
@@ -452,8 +499,27 @@ function fmtExact(ts: number): string {
   return t("time.dateAt", { date, time });
 }
 
+let configSaveQueue: Promise<void> = Promise.resolve();
+let configSaveError: string | null = null;
+
 async function patchConfig(patch: Partial<Config>): Promise<void> {
-  config = await invoke<Config>("set_config", { patch });
+  Object.assign(config, patch);
+  // Send a full current snapshot. If an earlier serialized write failed,
+  // the next save retries that still-live in-memory state as well.
+  const payload = JSON.parse(JSON.stringify(config)) as Partial<Config>;
+  const save = configSaveQueue.then(async () => {
+    await invoke<Config>("set_config", { patch: payload });
+    configSaveError = null;
+  });
+  configSaveQueue = save.catch(() => {});
+  try {
+    await save;
+  } catch (err) {
+    configSaveError = String(err);
+    const status = document.querySelector("#status");
+    if (status) status.textContent = t("footer.configSaveFailed", { err: configSaveError });
+    throw err;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -728,7 +794,7 @@ function providerLayout(id: string): ProviderLayout {
   );
 }
 
-function saveLayout(): void {
+function saveLayout(syncTray = true): void {
   if (!config.layout) return;
   // Undo history: remember the state we're moving away from.
   const next = JSON.stringify(config.layout);
@@ -738,6 +804,7 @@ function saveLayout(): void {
   }
   lastLayoutSnapshot = next;
   void patchConfig({ layout: config.layout });
+  if (syncTray) requestTraySync();
 }
 
 // ---------------------------------------------------------------------------
@@ -1964,7 +2031,7 @@ function undoLayout(): void {
   lastLayoutSnapshot = prev;
   void patchConfig({ layout: config.layout });
   renderAll();
-  void updateTrayStrip();
+  requestTraySync();
   document.querySelector("#status")!.textContent = "Layout change undone";
 }
 
@@ -2061,10 +2128,6 @@ systemLight.addEventListener("change", () => {
 // ---------------------------------------------------------------------------
 
 function isStarrable(s: Snapshot | undefined, key: string): boolean {
-  // Account-scoped cards (claude@<hash>) can't reach the tray strip — the
-  // Rust side validates ids against a fixed allowlist — so offering the ★
-  // there would be a silent no-op. Default family cards only.
-  if (s && s.id.includes("@")) return false;
   return s?.metrics.some((m) => m.label === key && m.kind === "progress") ?? false;
 }
 
@@ -2377,6 +2440,7 @@ async function paintCachedSnapshots(): Promise<void> {
     lastSnapshots = cached;
     ensureLayout();
     renderIfVisible();
+    requestTraySync();
   } catch {
     // No cache readable — the live fetch paints, as before.
   }
@@ -2388,12 +2452,31 @@ function setRefreshLock(on: boolean): void {
   document.querySelector("#refresh")?.setAttribute("aria-busy", on ? "true" : "false");
 }
 
-async function refresh(force = false): Promise<void> {
+function completeRefreshAttempt(generation: number): void {
+  completedRefreshGeneration = Math.max(completedRefreshGeneration, generation);
+  for (let index = refreshAttemptWaiters.length - 1; index >= 0; index -= 1) {
+    if (refreshAttemptWaiters[index].generation <= completedRefreshGeneration) {
+      refreshAttemptWaiters.splice(index, 1)[0].resolve();
+    }
+  }
+}
+
+async function forceUsageRefreshAttempt(usageOnly = true): Promise<void> {
+  const generation = refreshGeneration + 1;
+  const completed = new Promise<void>((resolve) => {
+    refreshAttemptWaiters.push({ generation, resolve });
+  });
+  void refresh(true, usageOnly);
+  await completed;
+}
+
+async function refresh(force = false, usageOnly = false): Promise<void> {
   if (refreshing) {
     // Remember a forced request instead of dropping it: the in-flight
     // fetch may have started before whatever prompted this one (a saved
     // key, a toggle), so one more pass runs when it finishes.
     if (force) {
+      refreshQueuedUsageOnly = refreshQueued ? refreshQueuedUsageOnly && usageOnly : usageOnly;
       refreshQueued = true;
       // The save message (or a stale "Updated") would otherwise sit on
       // the footer until the in-flight fetch ends, and Refresh looks dead.
@@ -2409,10 +2492,12 @@ async function refresh(force = false): Promise<void> {
   // The spend scan re-reads every session log on a cold start and can take
   // tens of seconds — it must never hold up the usage cards' first paint,
   // or the Refresh button (the lock used to stay on until spend finished).
-  const spendPromise = invoke<ProviderSpend[]>("fetch_spend").catch(() => null);
+  const spendPromise = usageOnly
+    ? Promise.resolve<ProviderSpend[] | null>(null)
+    : invoke<ProviderSpend[]>("fetch_spend").catch(() => null);
   try {
     await unparkRecentlyKeyed();
-    let snapshots = await invoke<Snapshot[]>("fetch_usage");
+    let snapshots = await invoke<Snapshot[]>("fetch_usage", { disabled: [...config.disabled] });
     // First launch ever (no layout yet): start with only the providers that
     // actually have credentials on this PC, like the Mac app's first-run
     // detection. The rest stay available in Customize.
@@ -2497,19 +2582,27 @@ async function refresh(force = false): Promise<void> {
     }
     renderIfVisible();
     if (firstData && !customizeOpen && !document.hidden) playReveal();
-    void updateTrayStrip();
+    requestTraySync();
     const time = new Date().toLocaleTimeString(localeTag(), { hour: "2-digit", minute: "2-digit" });
-    status.textContent = t("footer.updated", { time });
+    status.textContent = configSaveError
+      ? t("footer.configSaveFailed", { err: configSaveError })
+      : t("footer.updated", { time });
   } catch (err) {
-    status.textContent = t("footer.refreshFailed", { err: String(err) });
+    status.textContent = configSaveError
+      ? t("footer.configSaveFailed", { err: configSaveError })
+      : t("footer.refreshFailed", { err: String(err) });
   } finally {
     setRefreshLock(false);
+    completeRefreshAttempt(myGen);
     if (refreshQueued) {
       refreshQueued = false;
-      void refresh(true);
+      const queuedUsageOnly = refreshQueuedUsageOnly;
+      refreshQueuedUsageOnly = true;
+      void refresh(true, queuedUsageOnly);
     }
   }
   const spend = await spendPromise;
+  if (usageOnly) return;
   spendLoaded = true;
   // Overlapping scans are allowed now that Refresh unlocks before spend
   // finishes. Keep the newest successful result — a later failed scan
@@ -2523,9 +2616,9 @@ async function refresh(force = false): Promise<void> {
 }
 
 function scheduleAutoRefresh(): void {
-  if (refreshTimer !== undefined) clearInterval(refreshTimer);
+  if (refreshTimer !== undefined) window.clearInterval(refreshTimer);
   const minutes = Math.max(1, config.refreshMinutes || 5);
-  refreshTimer = setInterval(() => void refresh(), minutes * 60 * 1000);
+  refreshTimer = window.setInterval(() => void refresh(), minutes * 60 * 1000);
 }
 
 const logoPixels = new Map<string, number[]>();
@@ -2565,40 +2658,121 @@ async function rasterizeLogo(id: string): Promise<number[] | null> {
   }
 }
 
-/// The tray strip now follows the stars: any provider with starred metrics
-/// gets a [logo][numbers] pair, in customize order (max 4 providers).
-async function updateTrayStrip(): Promise<void> {
-  const entries = [];
-  const order = config.layout?.providerOrder ?? [];
-  for (const id of order) {
+interface TraySyncState {
+  snapshots: Snapshot[];
+  projection: TrayProjectionConfig;
+}
+
+let pendingTraySync: TraySyncState | null = null;
+let traySyncRunning = false;
+let traySyncFailureShown = false;
+let traySyncFailureText = "";
+
+function captureTraySyncState(): TraySyncState {
+  const providerOrder = [...(config.layout?.providerOrder ?? [])];
+  const providers: Record<string, TrayProjectionProvider> = {};
+  for (const id of providerOrder) {
+    const layout = providerLayout(id);
+    providers[id] = {
+      metricOrder: [...layout.metricOrder],
+      hidden: [...layout.hidden],
+      starred: [...layout.starred],
+    };
+  }
+  return {
+    snapshots: lastSnapshots.map((snapshot) => ({
+      ...snapshot,
+      metrics: snapshot.metrics.map((metric) => ({ ...metric })),
+    })),
+    projection: {
+      disabled: [...new Set([...config.disabled, ...pendingProviderEnables.keys()])],
+      providerOrder,
+      providers,
+      pinned: config.pinned ? { ...config.pinned } : null,
+      locale: resolveLocale(config.locale),
+    },
+  };
+}
+
+async function buildTrayStripEntries(state: TraySyncState): Promise<TrayStripEntry[]> {
+  const entries: TrayStripEntry[] = [];
+  for (const id of state.projection.providerOrder) {
     if (entries.length >= 4) break;
-    if (config.disabled.includes(id)) continue; // no tray icons for disabled providers
-    const L = providerLayout(id);
-    if (!L.starred.length) continue;
-    const snap = lastSnapshots.find((s) => s.id === id && s.status === "ok");
-    if (!snap) continue;
-    const starredMetrics = L.starred
-      .map((label) => snap.metrics.find((m) => m.label === label && m.kind === "progress"))
-      .filter((m): m is Metric => Boolean(m))
+    if (state.projection.disabled.includes(id)) continue;
+    const layout = state.projection.providers[id];
+    if (!layout?.starred.length) continue;
+    const snapshot = state.snapshots.find((candidate) => candidate.id === id && candidate.status === "ok");
+    if (!snapshot) continue;
+    const starredMetrics = layout.starred
+      .filter((label) => !layout.hidden.includes(label))
+      .map((label) =>
+        snapshot.metrics.find((metric) => metric.label === label && metric.kind === "progress"),
+      )
+      .filter((metric): metric is Metric => Boolean(metric))
       .slice(0, 2);
     if (!starredMetrics.length) continue;
-    const logo = await rasterizeLogo(id);
+    const logo = await rasterizeLogo(providerFamily(id));
     if (!logo) continue;
-    const values = starredMetrics.map((m) => Math.round(100 - clampPercent(m.used_percent ?? 0)));
-    const tooltip = `${snap.name}\n${starredMetrics
-      .map((m) =>
+    const values = starredMetrics.map(remainingPercent);
+    const name = snapshot.stale ? `⚠ ${snapshot.name}` : snapshot.name;
+    const tooltip = `${name}\n${starredMetrics
+      .map((metric) =>
         t("tray.left", {
-          label: displayMetricLabel(m.label),
-          n: Math.round(100 - clampPercent(m.used_percent ?? 0)),
+          label: displayMetricLabel(metric.label),
+          n: remainingPercent(metric),
         }),
       )
       .join("\n")}`;
     entries.push({ id, logo, values, tooltip });
   }
+  return entries;
+}
+
+function requestTraySync(): void {
+  pendingTraySync = captureTraySyncState();
+  if (!traySyncRunning) void drainTraySyncQueue();
+}
+
+async function drainTraySyncQueue(): Promise<void> {
+  if (traySyncRunning) return;
+  traySyncRunning = true;
   try {
-    await invoke("update_tray_strip", { entries });
-  } catch {
-    // Tray strip is cosmetic — never let it break a refresh.
+    while (pendingTraySync) {
+      const state = pendingTraySync;
+      pendingTraySync = null;
+      const entries = await buildTrayStripEntries(state);
+      // Rasterizing a logo may yield while the user changes configuration.
+      // Skip this stale generation before it reaches either native surface.
+      if (pendingTraySync) continue;
+      try {
+        await invoke("sync_tray_surfaces", {
+          snapshots: state.snapshots,
+          projection: state.projection,
+          entries,
+        });
+        if (traySyncFailureShown) {
+          const status = document.querySelector("#status");
+          if (status && status.textContent === traySyncFailureText) {
+            status.textContent = configSaveError
+              ? t("footer.configSaveFailed", { err: configSaveError })
+              : "";
+          }
+        }
+        traySyncFailureShown = false;
+        traySyncFailureText = "";
+      } catch (err) {
+        if (!traySyncFailureShown) {
+          const status = document.querySelector("#status");
+          const message = t("footer.traySyncFailed", { err: String(err) });
+          if (status) status.textContent = message;
+          traySyncFailureShown = true;
+          traySyncFailureText = message;
+        }
+      }
+    }
+  } finally {
+    traySyncRunning = false;
+    if (pendingTraySync) void drainTraySyncQueue();
   }
 }
 
@@ -2661,9 +2835,9 @@ function handleCustomizeClick(target: HTMLElement): boolean {
       // ones with no credentials on this PC.
       config.layout = null;
       config.disabled = [];
-      void patchConfig({ layout: null, disabled: [] }).then(() => {
+      void patchConfig({ layout: null, disabled: [] }).catch(() => {}).then(() => {
         setDrawer(false);
-        void refresh(true).then(() => void updateTrayStrip());
+        void forceUsageRefreshAttempt(false).then(requestTraySync);
       });
     });
     return true;
@@ -2676,7 +2850,6 @@ function handleCustomizeClick(target: HTMLElement): boolean {
     config.layout.providers[id] = defaultProviderLayout(snapshot, spend, false);
     saveLayout();
     renderAll();
-    void updateTrayStrip();
     return true;
   }
   const star = target.closest<HTMLElement>("[data-star]");
@@ -2693,7 +2866,6 @@ function handleCustomizeClick(target: HTMLElement): boolean {
     }
     saveLayout();
     renderAll();
-    void updateTrayStrip();
     return true;
   }
   return false;
@@ -2723,9 +2895,12 @@ function handleCustomizeChange(target: HTMLInputElement): void {
   if (target.dataset.enable !== undefined) {
     const id = target.dataset.enable;
     const enable = target.checked;
+    const enableGeneration = enable ? markProviderEnablePending(id) : null;
+    if (!enable) pendingProviderEnables.delete(id);
     pendingToggles.push({ id, enable });
     config.disabled = withPendingToggles(config.disabled); // optimistic
     renderAll(); // disabled cards vanish from the dashboard immediately
+    if (!enable) requestTraySync();
     disabledSaveQueue = disabledSaveQueue.then(async () => {
       // Fresh base at save time: includes server truth plus anything
       // refresh() changed while earlier saves were in flight.
@@ -2736,11 +2911,16 @@ function handleCustomizeChange(target: HTMLInputElement): void {
         // keep going — the delta stays applied locally
       }
       pendingToggles.shift(); // this task's toggle is now persisted
-      // patchConfig replaced config with the server echo; merge any newer
-      // still-pending toggles back on top of it.
+      // Merge any newer still-pending toggles back on top of the saved state.
       config.disabled = withPendingToggles(config.disabled);
-      // Only an enable needs fresh data; a disable is purely local.
-      if (enable) await refresh(true).catch(() => {});
+      // Only an unmatched enable generation still needs a usage attempt.
+      if (
+        enableGeneration !== null &&
+        pendingProviderEnables.get(id) === enableGeneration
+      ) {
+        await forceUsageRefreshAttempt();
+        finishProviderEnable(id, enableGeneration);
+      }
     });
     return;
   }
@@ -2823,7 +3003,6 @@ function setupCustomizeDnD(providersEl: HTMLElement): void {
         config.layout.providerOrder = order;
         saveLayout();
         renderAll();
-        void updateTrayStrip();
       }
     }
     dragPayload = null;
@@ -2848,6 +3027,7 @@ async function unparkRecentlyKeyed(): Promise<void> {
 async function saveApiKey(provider: string): Promise<void> {
   const input = document.querySelector<HTMLInputElement>(`#key-${provider}`)!;
   const status = document.querySelector("#status")!;
+  let enableGeneration: number | undefined;
   try {
     const key = input.value;
     if (!key.trim()) {
@@ -2856,6 +3036,9 @@ async function saveApiKey(provider: string): Promise<void> {
       // Mark before any await so an in-flight first-run pass cannot park
       // this provider after our save returns.
       recentlyKeyed.set(provider, refreshGeneration);
+      if (config.disabled.includes(provider)) {
+        enableGeneration = markProviderEnablePending(provider);
+      }
     }
     await invoke("set_api_key", { provider, key });
     input.value = "";
@@ -2870,9 +3053,13 @@ async function saveApiKey(provider: string): Promise<void> {
     }
     const name = providerDisplayName(provider);
     status.textContent = t("footer.keySaved", { name });
-    await refresh(true);
+    await forceUsageRefreshAttempt();
+    if (enableGeneration !== undefined) finishProviderEnable(provider, enableGeneration);
+    else requestTraySync();
   } catch (err) {
     recentlyKeyed.delete(provider);
+    if (enableGeneration !== undefined) finishProviderEnable(provider, enableGeneration);
+    else requestTraySync();
     status.textContent = t("footer.keySaveFailed", { err: String(err) });
   }
 }
@@ -2967,10 +3154,9 @@ async function initSettings(): Promise<void> {
   localeSel.value = config.locale;
   localeSel.addEventListener("change", () => {
     const next = normalizeLocalePref(localeSel.value);
-    void patchConfig({ locale: next }).then(() => {
-      applyLocale();
-      void updateTrayStrip();
-    });
+    void patchConfig({ locale: next }).catch(() => {});
+    applyLocale();
+    requestTraySync();
   });
 
   const notifyToggles: [string, keyof Config][] = [
@@ -2991,7 +3177,8 @@ async function initSettings(): Promise<void> {
   pinned.addEventListener("change", () => {
     const [provider, label] = pinned.value.split("::");
     const value = provider && label ? { provider, label } : null;
-    void patchConfig({ pinned: value }).then(() => refresh(true));
+    void patchConfig({ pinned: value }).catch(() => {});
+    requestTraySync();
   });
 
   const showSpend = document.querySelector<HTMLInputElement>("#show-total-spend")!;
@@ -3030,7 +3217,8 @@ async function initSettings(): Promise<void> {
   const hideShare = document.querySelector<HTMLInputElement>("#hide-while-sharing")!;
   hideShare.checked = config.hideUsageWhileSharing === true;
   hideShare.addEventListener("change", () => {
-    void patchConfig({ hideUsageWhileSharing: hideShare.checked }).then(() => void updateTrayStrip());
+    void patchConfig({ hideUsageWhileSharing: hideShare.checked }).catch(() => {});
+    requestTraySync();
   });
 
   const shortcut = document.querySelector<HTMLInputElement>("#shortcut")!;
@@ -3113,7 +3301,7 @@ async function resetAllSettings(): Promise<void> {
     reduceAnimations: false,
     hideUsageWhileSharing: false,
     locale: "auto",
-  });
+  }).catch(() => {});
   spendTab = "today";
   applyLocale();
   syncSettingsControls();
@@ -3123,7 +3311,7 @@ async function resetAllSettings(): Promise<void> {
   applyReduceMotion();
   document.body.classList.remove("settings-open");
   document.querySelector("#settings-btn")?.classList.remove("active");
-  void refresh(true).then(() => void updateTrayStrip());
+  void forceUsageRefreshAttempt(false).then(requestTraySync);
 }
 
 function syncSettingsControls(): void {
@@ -3317,6 +3505,7 @@ window.addEventListener("DOMContentLoaded", () => {
     const L = config.layout!;
     L.providerOrder = [...domIds, ...L.providerOrder.filter((id) => !domIds.includes(id))];
     void patchConfig({ layout: L });
+    requestTraySync();
     updateTrailActive();
   };
   providersEl.addEventListener("drop", (e) => {
@@ -3393,7 +3582,7 @@ window.addEventListener("DOMContentLoaded", () => {
       const id = caret.dataset.caret!;
       const L = providerLayout(id);
       L.expanded = !L.expanded;
-      saveLayout();
+      saveLayout(false);
       animateExpandId = L.expanded ? id : null;
       renderAll();
       animateExpandId = null;
@@ -3452,7 +3641,7 @@ window.addEventListener("DOMContentLoaded", () => {
   });
 
   void listen("tray-strip-restore", () => {
-    void updateTrayStrip();
+    requestTraySync();
   });
 
   void listen("popover-shown", () => {
@@ -3478,6 +3667,7 @@ window.addEventListener("DOMContentLoaded", () => {
     providersEl.scrollTop = 0;
     updateTrailActive();
     if (lastSnapshots.length && !customizeOpen) playReveal();
+    requestTraySync();
     void refresh();
   });
   void initSettings().then(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -206,6 +206,40 @@ interface Config {
   locale: LocalePref;
 }
 
+const FRONTEND_CONFIG_KEYS = [
+  "refreshMinutes",
+  "disabled",
+  "pinned",
+  "trayProviders",
+  "pacingAlways",
+  "telemetry",
+  "notifyAlmostOut",
+  "notifyCuttingClose",
+  "notifyWillRunOut",
+  "spendTab",
+  "spendMetric",
+  "showUsed",
+  "resetExact",
+  "timeFormat",
+  "layout",
+  "appearance",
+  "density",
+  "glassEffects",
+  "shortcut",
+  "proxy",
+  "showTotalSpend",
+  "welcomeDismissed",
+  "lastSeenVersion",
+  "reduceAnimations",
+  "hideUsageWhileSharing",
+  "locale",
+] as const satisfies readonly (keyof Config)[];
+type _AssertAllConfigKeys = Exclude<keyof Config, (typeof FRONTEND_CONFIG_KEYS)[number]> extends never
+  ? true
+  : Exclude<keyof Config, (typeof FRONTEND_CONFIG_KEYS)[number]>;
+const _assertAllConfigKeys: _AssertAllConfigKeys = true;
+void _assertAllConfigKeys;
+
 interface TrayProjectionProvider {
   metricOrder: string[];
   hidden: string[];
@@ -505,13 +539,21 @@ function fmtExact(ts: number): string {
 let configSaveQueue: Promise<void> = Promise.resolve();
 let configSaveError: string | null = null;
 
+function snapshotConfig(): Config {
+  const payload = {} as Record<string, unknown>;
+  for (const key of FRONTEND_CONFIG_KEYS) {
+    payload[key] = config[key];
+  }
+  return JSON.parse(JSON.stringify(payload)) as Config;
+}
+
 function applyConfigEcho(sent: Config, echoed: Config): void {
   // Keep newer in-memory fields. Only take server canonicalization for
-  // keys that still match the snapshot this save actually wrote.
+  // frontend keys that still match the snapshot this save actually wrote.
   const current = config as unknown as Record<string, unknown>;
   const from = sent as unknown as Record<string, unknown>;
   const echo = echoed as unknown as Record<string, unknown>;
-  for (const key of Object.keys(echo)) {
+  for (const key of FRONTEND_CONFIG_KEYS) {
     if (JSON.stringify(current[key]) === JSON.stringify(from[key])) {
       current[key] = echo[key];
     }
@@ -522,7 +564,7 @@ async function patchConfig(patch: Partial<Config>): Promise<void> {
   Object.assign(config, patch);
   // Send a full current snapshot. If an earlier serialized write failed,
   // the next save retries that still-live in-memory state as well.
-  const payload = JSON.parse(JSON.stringify(config)) as Config;
+  const payload = snapshotConfig();
   const save = configSaveQueue.then(async () => {
     const echoed = await invoke<Config>("set_config", { patch: payload });
     applyConfigEcho(payload, echoed);

--- a/src/main.ts
+++ b/src/main.ts
@@ -505,13 +505,27 @@ function fmtExact(ts: number): string {
 let configSaveQueue: Promise<void> = Promise.resolve();
 let configSaveError: string | null = null;
 
+function applyConfigEcho(sent: Config, echoed: Config): void {
+  // Keep newer in-memory fields. Only take server canonicalization for
+  // keys that still match the snapshot this save actually wrote.
+  const current = config as unknown as Record<string, unknown>;
+  const from = sent as unknown as Record<string, unknown>;
+  const echo = echoed as unknown as Record<string, unknown>;
+  for (const key of Object.keys(echo)) {
+    if (JSON.stringify(current[key]) === JSON.stringify(from[key])) {
+      current[key] = echo[key];
+    }
+  }
+}
+
 async function patchConfig(patch: Partial<Config>): Promise<void> {
   Object.assign(config, patch);
   // Send a full current snapshot. If an earlier serialized write failed,
   // the next save retries that still-live in-memory state as well.
-  const payload = JSON.parse(JSON.stringify(config)) as Partial<Config>;
+  const payload = JSON.parse(JSON.stringify(config)) as Config;
   const save = configSaveQueue.then(async () => {
-    await invoke<Config>("set_config", { patch: payload });
+    const echoed = await invoke<Config>("set_config", { patch: payload });
+    applyConfigEcho(payload, echoed);
     configSaveError = null;
   });
   configSaveQueue = save.catch(() => {});


### PR DESCRIPTION
## Summary

- Extract a testable main-tray projection so provider order, disable, hidden, starred, and pinned metrics drive the icon and tooltip.
- Route every config entrypoint through a latest-state-wins tray sync queue, and keep newly enabled providers off the tray until a forced usage refresh finishes.
- Truncate tray tooltips on complete UTF-16 lines within Windows capacity and localize them.
- Surface config-save and tray-sync failures in the footer instead of failing silently.

## Testing

- Unit tests in `src-tauri/src/tray_projection.rs` cover order/disable/pin/star/hidden, tooltip capacity, stale multi-account lines, and locale selection.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->