### PR TITLE
Move Pane's primary site to trypane.xyz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 - **Pane's website moved to trypane.xyz.** Public links and install
   commands use the new domain. Existing `pane.jazii.dev` updater clients
-  and the private dashboard remain supported through a compatibility alias.
+  and dashboard links remain supported through a permanent domain redirect.
 
 ## 0.4.46 — 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **Pane's website moved to trypane.xyz.** Public links and install
+  commands use the new domain. Existing `pane.jazii.dev` updater clients
+  remain supported through a permanent domain redirect.
+
 ## 0.4.46 — 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 - **Pane's website moved to trypane.xyz.** Public links and install
   commands use the new domain. Existing `pane.jazii.dev` updater clients
-  remain supported through a permanent domain redirect.
+  and the private dashboard remain supported through a compatibility alias.
 
 ## 0.4.46 — 2026-09-02
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ reset? What did today actually cost me?*
 Pane is the [OpenUsage](https://www.openusage.ai/) port for Windows: a free
 AI plan tracker for Claude, Codex, Cursor, Copilot, Kimi, Grok, and 15 more.
 
-**[pane.jazii.dev](https://pane.jazii.dev)** · [Guides](https://pane.jazii.dev/guides) · [Install](#install) · [How it works](#how-it-works) · [Providers](#providers-21-and-counting) · [Features](#features) · [Privacy](#privacy--security) · [Credits](#credits)
+**[trypane.xyz](https://trypane.xyz)** · [Guides](https://trypane.xyz/guides) · [Install](#install) · [How it works](#how-it-works) · [Providers](#providers-21-and-counting) · [Features](#features) · [Privacy](#privacy--security) · [Credits](#credits)
 
 <img src="docs/promo.png" width="760" alt="Pane — track all your AI subscription limits in one tray app: Total Spend donut with per-provider slices, usage cards with pace bars" />
 
@@ -50,7 +50,7 @@ reviewed, hash-verified, no SmartScreen prompt.
 ### One-liner (PowerShell)
 
 ```powershell
-irm https://pane.jazii.dev/install.ps1 | iex
+irm https://trypane.xyz/install.ps1 | iex
 ```
 
 Downloads the latest release, verifies its SHA-256, installs per-user
@@ -60,7 +60,7 @@ Piping a script straight into PowerShell runs whatever the server sends
 at that moment. Prefer to look first? Same script, two steps:
 
 ```powershell
-iwr https://pane.jazii.dev/install.ps1 -OutFile install.ps1
+iwr https://trypane.xyz/install.ps1 -OutFile install.ps1
 # read install.ps1 — one short, commented script — then:
 powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,7 +76,7 @@ All of this is auditable in the source — links go to the exact code.
 
 - The installer is **not yet Authenticode-signed**, so SmartScreen warns
   on first run. Updates are minisign-verified regardless. A code-signing
-  certificate is planned. (The `irm pane.jazii.dev/install.ps1 | iex`
+  certificate is planned. (The `irm https://trypane.xyz/install.ps1 | iex`
   install path and winget don't trigger SmartScreen.)
 - Release binaries are built by GitHub Actions from the pushed tag —
   see [.github/workflows/release.yml](.github/workflows/release.yml);

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -14,7 +14,7 @@ This is the complete list. Anything not listed here does not happen.
 | Each provider's own API (Anthropic, OpenAI/ChatGPT, cursor.com, GitHub, x.ai, opencode.ai, Devin, MiniMax, OpenRouter, Z.ai, Google, DeepSeek, Moonshot, Kimi Code, ElevenLabs, Codebuff, Kilo, AihubMix, Alibaba Model Studio…) | Every refresh (default 1 min), only for providers you have enabled | That provider's own token/key, exactly as its official tool would send it. Full per-provider detail: [providers.md](providers.md) |
 | User-configured One/New API origins | Status probe when saving/changing a site, plus one unauthenticated backfill if a stored site has no display unit; billing on every refresh for enabled keys | `/api/status` with no key. Subscription + usage send that site's key as Bearer, **only to that origin** — never to Pane servers. |
 | `raw.githubusercontent.com` (LiteLLM), `models.dev`, `robinebers.github.io` | ~Daily | Anonymous GET for public model price tables (no identifying data) |
-| `pane.jazii.dev/api/update` (falls back to `github.com/ItsJazii/pane/releases`) | On launch + every 4 h | Anonymous GET for the update manifest, carrying the app version. See "The update check" below for exactly what this counts. |
+| `trypane.xyz/api/update` (the legacy `pane.jazii.dev/api/update` redirects there; GitHub Releases is the final fallback) | On launch + every 4 h | Anonymous GET for the update manifest, carrying the app version. See "The update check" below for exactly what this counts. |
 | `us.i.posthog.com` | Once per day (unless switched off) | The two anonymous daily-statistic events described in "Anonymous usage statistics" below — a random ID, version, enabled-provider list, and per-provider success/failure counts. Never usage amounts, spend, keys, or error text. |
 | `127.0.0.1:11434` (your own PC) | Every refresh, if Ollama is enabled | Local-only query of your Ollama server |
 
@@ -64,12 +64,13 @@ auditable file: [`src-tauri/src/telemetry.rs`](../src-tauri/src/telemetry.rs)
 ## The update check
 
 Pane has to ask *somewhere* "is there a newer version?" — that request
-existed from day one. As of 0.4.17 it goes to `pane.jazii.dev` (which
-serves the same signed manifest; GitHub remains the automatic fallback,
-and every update is still signature-verified against the key baked into
-the app). The server counts, per day: **how many distinct installs
-checked in, from which country, on which version.** That's the entire
-list. Concretely:
+existed from day one. New builds ask `trypane.xyz` first, retain the
+legacy `pane.jazii.dev` endpoint for existing installs through a permanent
+redirect, and use GitHub as the final automatic fallback. Every endpoint
+serves the same manifest, and every update is still signature-verified
+against the key baked into the app. The server counts, per day: **how many
+distinct installs checked in, from which country, on which version.** That's
+the entire list. Concretely:
 
 - **No IP addresses are stored.** Uniqueness comes from a salted one-way
   hash folded into a [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog)

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,9 +1,9 @@
 # Privacy
 
 Pane is built on one rule: **your data is nobody's business, including
-ours.** There is no Pane server and no account. The only thing Pane ever
-reports about itself is a minimal, anonymous, opt-out daily statistic —
-described in full below, with the off switch.
+ours.** There is no Pane account, and no Pane backend receives your quotas,
+spend, keys, or provider data. The Pane-hosted update endpoint and the
+minimal, anonymous, opt-out daily statistic are described in full below.
 
 ## Every network call Pane can make
 
@@ -64,11 +64,11 @@ auditable file: [`src-tauri/src/telemetry.rs`](../src-tauri/src/telemetry.rs)
 ## The update check
 
 Pane has to ask *somewhere* "is there a newer version?" — that request
-existed from day one. New builds ask `trypane.xyz` first, retain the
-legacy `pane.jazii.dev` endpoint for existing installs through a permanent
-redirect, and use GitHub as the final automatic fallback. Every endpoint
-serves the same manifest, and every update is still signature-verified
-against the key baked into the app. The server counts, per day: **how many
+existed from day one. New builds ask `trypane.xyz` first and use GitHub as
+the automatic fallback. Old builds that still call `pane.jazii.dev` are
+handled by a permanent redirect to `trypane.xyz`. Every endpoint serves
+the same manifest, and every update is still signature-verified against
+the key baked into the app. The server counts, per day: **how many
 distinct installs checked in, from which country, on which version.** That's
 the entire list. Concretely:
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -14,7 +14,7 @@ This is the complete list. Anything not listed here does not happen.
 | Each provider's own API (Anthropic, OpenAI/ChatGPT, cursor.com, GitHub, x.ai, opencode.ai, Devin, MiniMax, OpenRouter, Z.ai, Google, DeepSeek, Moonshot, Kimi Code, ElevenLabs, Codebuff, Kilo, AihubMix, Alibaba Model Studio…) | Every refresh (default 1 min), only for providers you have enabled | That provider's own token/key, exactly as its official tool would send it. Full per-provider detail: [providers.md](providers.md) |
 | User-configured One/New API origins | Status probe when saving/changing a site, plus one unauthenticated backfill if a stored site has no display unit; billing on every refresh for enabled keys | `/api/status` with no key. Subscription + usage send that site's key as Bearer, **only to that origin** — never to Pane servers. |
 | `raw.githubusercontent.com` (LiteLLM), `models.dev`, `robinebers.github.io` | ~Daily | Anonymous GET for public model price tables (no identifying data) |
-| `trypane.xyz/api/update` (the legacy `pane.jazii.dev/api/update` remains available; GitHub Releases is the final fallback) | On launch + every 4 h | Anonymous GET for the update manifest, carrying the app version. See "The update check" below for exactly what this counts. |
+| `trypane.xyz/api/update` (the legacy `pane.jazii.dev/api/update` redirects there; GitHub Releases is the final fallback) | On launch + every 4 h | Anonymous GET for the update manifest, carrying the app version. See "The update check" below for exactly what this counts. |
 | `us.i.posthog.com` | Once per day (unless switched off) | The two anonymous daily-statistic events described in "Anonymous usage statistics" below — a random ID, version, enabled-provider list, and per-provider success/failure counts. Never usage amounts, spend, keys, or error text. |
 | `127.0.0.1:11434` (your own PC) | Every refresh, if Ollama is enabled | Local-only query of your Ollama server |
 
@@ -65,9 +65,9 @@ auditable file: [`src-tauri/src/telemetry.rs`](../src-tauri/src/telemetry.rs)
 
 Pane has to ask *somewhere* "is there a newer version?" — that request
 existed from day one. New builds ask `trypane.xyz` first and use GitHub as
-the automatic fallback. The legacy `pane.jazii.dev` endpoint remains a
-compatibility alias for old builds. Every endpoint serves the same
-manifest, and every update is still signature-verified against
+the automatic fallback. Old builds that still call `pane.jazii.dev` are
+handled by a permanent redirect to `trypane.xyz`. Every endpoint serves
+the same manifest, and every update is still signature-verified against
 the key baked into the app. The server counts, per day: **how many
 distinct installs checked in, from which country, on which version.** That's
 the entire list. Concretely:

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -14,7 +14,7 @@ This is the complete list. Anything not listed here does not happen.
 | Each provider's own API (Anthropic, OpenAI/ChatGPT, cursor.com, GitHub, x.ai, opencode.ai, Devin, MiniMax, OpenRouter, Z.ai, Google, DeepSeek, Moonshot, Kimi Code, ElevenLabs, Codebuff, Kilo, AihubMix, Alibaba Model Studio…) | Every refresh (default 1 min), only for providers you have enabled | That provider's own token/key, exactly as its official tool would send it. Full per-provider detail: [providers.md](providers.md) |
 | User-configured One/New API origins | Status probe when saving/changing a site, plus one unauthenticated backfill if a stored site has no display unit; billing on every refresh for enabled keys | `/api/status` with no key. Subscription + usage send that site's key as Bearer, **only to that origin** — never to Pane servers. |
 | `raw.githubusercontent.com` (LiteLLM), `models.dev`, `robinebers.github.io` | ~Daily | Anonymous GET for public model price tables (no identifying data) |
-| `trypane.xyz/api/update` (the legacy `pane.jazii.dev/api/update` redirects there; GitHub Releases is the final fallback) | On launch + every 4 h | Anonymous GET for the update manifest, carrying the app version. See "The update check" below for exactly what this counts. |
+| `trypane.xyz/api/update` (the legacy `pane.jazii.dev/api/update` remains available; GitHub Releases is the final fallback) | On launch + every 4 h | Anonymous GET for the update manifest, carrying the app version. See "The update check" below for exactly what this counts. |
 | `us.i.posthog.com` | Once per day (unless switched off) | The two anonymous daily-statistic events described in "Anonymous usage statistics" below — a random ID, version, enabled-provider list, and per-provider success/failure counts. Never usage amounts, spend, keys, or error text. |
 | `127.0.0.1:11434` (your own PC) | Every refresh, if Ollama is enabled | Local-only query of your Ollama server |
 
@@ -65,9 +65,9 @@ auditable file: [`src-tauri/src/telemetry.rs`](../src-tauri/src/telemetry.rs)
 
 Pane has to ask *somewhere* "is there a newer version?" — that request
 existed from day one. New builds ask `trypane.xyz` first and use GitHub as
-the automatic fallback. Old builds that still call `pane.jazii.dev` are
-handled by a permanent redirect to `trypane.xyz`. Every endpoint serves
-the same manifest, and every update is still signature-verified against
+the automatic fallback. The legacy `pane.jazii.dev` endpoint remains a
+compatibility alias for old builds. Every endpoint serves the same
+manifest, and every update is still signature-verified against
 the key baked into the app. The server counts, per day: **how many
 distinct installs checked in, from which country, on which version.** That's
 the entire list. Concretely:

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 # Pane quick installer
 #
-#   irm https://pane.jazii.dev/install.ps1 | iex
+#   irm https://trypane.xyz/install.ps1 | iex
 #
 # Downloads the latest signed release from GitHub, installs per-user
 # (no admin), and launches Pane. Works on Windows PowerShell 5.1 and pwsh.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2373,17 +2373,20 @@ async fn codex_redeem_credit(
 /// substituted in query strings, so 0.4.17 installs literally reported
 /// "?v={{current_version}}" — the version is now formatted in Rust.
 /// GitHub stays as the automatic fallback; the pubkey comes from config.
+fn updater_endpoint_strings(version: &str) -> [String; 2] {
+    [
+        format!("https://trypane.xyz/api/update?v={version}"),
+        "https://github.com/ItsJazii/pane/releases/latest/download/latest.json".into(),
+    ]
+}
+
 fn build_updater(app: &tauri::AppHandle) -> Result<tauri_plugin_updater::Updater, String> {
     use tauri_plugin_updater::UpdaterExt;
     let version = app.package_info().version.to_string();
-    let endpoints = vec![
-        format!("https://trypane.xyz/api/update?v={version}")
-            .parse()
-            .map_err(|e| format!("endpoint parse: {e}"))?,
-        "https://github.com/ItsJazii/pane/releases/latest/download/latest.json"
-            .parse()
-            .map_err(|e| format!("endpoint parse: {e}"))?,
-    ];
+    let endpoints = updater_endpoint_strings(&version)
+        .into_iter()
+        .map(|endpoint| endpoint.parse().map_err(|e| format!("endpoint parse: {e}")))
+        .collect::<Result<Vec<_>, _>>()?;
     app.updater_builder()
         .endpoints(endpoints)
         .map_err(|e| e.to_string())?
@@ -2657,8 +2660,8 @@ mod tests {
         restore_kimi_wallet_rows,
         restore_last_success_after_error,
         retain_current_onenewapi_results, strip_entry_application_order, strip_icon_ids_to_clear,
-        strip_is_active, strip_reset_ids, CachedSnap, FailState, OneNewApiMutationGuard,
-        StripEntry, SNAPSHOT_CACHE_MS, STALE_GRACE_MS,
+        strip_is_active, strip_reset_ids, updater_endpoint_strings, CachedSnap, FailState,
+        OneNewApiMutationGuard, StripEntry, SNAPSHOT_CACHE_MS, STALE_GRACE_MS,
     };
     use crate::alerts;
     use crate::providers::{Metric, Snapshot};
@@ -2672,6 +2675,17 @@ mod tests {
             values: vec![value],
             tooltip: id.into(),
         }
+    }
+
+    #[test]
+    fn updater_prefers_trypane_then_github() {
+        assert_eq!(
+            updater_endpoint_strings("0.4.46"),
+            [
+                "https://trypane.xyz/api/update?v=0.4.46".to_string(),
+                "https://github.com/ItsJazii/pane/releases/latest/download/latest.json".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2377,7 +2377,7 @@ fn build_updater(app: &tauri::AppHandle) -> Result<tauri_plugin_updater::Updater
     use tauri_plugin_updater::UpdaterExt;
     let version = app.package_info().version.to_string();
     let endpoints = vec![
-        format!("https://pane.jazii.dev/api/update?v={version}")
+        format!("https://trypane.xyz/api/update?v={version}")
             .parse()
             .map_err(|e| format!("endpoint parse: {e}"))?,
         "https://github.com/ItsJazii/pane/releases/latest/download/latest.json"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,7 +33,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://pane.jazii.dev/api/update?v={{current_version}}",
+        "https://trypane.xyz/api/update?v={{current_version}}",
         "https://github.com/ItsJazii/pane/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDhDRUI5RUYzRkVBMzlCQ0QKUldUTm02UCs4NTdyalB4dHhyci8wb2dzb1FUQzJpaCt1VWc5dDJCaGpoWlNMTlNlWTF3Z0F4NEEK"


### PR DESCRIPTION
## Summary
- move Pane's public website, guide, installer, and dashboard links to trypane.xyz
- make future app builds check trypane.xyz for updates with GitHub Releases as the automatic fallback
- document the permanent pane.jazii.dev redirect that preserves existing updater, installer, and dashboard paths

#### Test plan
- [x] cargo metadata --locked --no-deps --format-version 1
- [x] cargo check --lib
- [x] cargo test --lib updater_prefers_trypane_then_github
- [x] parsed src-tauri/tauri.conf.json
- [x] deployed site metadata validates across all public HTML files, sitemap, and robots.txt
- [x] verified trypane.xyz DNS on Google and Cloudflare, Vercel TLS, root/guides HTML, install.ps1 text/plain, and updater JSON
- [x] verified www.trypane.xyz and pane.jazii.dev redirects preserve paths and query strings
- [x] verified pane.jazii.dev/dash and /dash.html reach the protected dashboard on trypane.xyz
- [x] excluded the local .backup-pre-k3 folder from Vercel production and verified it returns 404
- [x] no local installer build or install

Generated with [Devin](https://devin.ai)