### PR TITLE
Keep Customize progress-bar placement across refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Customize keeps progress bars where you put them.** Dragging a
+  meter like Codex Extra credits into Show more used to look like it
+  saved, then the next usage refresh yanked it back above Usage Trend.
+  That "bars stay visible" rule now only places a row the first time
+  it appears. A later refresh no longer undoes the drag (issue #166).
+
 ## 0.4.43 — 2026-08-26
 
 ### Added

--- a/src/main.ts
+++ b/src/main.ts
@@ -781,23 +781,11 @@ function ensureLayout(): void {
         if (m.kind !== "progress") L.onDemand.push(m.label);
         changed = true;
       }
-      // A metric that upgraded from text to a progress bar (Extra
-      // credits/balance when funded) must surface like one: bars never
-      // hide behind Show more, and they sit above the Usage Trend.
-      if (m.kind === "progress") {
-        const tucked = L.onDemand.indexOf(m.label);
-        if (tucked >= 0) {
-          L.onDemand.splice(tucked, 1);
-          changed = true;
-        }
-        const at = L.metricOrder.indexOf(m.label);
-        const trendAt = L.metricOrder.indexOf(TREND_KEY);
-        if (at >= 0 && trendAt >= 0 && at > trendAt) {
-          L.metricOrder.splice(at, 1);
-          L.metricOrder.splice(L.metricOrder.indexOf(TREND_KEY), 0, m.label);
-          changed = true;
-        }
-      }
+      // Do not yank an existing progress row out of Show more or shuffle
+      // it above Usage Trend on later refreshes. Extra credits flips
+      // text↔progress with balance; a Customize drag would otherwise
+      // bounce back on the next snapshot (issue #166). New rows still
+      // land always-visible above the trend via the first-seen branch.
     }
     if (spend) {
       if (!L.metricOrder.includes(TREND_KEY)) {


### PR DESCRIPTION
## Summary
- Stop `ensureLayout()` from yanking progress rows (like Codex Extra credits) out of Show more on every usage refresh.
- First-time placement still puts new bars above Usage Trend; after that, Customize order and section stick (issue #166).

## Test plan
- [ ] Codex Extra credits is a bar (has leftover credits)
- [ ] Customize: drag Extra credits below the On Demand / Show more line
- [ ] Close Customize; the row is behind Show more on the card
- [ ] Refresh or reopen the popover — row stays in Show more (does not jump above Usage Trend)
- [ ] Drag it back to always-visible and refresh — that placement sticks too

Made with Cursor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->