### PR TITLE
Refresh documentation for Pane 0.4.46

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ asking: *How much of my Claude session is left? When does my Codex weekly
 reset? What did today actually cost me?*
 
 Pane is the [OpenUsage](https://www.openusage.ai/) port for Windows: a free
-AI plan tracker for Claude, Codex, Cursor, Copilot, Kimi, Grok, and 15 more.
+AI plan tracker for Claude, Codex, Cursor, Copilot, Kimi, Grok, and 16 more.
 
-**[trypane.xyz](https://trypane.xyz)** · [Guides](https://trypane.xyz/guides) · [Install](#install) · [How it works](#how-it-works) · [Providers](#providers-21-and-counting) · [Features](#features) · [Privacy](#privacy--security) · [Credits](#credits)
+**[trypane.xyz](https://trypane.xyz)** · [Guides](https://trypane.xyz/guides) · [Install](#install) · [How it works](#how-it-works) · [Providers](#providers-22-and-counting) · [Features](#features) · [Privacy](#privacy--security) · [Credits](#credits)
 
 <img src="docs/promo.png" width="760" alt="Pane — track all your AI subscription limits in one tray app: Total Spend donut with per-provider slices, usage cards with pace bars" />
 
@@ -149,13 +149,13 @@ statistic (random ID, version, which providers are enabled, provider
 success/failure counts — never amounts or error text) — see
 [Privacy](#privacy--security) for the full contract and the off switch.
 
-## Providers (21 and counting)
+## Providers (22 and counting)
 
 | Provider | How Pane connects |
 |---|---|
 | Claude (Claude Code) | `%USERPROFILE%\.claude\.credentials.json` + Anthropic usage API; multi-account — every discovered config-dir login gets its own card |
 | Codex (Codex CLI) | `%USERPROFILE%\.codex\auth.json` + ChatGPT usage API, incl. reset-credit redemption; multi-account like Claude |
-| Cursor | Cursor's local state database + cursor.com API |
+| Cursor | Cursor's local state database + modern usage RPC; `cursor.com/api/usage-summary` keeps plan bars live when the RPC host is unreachable |
 | OpenCode (Go plan) | Official account-wide usage API (Go key from `auth.json`); local `opencode.db` for spend* |
 | GitHub Copilot | Copilot editor login or GitHub CLI (Credential Manager) + GitHub API |
 | Grok (Grok CLI) | `%USERPROFILE%\.grok\auth.json` + Grok billing/subscription APIs |
@@ -165,15 +165,16 @@ success/failure counts — never amounts or error text) — see
 | Z.ai | API key (Settings), CLI key file, or env var |
 | Antigravity | Local language server, or Google Cloud Code API via Credential Manager |
 | DeepSeek | API key (Settings) → balance |
-| Moonshot (Kimi API) | API key (Settings) → balance (global + CN endpoints) |
-| Kimi Code | Official CLI login (`kimi login`) → Session + Weekly plan bars and membership name (Moderato / Allegretto / Allegro / Vivace); Moonshot API key → API wallet bar; local session spend |
+| Kimi API | Platform API key (Settings) → wallet balance and credits-used meter (global + CN endpoints) |
+| Kimi Code | Official CLI login (`kimi login`) or pasted Kimi For Coding plan key → Session + Weekly bars and membership name (Moderato / Allegretto / Allegro / Vivace); optional Kimi API wallet bar; local session spend |
 | ElevenLabs | API key (Settings) → character quota with reset pacing |
 | Ollama | Local server on :11434 — installed + loaded models, no key |
 | Codebuff | `codebuff login` credentials file or API key → credits + weekly limit |
 | Kilo | Kilo CLI login file or API key → credit blocks + Kilo Pass |
 | AihubMix | API key (Settings or auto-detected from OpenCode) → usage vs spending limit |
+| One/New API | Add multiple compatible sites and keys in Settings; one quota card per key, with owner-only local secret storage |
 | Qwen Code | Coding Plan key (Settings or env) → 5h/weekly/monthly request quotas + local spend |
-| Hermes | Local ledger `%LOCALAPPDATA%\hermes\state.db` — last model, route, and catalog-priced spend |
+| Hermes | Local ledger `%LOCALAPPDATA%\hermes\state.db` → two recent user models, routes, and catalog-priced spend, including scoped AihubMix launch-model rates |
 
 *OpenCode's meters use the official usage API that shipped in
 [anomalyco/opencode#16513](https://github.com/anomalyco/opencode/pull/16513)
@@ -188,12 +189,18 @@ whatever the community asks for loudest.
 
 ## Features
 
-- **Multi-account Claude & Codex** 🆕 — running a personal plan AND a
+- **Multi-account Claude & Codex** — running a personal plan AND a
   work/enterprise seat? Keep the second login in its own folder (via
   `CLAUDE_CONFIG_DIR` / `CODEX_HOME`) and Pane shows one card per
   account — each with its own limits, plan, credits, and spend, named
   by its organization or email ("Claude — Acme"). The same account
   signed in twice stays one card, and your existing setup is untouched.
+- **One/New API sites** — add multiple compatible sites and multiple keys
+  per site in Settings. Every key gets its own quota card; secrets remain
+  owner-only on this PC and are sent only to the configured origin.
+- **English, Chinese, and Russian** — choose a language explicitly or let
+  Auto follow the Windows display language across the popover, tray, and
+  quota notifications.
 - **Pace projections** — colored bars and "will run out" warnings based on
   your burn rate within each reset window, plus optional Windows toasts.
 - **Local spend** — Today / Yesterday / 30 Days donut with per-model
@@ -254,9 +261,10 @@ signature-verified.
 
 ## Settings (gear icon)
 
-Refresh interval · Start with Windows · tray metric picker · appearance &
-compact density · time format · global shortcut · notification toggles ·
-outbound proxy · API keys.
+Language (Auto / English / 中文 / Русский) · refresh interval · Start with
+Windows · tray metric picker · appearance and compact density · time format ·
+global shortcut · notification toggles · outbound proxy · provider API keys ·
+One/New API site and key management.
 
 ## Credits
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,16 +2,16 @@
 
 **Status (v0.4.46, 2026-09-02): every wave below is shipped, and the
 post-launch releases keep going.** Pane has full feature parity with the
-macOS original plus 21 providers, signed auto-updates published by CI,
-Codex reset-credit redemption, update-check-on-open with a one-click
-footer button, live model pricing that re-prices within the hour when
-new models appear, modern Cursor plan support, and a Mac-parity design
-pass (inset card composition, wedge spend donut with dollars ⇄ tokens,
-in-popover drag reorder, curated share cards). What comes next is
-demand-driven — open an issue for the provider or feature you're
-missing. Candidates on deck: Windsurf and JetBrains AI providers,
-long-context pricing tiers, a Re-detect Tools button, tray "Bars" icon
-style, code signing.
+macOS original plus 22 providers, multi-site One/New API key management,
+Kimi Code plan keys without a CLI login, resilient modern Cursor plan
+fallbacks, English/Chinese/Russian UI, signed CI updates, live model
+pricing, and a Mac-parity design pass (inset cards, wedge spend donut,
+in-popover drag reorder, curated share cards). The primary site is now
+`trypane.xyz`; app-side updater migration is on main for the next release.
+What comes next is demand-driven — open an issue for the provider or
+feature you're missing. Candidates on deck: Windsurf and JetBrains AI
+providers, a Re-detect Tools button, tray "Bars" icon style, and code
+signing.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,6 +71,8 @@ All of this is auditable in the source — links go to the exact code.
   the original to `*.pane-bak` — a bad write can never cost you a login.
 - **API keys you paste** are stored in `%APPDATA%\Pane` on your PC,
   readable only by your Windows user, and sent only to their own vendor.
+  One/New API sites and keys use a nested owner-only store; Settings returns
+  labels and origins after save, never secret values or fragments.
 
 ## Known limitations (honesty section)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -263,14 +263,17 @@ Ground rules that apply to every provider:
   Detected when that file exists; no API key.
 - **Calls:** nothing. This is a purely local source — Hermes records
   ZERO cost itself, so dollars are priced from Pane's shared catalog.
-- **Shows:** a card with last-used model, which backend billed it
-  (AihubMix, MiniMax, a custom URL, …), and session count. Today /
-  Yesterday / Last 30 Days spend (with a per-model breakdown on hover)
-  sit behind Show more, same as other cards.
-  MiniMax-routed sessions still join the MiniMax spend slice, OpenRouter-
-  routed join OpenRouter (including a custom URL pointed at those hosts);
-  AihubMix and other custom OpenAI-compatible URLs
-  (including a custom URL that points at aihubmix.com) stay on this card.
+- **Shows:** a card with the two most recent user-selected models, their
+  billing backends (AihubMix, MiniMax, a custom URL, …), and session count.
+  Hermes's internal title/approval tasks still count toward real usage but
+  do not replace that model summary. Today / Yesterday / Last 30 Days spend
+  (with a per-model breakdown on hover) sits behind Show more.
+  MiniMax-routed sessions join the MiniMax spend slice; OpenRouter-routed
+  sessions join OpenRouter (including custom URLs pointed at those hosts).
+  AihubMix and other custom OpenAI-compatible URLs stay on Hermes. Scoped
+  AihubMix pricing covers HY4 Preview, Qwen3.8 Flash, and the dated
+  Qwen3.8-Max-0902 spellings without leaking those gateway rates to other
+  routes.
 
 ## Ollama
 


### PR DESCRIPTION
## Summary
- update the README and roadmap from 21 to the canonical 22 providers
- document One/New API sites, Kimi plan-key fallback, Cursor usage-summary fallback, Hermes recent-model pricing behavior, and English/Chinese/Russian support
- strengthen the security description for owner-only One/New API storage without changing the documented privacy boundary

#### Test plan
- [x] source provider list, README table, and deployed site chips each count exactly 22
- [x] all repository Markdown links resolve
- [x] stale count/domain/Kimi/Cursor/Hermes wording sweep is clean
- [x] documentation diff contains no credential-like values
- [x] git diff --check
- [x] independent source-to-documentation review found no material contradictions
- [x] docs only; no local app build or install

Generated with [Devin](https://devin.ai)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->