### PR TITLE
Release 0.4.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.4.43 — 2026-08-26
+
+### Added
+- **Grok reset credits** show on the card as read-only rows (no Use
+  button). A **Status** link opens [status.x.ai](https://status.x.ai)
+  next to Usage.
+
+### Fixed
+- **Tray follows Customize.** Hide, disable, star, pin, and card order
+  now drive the tray icon and tooltip. A newly enabled provider stays
+  off the tray until a refresh finishes. If a save or tray update fails,
+  the footer says so instead of staying quiet.
+
 ## 0.4.42 — 2026-08-23
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — full Mac parity (and beyond)
 
-**Status (v0.4.42, 2026-08-23): every wave below is shipped, and the
+**Status (v0.4.43, 2026-08-26): every wave below is shipped, and the
 post-launch releases keep going.** Pane has full feature parity with the
 macOS original plus 21 providers, signed auto-updates published by CI,
 Codex reset-credit redemption, update-check-on-open with a one-click

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.42",
+  "version": "0.4.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.42",
+      "version": "0.4.43",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.42",
+  "version": "0.4.43",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.42"
+version = "0.4.43"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.42",
+  "version": "0.4.43",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Stamp **0.4.43** (tauri.conf / package.json / Cargo.toml + lockfiles, CHANGELOG, ROADMAP).
- Ships #162 Grok reset credits, #163 Grok Status link, and #164 tray sync with Customize.

## Test plan
- [x] Local install of `Pane_0.4.43_x64-setup.exe /S /UPDATE`; ProductVersion 0.4.43; Pane opened
- [ ] CI release build produces installer + updater artifacts after tag

Made with Cursor

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->