### PR TITLE
Add Russian localization across Pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Russian in Settings → Language.** Same surfaces as Chinese: cards,
+  Settings, Customize, tray tooltips, and quota toasts. Auto follows the
+  PC display language (Chinese or Russian). Provider names, plan names,
+  and the changelog stay English.
+
 ## 0.4.43 — 2026-08-26
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
               <option value="auto" data-i18n="settings.langAuto">Auto</option>
               <option value="en" data-i18n="settings.langEn">English</option>
               <option value="zh" data-i18n="settings.langZh">中文</option>
+              <option value="ru" data-i18n="settings.langRu">Русский</option>
             </select>
           </div>
           <div class="setting-row">

--- a/src-tauri/src/alerts.rs
+++ b/src-tauri/src/alerts.rs
@@ -122,37 +122,47 @@ pub fn evaluate(snapshots: &[Snapshot], cfg: &Value) -> Vec<Alert> {
             if !baseline {
                 let shown = crate::i18n::metric_label(cfg, &metric.label);
                 let name = format!("{} {}", snapshot.name, shown);
-                let zh = crate::i18n::is_zh(cfg);
+                let loc = crate::i18n::resolved_locale(cfg);
                 if want_runout && run_out_now && !entry.run_out {
                     alerts.push(Alert {
-                        title: if zh { "将会用完".into() } else { "Will Run Out".into() },
-                        body: if zh {
-                            format!("{name} 按当前速度会在重置前用完。")
-                        } else {
-                            format!("{name} is on pace to hit its limit before the reset.")
+                        title: match loc {
+                            "zh" => "将会用完".into(),
+                            "ru" => "Кончится до сброса".into(),
+                            _ => "Will Run Out".into(),
+                        },
+                        body: match loc {
+                            "zh" => format!("{name} 按当前速度会在重置前用完。"),
+                            "ru" => format!("{name} при текущем темпе исчерпается до сброса."),
+                            _ => format!("{name} is on pace to hit its limit before the reset."),
                         },
                     });
                 } else if want_close && close_now && !entry.close {
                     alerts.push(Alert {
-                        title: if zh {
-                            "余量紧张".into()
-                        } else {
-                            "Cutting It Close".into()
+                        title: match loc {
+                            "zh" => "余量紧张".into(),
+                            "ru" => "Запас на исходе".into(),
+                            _ => "Cutting It Close".into(),
                         },
-                        body: if zh {
-                            format!("{name} 按当前速度重置时大约只剩 {spare:.0}%。")
-                        } else {
-                            format!("{name} is on pace to finish with only ~{spare:.0}% spare.")
+                        body: match loc {
+                            "zh" => format!("{name} 按当前速度重置时大约只剩 {spare:.0}%。"),
+                            "ru" => format!("{name} к сбросу останется примерно {spare:.0}%."),
+                            _ => format!(
+                                "{name} is on pace to finish with only ~{spare:.0}% spare."
+                            ),
                         },
                     });
                 }
                 if want_almost && almost_now && !entry.almost_out {
                     alerts.push(Alert {
-                        title: if zh { "即将用完".into() } else { "Almost Out".into() },
-                        body: if zh {
-                            format!("{name} 剩余不足 10%（还剩 {left:.0}%）。")
-                        } else {
-                            format!("{name} is under 10% remaining ({left:.0}% left).")
+                        title: match loc {
+                            "zh" => "即将用完".into(),
+                            "ru" => "Почти кончилось".into(),
+                            _ => "Almost Out".into(),
+                        },
+                        body: match loc {
+                            "zh" => format!("{name} 剩余不足 10%（还剩 {left:.0}%）。"),
+                            "ru" => format!("{name} осталось меньше 10% (ещё {left:.0}%)."),
+                            _ => format!("{name} is under 10% remaining ({left:.0}% left)."),
                         },
                     });
                 }

--- a/src-tauri/src/i18n.rs
+++ b/src-tauri/src/i18n.rs
@@ -100,6 +100,7 @@ fn ru_metric(label: &str) -> String {
         "Requests this month" => "Запросы в этом месяце".into(),
         "Requests this cycle" => "Запросы за цикл".into(),
         "Last used" => "Последнее использование".into(),
+        "Recent models" => "Недавние модели".into(),
         "Via" => "Через".into(),
         "Sessions" => "Сессии".into(),
         other if other.starts_with("Reset credit ") => {
@@ -175,6 +176,7 @@ mod tests {
         assert_eq!(metric_label(&ru, "Sonnet weekly"), "Sonnet за неделю");
         assert_eq!(metric_label(&ru, "Reset credit"), "Сброс лимита");
         assert_eq!(metric_label(&ru, "Reset credit 2"), "Сброс лимита 2");
+        assert_eq!(metric_label(&ru, "Recent models"), "Недавние модели");
         assert_eq!(quit_label(&ru), "Выйти из Pane");
     }
 

--- a/src-tauri/src/i18n.rs
+++ b/src-tauri/src/i18n.rs
@@ -6,33 +6,29 @@ use serde_json::Value;
 pub fn resolved_locale(cfg: &Value) -> &'static str {
     match cfg.get("locale").and_then(Value::as_str) {
         Some("zh") => "zh",
+        Some("ru") => "ru",
         Some("en") => "en",
-        _ => {
-            if system_locale_is_zh() {
-                "zh"
-            } else {
-                "en"
-            }
-        }
+        _ => system_ui_locale(),
     }
 }
 
-pub fn is_zh(cfg: &Value) -> bool {
-    resolved_locale(cfg) == "zh"
-}
-
 pub fn quit_label(cfg: &Value) -> &'static str {
-    if is_zh(cfg) {
-        "退出 Pane"
-    } else {
-        "Quit Pane"
+    match resolved_locale(cfg) {
+        "zh" => "退出 Pane",
+        "ru" => "Выйти из Pane",
+        _ => "Quit Pane",
     }
 }
 
 pub fn metric_label(cfg: &Value, label: &str) -> String {
-    if !is_zh(cfg) {
-        return label.to_string();
+    match resolved_locale(cfg) {
+        "zh" => zh_metric(label),
+        "ru" => ru_metric(label),
+        _ => label.to_string(),
     }
+}
+
+fn zh_metric(label: &str) -> String {
     match label {
         "Session" => "会话".into(),
         "Weekly" => "每周".into(),
@@ -54,6 +50,7 @@ pub fn metric_label(cfg: &Value, label: &str) -> String {
         "Bonus" => "赠送".into(),
         "Extra usage" => "额外用量".into(),
         "Extra credits" => "额外额度".into(),
+        "Reset credit" => "重置额度".into(),
         "Reset credits" => "重置额度".into(),
         "Extra balance" => "额外余额".into(),
         "Kilo Pass" => "Kilo Pass".into(),
@@ -63,6 +60,9 @@ pub fn metric_label(cfg: &Value, label: &str) -> String {
         "Last used" => "上次使用".into(),
         "Via" => "经由".into(),
         "Sessions" => "会话数".into(),
+        other if other.starts_with("Reset credit ") => {
+            format!("重置额度 {}", other.trim_start_matches("Reset credit "))
+        }
         other if other.ends_with(" weekly") => {
             format!("{} 每周", other.trim_end_matches(" weekly"))
         }
@@ -70,12 +70,54 @@ pub fn metric_label(cfg: &Value, label: &str) -> String {
     }
 }
 
+fn ru_metric(label: &str) -> String {
+    match label {
+        "Session" => "Сессия".into(),
+        "Weekly" => "За неделю".into(),
+        "Monthly" => "За месяц".into(),
+        "Daily" => "За день".into(),
+        "Usage" => "Использование".into(),
+        "Credits" => "Кредиты".into(),
+        "Credits used" => "Использовано кредитов".into(),
+        "API" => "API".into(),
+        "Balance" => "Баланс".into(),
+        "Vouchers" => "Ваучеры".into(),
+        "Cash" => "Наличные".into(),
+        "Limit" => "Лимит".into(),
+        "Used" => "Использовано".into(),
+        "On-demand" => "По факту".into(),
+        "Cursor Models" => "Модели Cursor".into(),
+        "Other Models" => "Другие модели".into(),
+        "Total usage" => "Всего".into(),
+        "Bonus" => "Бонус".into(),
+        "Extra usage" => "Дополнительно".into(),
+        "Extra credits" => "Доп. кредиты".into(),
+        "Reset credit" => "Сброс лимита".into(),
+        "Reset credits" => "Сброс лимита".into(),
+        "Extra balance" => "Доп. баланс".into(),
+        "Kilo Pass" => "Kilo Pass".into(),
+        "Requests today" => "Запросы сегодня".into(),
+        "Requests this month" => "Запросы в этом месяце".into(),
+        "Requests this cycle" => "Запросы за цикл".into(),
+        "Last used" => "Последнее использование".into(),
+        "Via" => "Через".into(),
+        "Sessions" => "Сессии".into(),
+        other if other.starts_with("Reset credit ") => {
+            format!("Сброс лимита {}", other.trim_start_matches("Reset credit "))
+        }
+        other if other.ends_with(" weekly") => {
+            format!("{} за неделю", other.trim_end_matches(" weekly"))
+        }
+        other => other.to_string(),
+    }
+}
+
 pub fn pct_left(cfg: &Value, name: &str, label: &str, left: f64) -> String {
     let shown = metric_label(cfg, label);
-    if is_zh(cfg) {
-        format!("{name} {shown}: 剩余 {left:.0}%")
-    } else {
-        format!("{name} {shown}: {left:.0}% left")
+    match resolved_locale(cfg) {
+        "zh" => format!("{name} {shown}: 剩余 {left:.0}%"),
+        "ru" => format!("{name} {shown}: осталось {left:.0}%"),
+        _ => format!("{name} {shown}: {left:.0}% left"),
     }
 }
 
@@ -85,11 +127,24 @@ fn langid_is_zh(langid: u16) -> bool {
     langid & 0x03FF == LANG_CHINESE
 }
 
+/// Primary language 0x19 = Russian (ru-RU, ru-MD, …).
+fn langid_is_ru(langid: u16) -> bool {
+    const LANG_RUSSIAN: u16 = 0x19;
+    langid & 0x03FF == LANG_RUSSIAN
+}
+
 /// Windows *display* language, not the regional-format locale.
 /// Same source the popover asks for via `system_ui_locale`.
-pub fn system_locale_is_zh() -> bool {
+pub fn system_ui_locale() -> &'static str {
     use windows::Win32::Globalization::GetUserDefaultUILanguage;
-    langid_is_zh(unsafe { GetUserDefaultUILanguage() })
+    let langid = unsafe { GetUserDefaultUILanguage() };
+    if langid_is_zh(langid) {
+        "zh"
+    } else if langid_is_ru(langid) {
+        "ru"
+    } else {
+        "en"
+    }
 }
 
 #[cfg(test)]
@@ -101,6 +156,7 @@ mod tests {
     fn explicit_locale_wins() {
         assert_eq!(resolved_locale(&json!({"locale": "zh"})), "zh");
         assert_eq!(resolved_locale(&json!({"locale": "en"})), "en");
+        assert_eq!(resolved_locale(&json!({"locale": "ru"})), "ru");
     }
 
     #[test]
@@ -108,7 +164,18 @@ mod tests {
         let zh = json!({"locale": "zh"});
         assert_eq!(metric_label(&zh, "Session"), "会话");
         assert_eq!(metric_label(&zh, "Sonnet weekly"), "Sonnet 每周");
+        assert_eq!(metric_label(&zh, "Reset credit 2"), "重置额度 2");
         assert_eq!(metric_label(&json!({"locale": "en"}), "Session"), "Session");
+    }
+
+    #[test]
+    fn ru_metric_labels() {
+        let ru = json!({"locale": "ru"});
+        assert_eq!(metric_label(&ru, "Session"), "Сессия");
+        assert_eq!(metric_label(&ru, "Sonnet weekly"), "Sonnet за неделю");
+        assert_eq!(metric_label(&ru, "Reset credit"), "Сброс лимита");
+        assert_eq!(metric_label(&ru, "Reset credit 2"), "Сброс лимита 2");
+        assert_eq!(quit_label(&ru), "Выйти из Pane");
     }
 
     #[test]
@@ -118,5 +185,13 @@ mod tests {
         assert!(langid_is_zh(0x0C04)); // zh-HK
         assert!(!langid_is_zh(0x0409)); // en-US
         assert!(!langid_is_zh(0x0411)); // ja
+        assert!(!langid_is_zh(0x0419)); // ru-RU
+    }
+
+    #[test]
+    fn russian_langids_match() {
+        assert!(langid_is_ru(0x0419)); // ru-RU
+        assert!(!langid_is_ru(0x0409)); // en-US
+        assert!(!langid_is_ru(0x0804)); // zh-CN
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -117,11 +117,7 @@ fn config_with_defaults(mut cfg: Value) -> Value {
 
 #[tauri::command]
 fn system_ui_locale() -> &'static str {
-    if i18n::system_locale_is_zh() {
-        "zh"
-    } else {
-        "en"
-    }
+    i18n::system_ui_locale()
 }
 
 #[tauri::command]
@@ -171,7 +167,7 @@ fn set_config_inner(patch: Value) -> Result<Value, String> {
         for (k, v) in source {
             if CONFIG_KEYS.contains(&k.as_str()) {
                 if k == "locale" {
-                    let ok = matches!(v.as_str(), Some("auto" | "en" | "zh"));
+                    let ok = matches!(v.as_str(), Some("auto" | "en" | "zh" | "ru"));
                     target.insert(k.clone(), if ok { v.clone() } else { json!("auto") });
                 } else {
                     target.insert(k.clone(), v.clone());

--- a/src-tauri/src/tray_projection.rs
+++ b/src-tauri/src/tray_projection.rs
@@ -231,18 +231,15 @@ fn format_provider_line(
         return name;
     };
     let mut line = crate::i18n::pct_left(locale, &name, &first.label, percent_left(first));
-    let separator = if crate::i18n::is_zh(locale) {
-        "，"
-    } else {
-        ", "
-    };
+    let resolved = crate::i18n::resolved_locale(locale);
+    let separator = if resolved == "zh" { "，" } else { ", " };
     for metric in metrics {
         let fragment = {
             let label = crate::i18n::metric_label(locale, &metric.label);
-            if crate::i18n::is_zh(locale) {
-                format!("{label}: 剩余 {:.0}%", percent_left(metric))
-            } else {
-                format!("{label}: {:.0}% left", percent_left(metric))
+            match resolved {
+                "zh" => format!("{label}: 剩余 {:.0}%", percent_left(metric)),
+                "ru" => format!("{label}: осталось {:.0}%", percent_left(metric)),
+                _ => format!("{label}: {:.0}% left", percent_left(metric)),
             }
         };
         line.push_str(separator);
@@ -568,15 +565,27 @@ mod tests {
 
     #[test]
     fn locale_changes_text_without_changing_selection() {
-        let snapshots = vec![snapshot("codex", "Codex", vec![progress("Weekly", 23.0)])];
+        let snapshots = vec![snapshot(
+            "codex",
+            "Codex",
+            vec![progress("Weekly", 23.0), progress("Session", 10.0)],
+        )];
         let en = project_main_tray(&snapshots, &config(&["codex"]), false);
         let mut zh_config = config(&["codex"]);
         zh_config.locale = "zh".into();
+        let mut ru_config = config(&["codex"]);
+        ru_config.locale = "ru".into();
 
         let zh = project_main_tray(&snapshots, &zh_config, false);
+        let ru = project_main_tray(&snapshots, &ru_config, false);
 
         assert_eq!(en.remaining_percentages, zh.remaining_percentages);
-        assert_eq!(zh.tooltip, "Pane\nCodex 每周: 剩余 77%");
+        assert_eq!(en.remaining_percentages, ru.remaining_percentages);
+        assert_eq!(zh.tooltip, "Pane\nCodex 每周: 剩余 77%，会话: 剩余 90%");
+        assert_eq!(
+            ru.tooltip,
+            "Pane\nCodex За неделю: осталось 77%, Сессия: осталось 90%"
+        );
     }
 
     #[test]

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,9 +1,9 @@
-// Frontend locale: Settings stores auto / en / zh. Metric row labels from
+// Frontend locale: Settings stores auto / en / zh / ru. Metric row labels from
 // Rust stay English in config.layout (stars, pins, Customize keys); only
 // the painted text switches.
 
-export type LocalePref = "auto" | "en" | "zh";
-export type Locale = "en" | "zh";
+export type LocalePref = "auto" | "en" | "zh" | "ru";
+export type Locale = "en" | "zh" | "ru";
 
 type Dict = Record<string, string>;
 
@@ -48,6 +48,7 @@ const en: Dict = {
   "settings.langAuto": "Auto",
   "settings.langEn": "English",
   "settings.langZh": "中文",
+  "settings.langRu": "Русский",
   "settings.refreshEvery": "Refresh every",
   "settings.min": "min",
   "settings.startWithWindows": "Start with Windows",
@@ -357,6 +358,7 @@ const zh: Dict = {
   "settings.langAuto": "自动",
   "settings.langEn": "English",
   "settings.langZh": "中文",
+  "settings.langRu": "Русский",
   "settings.refreshEvery": "刷新间隔",
   "settings.min": "分钟",
   "settings.startWithWindows": "开机启动",
@@ -614,6 +616,316 @@ const zh: Dict = {
   "detail.countOfUsed": "已用 {a} / {b}",
 };
 
+const ru: Dict = {
+  "sidebar.theme": "Светлая / тёмная тема",
+  "sidebar.themeToDark": "Переключить на тёмную тему",
+  "sidebar.themeToLight": "Переключить на светлую тему",
+  "sidebar.refresh": "Обновить сейчас",
+  "sidebar.customize": "Настройка",
+  "sidebar.settings": "Настройки",
+  "sidebar.cards": "Навигация по карточкам",
+
+  "footer.starting": "Запуск…",
+  "footer.refreshing": "Обновление…",
+  "footer.updated": "Обновлено {time}",
+  "footer.refreshFailed": "Ошибка обновления: {err}",
+  "footer.keySaved": "Ключ {name} сохранён",
+  "footer.keySaveFailed": "Не удалось сохранить ключ: {err}",
+  "footer.shortcutSaved": "Ярлык сохранён",
+  "footer.shortcutCleared": "Ярлык сброшен",
+  "footer.proxySaved": "Прокси сохранён — заработает после перезапуска",
+  "footer.autostartFailed": "Автозапуск не удался: {err}",
+  "footer.copied": "Скопировано в буфер",
+  "footer.shareFailed": "Не удалось поделиться: {err}",
+  "footer.updateFailed": "Ошибка обновления: {err}",
+  "footer.openLinkFailed": "Не удалось открыть ссылку: {err}",
+  "footer.twoStars": "Не больше 2 звёзд на сервис",
+  "footer.redeeming": "Применяем сброс лимита…",
+  "footer.redeemFailed": "Не удалось применить сброс: {err}",
+  "footer.configSaveFailed": "Настройки не сохранены и могут быть утеряны после перезапуска: {err}",
+  "footer.traySyncFailed": "Не удалось обновить значок в трее; будет повторная попытка: {err}",
+
+  "update.check": "Проверка обновлений…",
+  "update.to": "⬆ Обновить до v{version}",
+  "update.installing": "Установка…",
+  "update.retry": "⬆ Обновить до v{version} — повторить",
+
+  "settings.done": "← Готово",
+  "settings.title": "Настройки",
+  "settings.general": "Общие",
+  "settings.language": "Язык",
+  "settings.langAuto": "Авто",
+  "settings.langEn": "English",
+  "settings.langZh": "中文",
+  "settings.langRu": "Русский",
+  "settings.refreshEvery": "Обновлять каждые",
+  "settings.min": "мин",
+  "settings.startWithWindows": "Запускать с Windows",
+  "settings.pacing": "Всегда показывать темп",
+  "settings.trayShows": "Значок в трее показывает",
+  "settings.pinAuto": "Авто (первый живой показатель)",
+  "settings.pinOption": "{name} — {label}",
+  "settings.timeFormat": "Формат времени",
+  "settings.timeAuto": "Авто",
+  "settings.time12": "12 часов",
+  "settings.time24": "24 часа",
+  "settings.appearance": "Оформление",
+  "settings.appearSystem": "Как в системе",
+  "settings.appearLight": "Светлая",
+  "settings.appearDark": "Тёмная",
+  "settings.compact": "Компактный вид",
+  "settings.glass": "Эффект жидкого стекла",
+  "settings.glassTip":
+    "На слабых ПК лучше выключить — вместо стекла будет простой фон",
+  "settings.reduceAnim": "Меньше анимации",
+  "settings.reduceAnimTip":
+    "Пропустить появление карточек и переход день/ночь. Настройка Windows «Эффекты анимации» всё равно учитывается.",
+  "settings.showSpend": "Показывать карточку общих трат",
+  "settings.shortcut": "Глобальная горячая клавиша",
+  "settings.shortcutPh": "например Ctrl+Shift+U",
+
+  "settings.notifications": "Уведомления",
+  "settings.notifyNote":
+    "Всплывающие уведомления Windows, когда квота ухудшается — один раз на показатель за период сброса.",
+  "settings.notifyAlmost": "Почти кончилось (осталось <10%)",
+  "settings.notifyClose": "Запас на исходе",
+  "settings.notifyRunout": "Кончится до сброса",
+
+  "settings.privacy": "Конфиденциальность",
+  "settings.privacyNote":
+    'Один анонимный сигнал «сегодня жив» и счётчики успеха/сбоя по сервисам, раз в день, под случайным ID без привязки. Без объёмов, трат и IP. Подробности в docs/privacy.md.',
+  "settings.telemetry": "Делиться анонимной статистикой",
+  "settings.hideSharing": "Скрывать цифры в трее при демонстрации экрана",
+  "settings.hideSharingTip":
+    "В режиме презентации, полноэкранном режиме или удалённом управлении проценты в трее скрываются. Значок Pane и логотипы со звёздами остаются. Демонстрация окна в Teams/Zoom не определяется. По умолчанию выключено.",
+
+  "settings.network": "Сеть",
+  "settings.useProxy": "Использовать прокси",
+  "settings.proxyUrl": "Адрес прокси",
+  "settings.networkNote":
+    "Применяется после перезапуска. Локальный API всегда на http://127.0.0.1:6736/v1/usage",
+
+  "settings.apiKeys": "Ключи API",
+  "settings.apiKeysNote":
+    "Хранятся только на этом ПК (%APPDATA%\\Pane). Оставьте пустым и сохраните, чтобы удалить.",
+  "settings.save": "Сохранить",
+  "settings.keyPlaceholder": "Ключ API",
+  "settings.keyPhMinimax": "Ключ API (можно взять из CLI)",
+  "settings.keyPhMoonshot": "sk-… (ключ platform.kimi.ai)",
+  "settings.keyPhCodebuff": "Ключ API (можно взять из CLI)",
+  "settings.keyPhKilo": "Ключ API (можно взять из CLI)",
+  "settings.keyPhAihubmix": "sk-… (можно взять из OpenCode)",
+  "settings.keyPhQwen": "sk-sp-… (можно взять из переменных среды)",
+
+  "settings.advanced": "Дополнительно",
+  "settings.advancedNote":
+    "Вернёт все настройки к значениям по умолчанию и заново найдёт установленные инструменты. Ключи API и история использования останутся. Смена прокси по-прежнему требует перезапуска.",
+  "settings.resetAll": "Сбросить все настройки",
+  "settings.changelog": "Что нового · Журнал изменений",
+  "settings.customizeHint":
+    "Сервисы, порядок строк и звёзды трея — в «Настройка» (☰ в боковой панели). Там можно отметить до 2 показателей на сервис — они появятся значками в трее.",
+
+  "settings.resetTitle": "Сбросить все настройки?",
+  "settings.resetBody":
+    "Тема, плотность, уведомления, ярлык, прокси, темп, звёзды трея и раскладки карточек вернутся к значениям по умолчанию. Установленные инструменты будут найдены заново. Ключи API и история использования останутся. Смена прокси по-прежнему требует перезапуска.",
+  "settings.resetConfirm": "Сбросить всё",
+
+  "dialog.cancel": "Отмена",
+  "dialog.gotIt": "Понятно",
+  "dialog.changelog": "Журнал изменений",
+  "dialog.whatsNew": "Что нового в v{version}",
+
+  "card.notConnected": "Не подключено",
+  "card.outdated": "⚠ Данные устарели",
+  "card.showMore": "Ещё",
+  "card.showLess": "Свернуть",
+  "card.share": "Скопировать карточку как изображение",
+  "card.drag": "Перетащите, чтобы изменить порядок",
+  "card.notStarted": "Ещё не началось",
+  "card.notStartedTip": "Окно начнётся после первого сообщения.",
+  "card.resetsSoon": "Скоро сброс",
+  "card.resetsIn": "Сброс через {time}",
+  "card.resetsAt": "Сброс {when}",
+  "card.expires": "Истекает {when}",
+  "card.available": "Доступно",
+  "card.use": "Использовать",
+  "card.useTip": "Потратить этот кредит, чтобы сразу сбросить лимиты Codex",
+  "card.creditDying": "Этот кредит истечёт через {time} — используйте или пропадёт.",
+  "card.pctUsed": "Использовано {n}%",
+  "card.pctLeft": "Осталось {n}%",
+  "card.noData": "Нет данных",
+  "card.tokens": "{n} tokens",
+  "card.tokensEst": "{cost} · {n} tokens · оценка",
+  "card.tokensPlain": "{cost} · {n} tokens",
+
+  "pace.limitReached": "🔥 Лимит исчерпан",
+  "pace.limitReachedTitle": "Лимит исчерпан",
+  "pace.limitAt": "Лимит {when}",
+  "pace.limitIn": "Лимит через {time}",
+  "pace.overReset": "~{n}% сверх лимита к сбросу",
+  "pace.fullReset": "~100% к сбросу",
+  "pace.spare": "запас ~{n}%",
+  "pace.usedReset": "~{n}% будет использовано к сбросу",
+  "pace.leftReset": "~{n}% останется к сбросу",
+
+  "time.today": "сегодня в {time}",
+  "time.tomorrow": "завтра в {time}",
+  "time.dateAt": "{date} в {time}",
+  "time.daysHours": "{d}д {h}ч",
+  "time.hoursMins": "{h}ч {m}м",
+  "time.mins": "{m}м",
+
+  "stale.lastFailed": "Последнее обновление не удалось",
+  "stale.reloginDefault":
+    "снова вставьте ключ API в Настройках (или войдите в инструмент один раз)",
+  "stale.fixRetry": "Pane сам повторяет попытки — ничего делать не нужно, пока это не затянется.",
+  "stale.fixDone": "Pane восстановится сам, как только это будет сделано.",
+  "stale.fixRelogin": "Что сделать: {how} — Pane подхватит это при следующем обновлении.",
+  "stale.fix429":
+    "Сервис ограничивает частоту запросов; Pane ждёт ровно столько, сколько просили, и повторяет сам.",
+  "stale.fix5xx":
+    "У сервиса сбой API; Pane повторяет попытки, пока тот не восстановится.",
+  "stale.fixNet":
+    "Pane не достучался до сервиса — проверьте интернет (или прокси в Настройках).",
+  "stale.tail": "Пока показываем последние хорошие данные.",
+  "stale.relogin.claude": "запустите `claude` в терминале и войдите",
+  "stale.relogin.codex": "запустите `codex login` в терминале",
+  "stale.relogin.grok": "запустите `grok` в терминале и войдите",
+  "stale.relogin.copilot": "запустите `gh auth login` в терминале",
+  "stale.relogin.cursor": "откройте Cursor и войдите снова",
+  "stale.relogin.devin": "запустите `devin` в терминале и войдите",
+  "stale.relogin.opencode": "запустите `opencode auth login` в терминале",
+  "stale.relogin.antigravity": "откройте Antigravity и войдите снова",
+  "stale.relogin.ollama": "убедитесь, что Ollama запущена",
+  "stale.relogin.hermes":
+    "откройте приложение Hermes один раз, чтобы оно записало локальный журнал",
+  "stale.relogin.kimi": "запустите `kimi login` в терминале",
+
+  "unpriced.tip":
+    "{n} запросов шли на модели без публичных цен ({models}). Токены учтены, но в доллары их не перевести — реальная стоимость чуть выше, чем на экране.",
+
+  "spend.title": "Всего потрачено",
+  "spend.scanning": "Сканирование журналов сессий…",
+  "spend.emptyFirst":
+    "Пока нет данных о тратах — появятся, когда Claude Code, Codex или другой CLI запишет использование на этом ПК.",
+  "spend.emptyPeriod": "За этот период трат нет.",
+  "spend.emptyPeriodTip": "За этот период траты не записаны.",
+  "spend.info":
+    "Источники: {names}. Все цифры — локальные оценки по журналам самих инструментов.",
+  "spend.clickTip":
+    "{exact} — посчитано локально по журналам сессий. Нажмите, чтобы показать {next}.",
+  "spend.today": "Сегодня",
+  "spend.yesterday": "Вчера",
+  "spend.days30": "30 дней",
+  "spend.last30": "Последние 30 дней",
+  "spend.trend": "Динамика",
+  "spend.trendTip":
+    "Последние 30 дней ({from} – {to}) · пик {tokens} tokens {peak} · из локальных журналов",
+  "spend.others": "Другие",
+  "spend.underEach": "Каждый меньше ${limit}:",
+  "spend.metric.cost": "доллары",
+  "spend.metric.mtok": "стоимость за млн токенов",
+  "spend.metric.tokens": "tokens",
+  "spend.centerTokens": "tokens",
+  "spend.noUsage": "Нет использования",
+  "spend.of30": "{n}% за последние 30 дней",
+  "spend.noModelData": "За этот период нет разбивки по моделям.",
+
+  "metric.session": "Сессия",
+  "metric.weekly": "За неделю",
+  "metric.monthly": "За месяц",
+  "metric.daily": "За день",
+  "metric.usage": "Использование",
+  "metric.credits": "Кредиты",
+  "metric.creditsUsed": "Использовано кредитов",
+  "metric.api": "API",
+  "metric.balance": "Баланс",
+  "metric.vouchers": "Ваучеры",
+  "metric.cash": "Наличные",
+  "metric.limit": "Лимит",
+  "metric.used": "Использовано",
+  "metric.onDemand": "По факту",
+  "metric.cursorModels": "Модели Cursor",
+  "metric.otherModels": "Другие модели",
+  "metric.totalUsage": "Всего",
+  "metric.bonus": "Бонус",
+  "metric.extraUsage": "Дополнительно",
+  "metric.extraCredits": "Доп. кредиты",
+  "metric.resetCredit": "Сброс лимита",
+  "metric.resetCreditNumbered": "Сброс лимита {n}",
+  "metric.resetCredits": "Сброс лимита",
+  "metric.extraBalance": "Доп. баланс",
+  "metric.kiloPass": "Kilo Pass",
+  "metric.reqToday": "Запросы сегодня",
+  "metric.reqMonth": "Запросы в этом месяце",
+  "metric.reqCycle": "Запросы за цикл",
+  "metric.lastUsed": "Последнее использование",
+  "metric.via": "Через",
+  "metric.sessions": "Сессии",
+  "metric.modelWeekly": "{model} за неделю",
+
+  "link.Status": "Статус",
+  "link.Dashboard": "Панель",
+  "link.Usage": "Использование",
+  "link.Credits": "Кредиты",
+  "link.Platform": "Платформа",
+  "link.Activity": "Активность",
+  "link.API Keys": "Ключи API",
+  "link.Console": "Консоль",
+  "link.Coding Plan": "Тариф для кода",
+  "link.Library": "Библиотека",
+  "link.Site": "Сайт",
+  "link.Quota": "Квота",
+  "link.API": "API",
+
+  "welcome.title": "Добро пожаловать 👋",
+  "welcome.body":
+    "Настроены инструменты ИИ, найденные на этом ПК. Карточки, звёзды трея и скрытые строки — в «Настройка».",
+  "welcome.open": "Открыть настройку",
+  "welcome.dismiss": "Закрыть",
+
+  "customize.done": "← Готово",
+  "customize.starred": "Отмечено {n} · перетащите ⠿, чтобы изменить порядок",
+  "customize.resetAll": "↺ Сбросить всё",
+  "customize.resetAllTip":
+    "Вернуть раскладки всех карточек по умолчанию — лимиты использования не трогает",
+  "customize.resetLayout": "Сбросить раскладку",
+  "customize.resetLayoutTip":
+    "Вернуть раскладку этой карточки по умолчанию — лимиты использования не трогает",
+  "customize.enable": "Включить сервис",
+  "customize.expand": "Развернуть",
+  "customize.collapse": "Свернуть",
+  "customize.dragRows": "Перетащите, чтобы изменить порядок",
+  "customize.dragProviders": "Перетащите, чтобы изменить порядок сервисов",
+  "customize.star": "Звезда в трее (не больше 2)",
+  "customize.onDemand": "Ещё — за стрелкой на карточке",
+  "customize.noData": "Пока нет данных — сначала включите этот сервис и обновите.",
+  "customize.resetTitle": "Сбросить все раскладки?",
+  "customize.resetBody":
+    "Порядок, звёзды и скрытые строки вернутся к значениям по умолчанию, установленные инструменты ИИ будут найдены заново. Лимиты использования не изменятся.",
+  "customize.resetConfirm": "Сбросить всё",
+
+  "redeem.title": "Использовать сброс лимита?",
+  "redeem.body":
+    "Это сразу сбросит окна лимитов Codex и отменить нельзя. Обновлённые окна могут появиться через пару минут.",
+  "redeem.confirm": "Использовать",
+
+  "share.tagline": "Следите за подписками ИИ с Pane",
+  "tray.left": "{label}: осталось {n}%",
+
+  "detail.unlimited": "Без лимита",
+  "detail.moneyOfLeft": "{a} / {b} осталось",
+  "detail.moneyOfLeftCredits": "{a} / {b} осталось · {n} кредитов",
+  "detail.moneyLeftOf": "{a} / {b} осталось",
+  "detail.moneyOfUsed": "Использовано {a} / {b}",
+  "detail.moneyOfLimit": "{a} / {b} лимит",
+  "detail.moneyOf": "{a} / {b}",
+  "detail.moneyCredits": "{a} · {n} кредитов",
+  "detail.countCreditsUsed": "Использовано {a} / {b} кредитов",
+  "detail.countOfLeft": "{a} / {b} осталось",
+  "detail.countOfUsed": "Использовано {a} / {b}",
+};
+
 const METRIC_KEYS: Record<string, string> = {
   Session: "metric.session",
   Weekly: "metric.weekly",
@@ -656,7 +968,10 @@ let active: Locale = "en";
 let systemLocale: Locale | null = null;
 
 export function detectSystemLocale(): Locale {
-  return (navigator.language || "").toLowerCase().startsWith("zh") ? "zh" : "en";
+  const lang = (navigator.language || "").toLowerCase();
+  if (lang.startsWith("zh")) return "zh";
+  if (lang.startsWith("ru")) return "ru";
+  return "en";
 }
 
 export function setSystemLocale(locale: Locale): void {
@@ -664,12 +979,12 @@ export function setSystemLocale(locale: Locale): void {
 }
 
 export function resolveLocale(pref: string | undefined): Locale {
-  if (pref === "zh" || pref === "en") return pref;
+  if (pref === "zh" || pref === "en" || pref === "ru") return pref;
   return systemLocale ?? detectSystemLocale();
 }
 
 export function normalizeLocalePref(raw: unknown): LocalePref {
-  return raw === "en" || raw === "zh" || raw === "auto" ? raw : "auto";
+  return raw === "en" || raw === "zh" || raw === "ru" || raw === "auto" ? raw : "auto";
 }
 
 export function setActiveLocale(locale: Locale): void {
@@ -681,11 +996,13 @@ export function getLocale(): Locale {
 }
 
 export function localeTag(): string {
-  return active === "zh" ? "zh-CN" : "en-US";
+  if (active === "zh") return "zh-CN";
+  if (active === "ru") return "ru-RU";
+  return "en-US";
 }
 
 export function t(key: string, vars?: Record<string, string | number>): string {
-  const dict = active === "zh" ? zh : en;
+  const dict = active === "zh" ? zh : active === "ru" ? ru : en;
   let s = dict[key] ?? en[key] ?? key;
   if (vars) {
     for (const [k, v] of Object.entries(vars)) {
@@ -719,7 +1036,7 @@ export function displayLinkLabel(label: string): string {
 /// Rust still emits English captions ("$21.80 of $79.56 left · 545 credits").
 /// Translate the known shapes at paint time so layout keys stay English.
 export function displayMetricDetail(text: string): string {
-  if (getLocale() !== "zh" || !text) return text;
+  if (getLocale() === "en" || !text) return text;
   const money = "\\$[\\d,]+(?:\\.\\d+)?K?";
   const num = "[\\d,]+(?:\\.\\d+)?";
   let m = text.match(new RegExp(`^(${money}) of (${money}) left(?: · (\\d+) credits)?$`, "i"));
@@ -750,7 +1067,7 @@ export function displayMetricDetail(text: string): string {
 }
 
 export function applyStaticI18n(): void {
-  document.documentElement.lang = active === "zh" ? "zh-CN" : "en";
+  document.documentElement.lang = localeTag();
   document.querySelectorAll<HTMLElement>("[data-i18n]").forEach((el) => {
     const key = el.dataset.i18n;
     if (key) el.textContent = t(key);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -860,6 +860,7 @@ const ru: Dict = {
   "metric.reqMonth": "Запросы в этом месяце",
   "metric.reqCycle": "Запросы за цикл",
   "metric.lastUsed": "Последнее использование",
+  "metric.recentModels": "Недавние модели",
   "metric.via": "Через",
   "metric.sessions": "Сессии",
   "metric.modelWeekly": "{model} за неделю",

--- a/src/main.ts
+++ b/src/main.ts
@@ -3175,7 +3175,7 @@ async function initSettings(): Promise<void> {
   config.locale = normalizeLocalePref(config.locale);
   try {
     const sys = await invoke<string>("system_ui_locale");
-    setSystemLocale(sys === "zh" ? "zh" : "en");
+    setSystemLocale(sys === "zh" || sys === "ru" ? sys : "en");
   } catch {
     // Dev / missing command — fall back to navigator.language.
   }


### PR DESCRIPTION
## Summary
- add Russian across Settings, cards, Customize, spend details, links, dialogs, tray labels, and quota notifications
- auto-detect Russian from the Windows display language while keeping explicit English, Chinese, and Russian choices
- localize multi-metric tray tooltips and the two newest footer failure messages
- include the Russian translation for #169's Recent models label without including its Hermes implementation

#### Test plan
- [x] verified English, Chinese, and Russian frontend dictionaries cover all 259 current keys
- [x] 
pm run build
- [x] cargo test --lib i18n::tests (5 passed)
- [x] cargo test --lib locale_changes_text_without_changing_selection
- [x] no local installer build or install, per project rule

Generated with [Devin](https://devin.ai)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->