### PR TITLE
Release 0.4.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.4.46 — 2026-09-02
 
 ### Added
+- **One/New API sites.** Settings has a new **One/New API sites**
+  section: add as many One API / New API hosts as you want, each with
+  its own keys. Each key gets its own quota card (PR #172).
 - **Kimi Code without the CLI.** Settings → API keys has a new **Kimi
   Code** field for your Kimi For Coding plan key. With no `kimi login` on
   the PC, Pane sends that key to the same usage endpoint the CLI uses and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — full Mac parity (and beyond)
 
-**Status (v0.4.45, 2026-08-29): every wave below is shipped, and the
+**Status (v0.4.46, 2026-09-02): every wave below is shipped, and the
 post-launch releases keep going.** Pane has full feature parity with the
 macOS original plus 21 providers, signed auto-updates published by CI,
 Codex reset-credit redemption, update-check-on-open with a one-click

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.45",
+  "version": "0.4.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.45",
+      "version": "0.4.46",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.45",
+  "version": "0.4.46",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.45"
+version = "0.4.46"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.45",
+  "version": "0.4.46",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Version bump to **0.4.46**: `tauri.conf.json`, `package.json`, `Cargo.toml`, both lockfiles, ROADMAP status line.
- CHANGELOG Unreleased retitled **0.4.46 — 2026-09-02**. Prior **0.4.45** header kept.
- Adds the missing **One/New API sites** CHANGELOG line for #172.

Ships on main: #172 One/New API multi-site keys, #174 Kimi Code pasted plan key (closes #173), #175 Cursor no fake "Requests this cycle 0", #176 live Cursor bars via `usage-summary`, #177 Hermes AihubMix Qwen3.8-Max-0902 pricing.

No Grok Bot work in this cut.

## Test plan
- [ ] Release CI publishes `v0.4.46` installer + `latest.json`
- [ ] `pane.jazii.dev/api/update?current=0.4.45` serves 0.4.46
- [ ] Winget workflow opens the version PR
- [ ] CHANGELOG on the GitHub release lists One/New API + Kimi + Cursor + Hermes 0902

Made with Cursor

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->