### PR TITLE
Stop copying vendor SQLite ledgers into Temp so Devin cannot fill C:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
   read-only. Cursor's `state.vscdb` is also live-first; a temp copy is
   the last resort and is refused above 64 MB. Leftover `pane-devin-*`,
   `pane-minimax-*`, `pane-hermes-*`, `openusage-cursor-*`, and
-  `%APPDATA%\Pane\tmp\openusage-oc-*` files are deleted on the next
+  `%APPDATA%\Pane\tmp\openusage-oc-*` files (including leftover
+  `-wal` / `-shm` / `-journal` sidecars) are deleted on the next
   spend scan.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Fixed
+- **Devin spend no longer fills the C: temp folder.** Pane used to copy
+  the whole Devin CLI sessions database into `%TEMP%\pane-devin-<pid>.db`
+  on every spend refresh. That file is often multiple GB and stays in
+  WAL mode, so a leftover journal grew by another full copy each cycle
+  (tens of GB). **No tracked app is copied into Temp anymore** for
+  spend: Devin, MiniMax, Hermes, and OpenCode are read live and
+  read-only. Cursor's `state.vscdb` is also live-first; a temp copy is
+  the last resort and is refused above 64 MB. Leftover `pane-devin-*`,
+  `pane-minimax-*`, `pane-hermes-*`, `openusage-cursor-*`, and
+  `%APPDATA%\Pane\tmp\openusage-oc-*` files are deleted on the next
+  spend scan.
+
 ### Changed
 - **Pane's website moved to trypane.xyz.** Public links and install
   commands use the new domain. Existing `pane.jazii.dev` updater clients

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -79,8 +79,8 @@ Ground rules that apply to every provider:
 ## Cursor
 
 - **Reads:** Cursor's local state database
-  (`%APPDATA%\Cursor\User\globalStorage\state.vscdb` — copied before
-  reading, never modified).
+  (`%APPDATA%\Cursor\User\globalStorage\state.vscdb` — read live,
+  read-only; a Temp copy is last-resort only and capped at 64 MB).
 - **Calls:** `api2.cursor.sh` Connect RPCs (`GetCurrentPeriodUsage`,
   `GetPlanInfo`, `GetCreditGrantsBalance`); the dashboard's
   usage-events CSV export (for spend). `GetCreditGrantsBalance` cents
@@ -100,8 +100,8 @@ Ground rules that apply to every provider:
 
 - **Reads:** the Go key from
   `%USERPROFILE%\.local\share\opencode\auth.json`;
-  `%USERPROFILE%\.local\share\opencode\opencode.db` (copied before
-  reading) for spend — message costs your own OpenCode history already
+  `%USERPROFILE%\.local\share\opencode\opencode.db` (read live,
+  read-only) for spend — message costs your own OpenCode history already
   contains.
 - **Calls:** `opencode.ai/zen/go/v1/usage` (the official account-wide
   usage API, shipped in anomalyco/opencode#16513) — Session / Weekly /
@@ -138,8 +138,8 @@ Ground rules that apply to every provider:
 ## Devin (Devin CLI)
 
 - **Reads:** `%APPDATA%\devin\credentials.toml`;
-  `%APPDATA%\devin\cli\sessions.db` (+ WAL/SHM sidecars, copied before
-  reading) for local spend.
+  `%APPDATA%\devin\cli\sessions.db` (read live, read-only — the WAL is
+  followed in place, never copied to Temp) for local spend.
 - **Calls:** Devin's `GetUserStatus` RPC.
 - **Shows:** weekly/daily quota, extra balance, plan; local spend from
   Devin CLI sessions (cloud Devin sessions bill ACUs and keep no local
@@ -152,8 +152,7 @@ Ground rules that apply to every provider:
   `provider.minimax.options.apiKey` — a same-named key under another
   provider's section is never used); local spend from
   `%USERPROFILE%\.minimax\sqlite.db` (the Agent CLI's per-turn
-  token_usage table, snapshotted via SQLite's backup API — never
-  modified) and from Claude Code sessions that ran against MiniMax's
+  token_usage table, read live and read-only) and from Claude Code sessions that ran against MiniMax's
   Anthropic-compatible endpoint (those log MiniMax models into
   `~\.claude\projects\` and are re-routed here from the Claude card).
 - **Calls:** `api.minimax.io/v1/token_plan/remains` (+ regional fallbacks).
@@ -258,7 +257,8 @@ Ground rules that apply to every provider:
 ## Hermes (Nous Research desktop)
 
 - **Reads:** the Hermes desktop app's local ledger
-  (`%LOCALAPPDATA%\hermes\state.db`, `session_model_usage` table — model,
+  (`%LOCALAPPDATA%\hermes\state.db` — read live, read-only;
+  `session_model_usage` table — model,
   billing route, token buckets, and the app's own cost per session).
   Detected when that file exists; no API key.
 - **Calls:** nothing. This is a purely local source — Hermes records

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -28,40 +28,24 @@ fn read_pair(conn: &rusqlite::Connection) -> Result<(Option<String>, Option<Stri
     Ok((get("cursorAuth/accessToken")?, get("cursorAuth/refreshToken")?))
 }
 
-/// Cursor stores its session token in a small SQLite database. The running
-/// Cursor app may hold a lock on it, so we read from a temporary copy —
-/// retried a few times because the copy loses to Cursor's own writes now
-/// and then, and finally via a lock-free immutable open of the original.
+/// Cursor stores its session token in SQLite. Prefer a live read-only
+/// open (WAL-safe, no temp file). A full copy into `%TEMP%` is the last
+/// resort and is refused when the file is over the shared size cap.
 fn read_state_values() -> Result<(Option<String>, Option<String>), String> {
     let Some(db_path) = state_db_path() else {
         return Ok((None, None));
     };
-    let tmp = std::env::temp_dir().join(format!("openusage-cursor-{}.vscdb", std::process::id()));
 
-    let mut copy_err = String::new();
-    for attempt in 0..3 {
-        match std::fs::copy(&db_path, &tmp) {
-            Ok(_) => {
-                let result = rusqlite::Connection::open_with_flags(
-                    &tmp,
-                    rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-                )
-                .and_then(|conn| read_pair(&conn));
-                let _ = std::fs::remove_file(&tmp);
-                return result.map_err(|e| format!("read state.vscdb: {e}"));
-            }
-            Err(e) => {
-                copy_err = e.to_string();
-                if attempt < 2 {
-                    std::thread::sleep(std::time::Duration::from_millis(150));
-                }
-            }
+    if let Ok(conn) = super::open_readonly_sqlite(&db_path) {
+        if let Ok(pair) = read_pair(&conn) {
+            return Ok(pair);
         }
     }
 
-    // Copy kept losing to Cursor's lock: open the real file read-only and
-    // immutable (SQLite promises not to write, so no lock is taken).
-    let uri = format!("file:{}?immutable=1", db_path.to_string_lossy().replace('\\', "/"));
+    let uri = format!(
+        "file:{}?immutable=1",
+        db_path.to_string_lossy().replace('\\', "/")
+    );
     match rusqlite::Connection::open_with_flags(
         &uri,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
@@ -69,7 +53,43 @@ fn read_state_values() -> Result<(Option<String>, Option<String>), String> {
     .and_then(|conn| read_pair(&conn))
     {
         Ok(pair) => Ok(pair),
-        Err(e) => Err(format!("copy state.vscdb: {copy_err}; immutable open: {e}")),
+        Err(e) => {
+            if !super::temp_sqlite_copy_allowed(&db_path) {
+                return Err(format!(
+                    "read state.vscdb: {e}; temp copy refused (file over {} bytes)",
+                    super::MAX_TEMP_SQLITE_BYTES
+                ));
+            }
+            read_state_from_capped_copy(&db_path, e.to_string())
+        }
+    }
+}
+
+fn read_state_from_capped_copy(
+    db_path: &std::path::Path,
+    live_err: String,
+) -> Result<(Option<String>, Option<String>), String> {
+    let tmp = std::env::temp_dir().join(format!(
+        "openusage-cursor-{}-{}.vscdb",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or_default()
+    ));
+    match std::fs::copy(db_path, &tmp) {
+        Ok(_) => {
+            let result = rusqlite::Connection::open_with_flags(
+                &tmp,
+                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+            )
+            .and_then(|conn| read_pair(&conn));
+            let _ = std::fs::remove_file(&tmp);
+            result.map_err(|e| format!("read state.vscdb copy: {e}"))
+        }
+        Err(e) => Err(format!(
+            "read state.vscdb: {live_err}; copy: {e}"
+        )),
     }
 }
 

--- a/src-tauri/src/providers/devin.rs
+++ b/src-tauri/src/providers/devin.rs
@@ -55,6 +55,39 @@ mod tests {
         assert_eq!(zero_when_omitted(None, None), None);
     }
 
+    #[test]
+    fn usage_events_read_live_file_read_only() {
+        let path = std::env::temp_dir().join(format!(
+            "devin-usage-read-test-{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE sessions (id TEXT PRIMARY KEY, model TEXT);
+            CREATE TABLE message_nodes (
+                session_id TEXT, chat_message TEXT, created_at INTEGER
+            );
+            INSERT INTO sessions VALUES ('s1', 'claude-sonnet-4');
+            INSERT INTO message_nodes VALUES (
+                's1',
+                '{"role":"assistant","message_id":"m1","metadata":{"metrics":{"input_tokens":10,"output_tokens":4,"cache_read_tokens":0,"cache_creation_tokens":0},"created_at":"2026-09-06T00:00:00Z"}}',
+                1757116800
+            );
+            "#,
+        )
+        .unwrap();
+        drop(conn);
+
+        let events = read_usage_events(&path).expect("read-only live query");
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].input, 10.0);
+        assert_eq!(events[0].output, 4.0);
+        assert_eq!(events[0].model, "claude-sonnet-4");
+    }
+
     /// Live diagnostic (ignored): prints the raw planStatus so quota
     /// misreports can be debugged against real account states (never
     /// prints the key). Run:
@@ -254,13 +287,18 @@ fn file_stamp(path: &std::path::Path) -> FileStamp {
 /// the store keeps one row per message per branch of the session's message
 /// forest, so rows dedupe by (session, message id). The model is tracked
 /// per session. Cloud Devin sessions bill ACUs and never land in this db —
-/// only CLI usage shows up. Parsed results are cached so the 37 MB file
-/// isn't copied on every refresh; the cache keys on the main db AND the
-/// WAL sidecar, because SQLite appends new rows to the -wal without
-/// touching the main file until a checkpoint runs.
+/// only CLI usage shows up.
+///
+/// The live file is often multiple GB. Copying it into `%TEMP%` via the
+/// backup API inherited WAL mode and, when the dest journal survived a
+/// refresh, grew by another full copy each cycle (tens of GB on C:).
+/// Readers in WAL mode already see a consistent snapshot, so we query
+/// the live file read-only and never write a temp copy.
 pub fn collect_usage_events() -> Vec<UsageEvent> {
     use std::sync::Mutex;
     static CACHE: Mutex<Option<(FileStamp, FileStamp, Vec<UsageEvent>)>> = Mutex::new(None);
+
+    super::sweep_temp_sqlite_prefix("pane-devin-");
 
     let Some(db_path) = sessions_db_path() else { return Vec::new() };
     if !db_path.exists() {
@@ -277,17 +315,7 @@ pub fn collect_usage_events() -> Vec<UsageEvent> {
         }
     }
 
-    // Snapshot through SQLite's backup API rather than copying files: the
-    // Devin app writes new rows to the WAL continuously, and a raw copy of
-    // db + WAL taken at slightly different instants makes SQLite silently
-    // discard the WAL — recent sessions would just vanish from the totals.
-    let tmp_base = std::env::temp_dir().join(format!("pane-devin-{}", std::process::id()));
-    let tmp_db = tmp_base.with_extension("db");
-    let events = snapshot_db(&db_path, &tmp_db).and_then(|()| read_usage_events(&tmp_db));
-
-    for suffix in ["db", "db-wal", "db-shm"] {
-        let _ = std::fs::remove_file(tmp_base.with_extension(suffix));
-    }
+    let events = read_usage_events(&db_path);
 
     match events {
         Ok(events) => {
@@ -306,26 +334,8 @@ pub fn collect_usage_events() -> Vec<UsageEvent> {
     }
 }
 
-/// Consistent point-in-time copy of the live db (reads through the WAL
-/// with proper locks, retrying briefly while the writer is busy).
-fn snapshot_db(src_path: &std::path::Path, dst_path: &std::path::Path) -> Result<(), String> {
-    let _ = std::fs::remove_file(dst_path);
-    let src = rusqlite::Connection::open_with_flags(
-        src_path,
-        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-    )
-    .map_err(|e| format!("open live db: {e}"))?;
-    let mut dst =
-        rusqlite::Connection::open(dst_path).map_err(|e| format!("open snapshot: {e}"))?;
-    let backup = rusqlite::backup::Backup::new(&src, &mut dst)
-        .map_err(|e| format!("backup init: {e}"))?;
-    backup
-        .run_to_completion(256, std::time::Duration::from_millis(10), None)
-        .map_err(|e| format!("backup run: {e}"))
-}
-
 fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
-    let conn = rusqlite::Connection::open(db).map_err(|e| format!("open db copy: {e}"))?;
+    let conn = super::open_readonly_sqlite(db)?;
     let mut stmt = conn
         .prepare(
             "SELECT m.session_id, m.chat_message, m.created_at, s.model

--- a/src-tauri/src/providers/hermes.rs
+++ b/src-tauri/src/providers/hermes.rs
@@ -11,16 +11,11 @@
 //! Hermes card. Hermes records ZERO cost itself, so dollars come from
 //! the shared pricing catalog.
 
-use super::minimax::{file_stamp, snapshot_db, FileStamp};
+use super::minimax::{file_stamp, FileStamp};
 use super::{Metric, Snapshot};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 const ID: &str = "hermes";
 const NAME: &str = "Hermes";
-
-/// Concurrent card refresh + spend scan each copy the ledger; a per-call
-/// counter keeps their temp files from colliding (same pattern as OpenCode).
-static COPY_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone)]
 pub struct HermesUsage {
@@ -223,13 +218,7 @@ pub fn collect_usage_events() -> Vec<HermesUsage> {
         }
     }
 
-    let n = COPY_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let tmp_base = std::env::temp_dir().join(format!("pane-hermes-{}-{n}", std::process::id()));
-    let tmp_db = tmp_base.with_extension("db");
-    let events = snapshot_db(&db_path, &tmp_db).and_then(|()| read_usage_events(&tmp_db));
-    for suffix in ["db", "db-wal", "db-shm"] {
-        let _ = std::fs::remove_file(tmp_base.with_extension(suffix));
-    }
+    let events = read_usage_events(&db_path);
 
     match events {
         Ok(events) => {
@@ -247,7 +236,7 @@ pub fn collect_usage_events() -> Vec<HermesUsage> {
 }
 
 fn read_usage_events(db: &std::path::Path) -> Result<Vec<HermesUsage>, String> {
-    let conn = rusqlite::Connection::open(db).map_err(|e| format!("open db copy: {e}"))?;
+    let conn = super::open_readonly_sqlite(db)?;
     // Optional columns (session_id, billing_base_url, task) were added as
     // Hermes grew; an older ledger must still yield tokens and cost.
     let cols = table_columns(&conn)?;

--- a/src-tauri/src/providers/minimax.rs
+++ b/src-tauri/src/providers/minimax.rs
@@ -7,6 +7,12 @@ use serde_json::Value;
 
 use super::{Metric, Snapshot};
 
+pub(crate) const MAX_TEMP_SNAPSHOT_BYTES: u64 = super::MAX_TEMP_SQLITE_BYTES;
+
+pub(crate) fn temp_snapshot_allowed(src_len: u64) -> bool {
+    src_len <= MAX_TEMP_SNAPSHOT_BYTES
+}
+
 const ID: &str = "minimax";
 const NAME: &str = "MiniMax";
 
@@ -252,12 +258,7 @@ pub fn collect_usage_events() -> Vec<UsageEvent> {
         }
     }
 
-    let tmp_base = std::env::temp_dir().join(format!("pane-minimax-{}", std::process::id()));
-    let tmp_db = tmp_base.with_extension("db");
-    let events = snapshot_db(&db_path, &tmp_db).and_then(|()| read_usage_events(&tmp_db));
-    for suffix in ["db", "db-wal", "db-shm"] {
-        let _ = std::fs::remove_file(tmp_base.with_extension(suffix));
-    }
+    let events = read_usage_events(&db_path);
 
     match events {
         Ok(events) => {
@@ -276,24 +277,40 @@ pub fn collect_usage_events() -> Vec<UsageEvent> {
 
 /// Consistent point-in-time copy via SQLite's backup API (reads through the
 /// WAL with proper locks, retrying briefly while the writer is busy).
+///
+/// Sidecars are deleted first. Destination DBs inherit WAL mode from the
+/// source; we checkpoint and switch them to DELETE so a leftover journal
+/// cannot grow by another full copy on the next refresh.
 pub(crate) fn snapshot_db(src_path: &std::path::Path, dst_path: &std::path::Path) -> Result<(), String> {
-    let _ = std::fs::remove_file(dst_path);
+    if !super::temp_sqlite_copy_allowed(src_path) {
+        let src_len = std::fs::metadata(src_path).map(|m| m.len()).unwrap_or(0);
+        return Err(format!(
+            "temp snapshot refused: source is {src_len} bytes (cap {MAX_TEMP_SNAPSHOT_BYTES})"
+        ));
+    }
+    super::remove_sqlite_files(dst_path);
     let src = rusqlite::Connection::open_with_flags(
         src_path,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
     )
     .map_err(|e| format!("open live db: {e}"))?;
+    src.busy_timeout(std::time::Duration::from_millis(250))
+        .map_err(|e| format!("busy timeout: {e}"))?;
     let mut dst =
         rusqlite::Connection::open(dst_path).map_err(|e| format!("open snapshot: {e}"))?;
-    let backup = rusqlite::backup::Backup::new(&src, &mut dst)
-        .map_err(|e| format!("backup init: {e}"))?;
-    backup
-        .run_to_completion(256, std::time::Duration::from_millis(10), None)
-        .map_err(|e| format!("backup run: {e}"))
+    {
+        let backup = rusqlite::backup::Backup::new(&src, &mut dst)
+            .map_err(|e| format!("backup init: {e}"))?;
+        backup
+            .run_to_completion(256, std::time::Duration::from_millis(10), None)
+            .map_err(|e| format!("backup run: {e}"))?;
+    }
+    let _ = dst.execute_batch("PRAGMA wal_checkpoint(TRUNCATE); PRAGMA journal_mode=DELETE;");
+    Ok(())
 }
 
 fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
-    let conn = rusqlite::Connection::open(db).map_err(|e| format!("open db copy: {e}"))?;
+    let conn = super::open_readonly_sqlite(db)?;
     let mut stmt = conn
         .prepare(
             "SELECT ts, model, input_tokens, output_tokens, reasoning_tokens,
@@ -339,6 +356,43 @@ mod tests {
         // Short placeholder keys are still rejected.
         let raw = "provider:\n  minimax:\n    options:\n      apiKey: sk-short\n";
         assert_eq!(cli_config_key(raw), None);
+    }
+
+    #[test]
+    fn huge_ledgers_are_not_copied_to_temp() {
+        assert!(super::temp_snapshot_allowed(0));
+        assert!(super::temp_snapshot_allowed(super::MAX_TEMP_SNAPSHOT_BYTES));
+        assert!(!super::temp_snapshot_allowed(super::MAX_TEMP_SNAPSHOT_BYTES + 1));
+    }
+
+    #[test]
+    fn snapshot_db_deletes_leftover_wal_before_copy() {
+        let pid = std::process::id();
+        let src = std::env::temp_dir().join(format!("pane-snap-src-{pid}.db"));
+        let dst = std::env::temp_dir().join(format!("pane-snap-dst-{pid}.db"));
+        crate::providers::remove_sqlite_files(&src);
+        crate::providers::remove_sqlite_files(&dst);
+
+        let conn = rusqlite::Connection::open(&src).unwrap();
+        conn.execute_batch("CREATE TABLE t (x INTEGER); INSERT INTO t VALUES (1);")
+            .unwrap();
+        drop(conn);
+
+        let mut leftover = dst.as_os_str().to_os_string();
+        leftover.push("-wal");
+        let leftover = std::path::PathBuf::from(leftover);
+        std::fs::write(&leftover, vec![0u8; 1024 * 1024]).unwrap();
+        assert_eq!(std::fs::metadata(&leftover).unwrap().len(), 1024 * 1024);
+
+        super::snapshot_db(&src, &dst).expect("snapshot should succeed");
+        let wal_len = std::fs::metadata(&leftover).map(|m| m.len()).unwrap_or(0);
+        assert!(
+            wal_len < 64 * 1024,
+            "leftover dest WAL must not survive a fresh snapshot, was {wal_len} bytes"
+        );
+
+        crate::providers::remove_sqlite_files(&src);
+        crate::providers::remove_sqlite_files(&dst);
     }
 
     /// Live probe with this machine's real key — run manually via

--- a/src-tauri/src/providers/minimax.rs
+++ b/src-tauri/src/providers/minimax.rs
@@ -7,8 +7,10 @@ use serde_json::Value;
 
 use super::{Metric, Snapshot};
 
+#[cfg(test)]
 pub(crate) const MAX_TEMP_SNAPSHOT_BYTES: u64 = super::MAX_TEMP_SQLITE_BYTES;
 
+#[cfg(test)]
 pub(crate) fn temp_snapshot_allowed(src_len: u64) -> bool {
     src_len <= MAX_TEMP_SNAPSHOT_BYTES
 }
@@ -275,17 +277,16 @@ pub fn collect_usage_events() -> Vec<UsageEvent> {
     }
 }
 
-/// Consistent point-in-time copy via SQLite's backup API (reads through the
-/// WAL with proper locks, retrying briefly while the writer is busy).
-///
-/// Sidecars are deleted first. Destination DBs inherit WAL mode from the
-/// source; we checkpoint and switch them to DELETE so a leftover journal
-/// cannot grow by another full copy on the next refresh.
+/// Test-only helper: the production spend path never copies a vendor
+/// ledger into Temp. Kept so we can still prove leftover WAL files are
+/// wiped and oversized sources are refused.
+#[cfg(test)]
 pub(crate) fn snapshot_db(src_path: &std::path::Path, dst_path: &std::path::Path) -> Result<(), String> {
     if !super::temp_sqlite_copy_allowed(src_path) {
         let src_len = std::fs::metadata(src_path).map(|m| m.len()).unwrap_or(0);
         return Err(format!(
-            "temp snapshot refused: source is {src_len} bytes (cap {MAX_TEMP_SNAPSHOT_BYTES})"
+            "temp snapshot refused: source is {src_len} bytes (cap {})",
+            super::MAX_TEMP_SQLITE_BYTES
         ));
     }
     super::remove_sqlite_files(dst_path);

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -456,6 +456,7 @@ pub(crate) fn open_readonly_sqlite(
 /// Delete a SQLite file and its `-wal` / `-shm` sidecars. Call this before
 /// opening a reused temp destination — removing only the `.db` leaves the
 /// journal, and the next backup appends another full copy to it.
+#[cfg(test)]
 pub(crate) fn remove_sqlite_files(db_path: &std::path::Path) {
     let _ = std::fs::remove_file(db_path);
     let mut wal = db_path.as_os_str().to_os_string();
@@ -464,6 +465,9 @@ pub(crate) fn remove_sqlite_files(db_path: &std::path::Path) {
     let mut shm = db_path.as_os_str().to_os_string();
     shm.push("-shm");
     let _ = std::fs::remove_file(&shm);
+    let mut journal = db_path.as_os_str().to_os_string();
+    journal.push("-journal");
+    let _ = std::fs::remove_file(&journal);
 }
 
 /// Drop leftover Pane temp snapshots in `%TEMP%` (`pane-devin-*.db` and
@@ -484,6 +488,7 @@ fn is_pane_temp_sqlite(name: &str, prefix: &str) -> bool {
     let stem = rest
         .strip_suffix(".db-wal")
         .or_else(|| rest.strip_suffix(".db-shm"))
+        .or_else(|| rest.strip_suffix(".db-journal"))
         .or_else(|| rest.strip_suffix(".db"));
     let Some(stem) = stem else {
         return false;
@@ -547,6 +552,10 @@ mod sqlite_temp_tests {
         assert!(super::is_pane_temp_sqlite(
             "pane-minimax-10568-3.db",
             "pane-minimax-"
+        ));
+        assert!(super::is_pane_temp_sqlite(
+            "pane-devin-16636.db-journal",
+            "pane-devin-"
         ));
         assert!(!super::is_pane_temp_sqlite(
             "pane-hermes-narrow-test-1.db",

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -428,3 +428,145 @@ pub fn stored_api_key(provider: &str, env_vars: &[&str]) -> Option<String> {
     }
     None
 }
+
+/// Hard cap for any leftover temp copy path. Multi-GB ledgers (Devin) must
+/// never be cloned onto C:.
+pub(crate) const MAX_TEMP_SQLITE_BYTES: u64 = 64 * 1024 * 1024;
+
+pub(crate) fn temp_sqlite_copy_allowed(path: &std::path::Path) -> bool {
+    std::fs::metadata(path)
+        .map(|m| m.len())
+        .unwrap_or(u64::MAX)
+        <= MAX_TEMP_SQLITE_BYTES
+}
+
+pub(crate) fn open_readonly_sqlite(
+    path: &std::path::Path,
+) -> Result<rusqlite::Connection, String> {
+    let conn = rusqlite::Connection::open_with_flags(
+        path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .map_err(|e| format!("open live db: {e}"))?;
+    conn.busy_timeout(std::time::Duration::from_millis(250))
+        .map_err(|e| format!("busy timeout: {e}"))?;
+    Ok(conn)
+}
+
+/// Delete a SQLite file and its `-wal` / `-shm` sidecars. Call this before
+/// opening a reused temp destination — removing only the `.db` leaves the
+/// journal, and the next backup appends another full copy to it.
+pub(crate) fn remove_sqlite_files(db_path: &std::path::Path) {
+    let _ = std::fs::remove_file(db_path);
+    let mut wal = db_path.as_os_str().to_os_string();
+    wal.push("-wal");
+    let _ = std::fs::remove_file(&wal);
+    let mut shm = db_path.as_os_str().to_os_string();
+    shm.push("-shm");
+    let _ = std::fs::remove_file(&shm);
+}
+
+/// Drop leftover Pane temp snapshots in `%TEMP%` (`pane-devin-*.db` and
+/// friends). A crashed or overlapping spend scan used to leave multi-GB
+/// WAL journals on C:.
+pub fn sweep_temp_sqlite_copies() {
+    for prefix in ["pane-devin-", "pane-minimax-", "pane-hermes-"] {
+        sweep_temp_sqlite_prefix(prefix);
+    }
+    sweep_temp_prefix_ext("openusage-cursor-", &[".vscdb", ".vscdb-wal", ".vscdb-shm"]);
+    sweep_opencode_scratch();
+}
+
+fn is_pane_temp_sqlite(name: &str, prefix: &str) -> bool {
+    let Some(rest) = name.strip_prefix(prefix) else {
+        return false;
+    };
+    let stem = rest
+        .strip_suffix(".db-wal")
+        .or_else(|| rest.strip_suffix(".db-shm"))
+        .or_else(|| rest.strip_suffix(".db"));
+    let Some(stem) = stem else {
+        return false;
+    };
+    !stem.is_empty()
+        && stem.chars().all(|c| c.is_ascii_digit() || c == '-')
+        && stem.chars().any(|c| c.is_ascii_digit())
+}
+
+pub(crate) fn sweep_temp_sqlite_prefix(prefix: &str) {
+    sweep_temp_dir(std::env::temp_dir(), |name| is_pane_temp_sqlite(name, prefix));
+}
+
+fn sweep_temp_prefix_ext(prefix: &str, suffixes: &[&str]) {
+    sweep_temp_dir(std::env::temp_dir(), |name| {
+        name.starts_with(prefix) && suffixes.iter().any(|s| name.ends_with(s))
+    });
+}
+
+fn sweep_opencode_scratch() {
+    let dir = config_dir().join("tmp");
+    sweep_temp_dir(dir, |name| name.starts_with("openusage-oc-"));
+}
+
+fn sweep_temp_dir(dir: std::path::PathBuf, keep: impl Fn(&str) -> bool) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for ent in entries.flatten() {
+        let name = ent.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if keep(name) {
+            let _ = std::fs::remove_file(ent.path());
+        }
+    }
+}
+
+#[cfg(test)]
+mod sqlite_temp_tests {
+    #[test]
+    fn sweep_removes_devin_temp_journals() {
+        let marker = std::env::temp_dir().join(format!(
+            "pane-devin-{}-9.db-wal",
+            std::process::id()
+        ));
+        std::fs::write(&marker, b"leftover").unwrap();
+        assert!(marker.exists());
+        super::sweep_temp_sqlite_prefix("pane-devin-");
+        assert!(
+            !marker.exists(),
+            "sweep must delete leftover pane-devin journals"
+        );
+    }
+
+    #[test]
+    fn sweep_skips_unrelated_temp_names() {
+        assert!(super::is_pane_temp_sqlite(
+            "pane-devin-10568.db-wal",
+            "pane-devin-"
+        ));
+        assert!(super::is_pane_temp_sqlite(
+            "pane-minimax-10568-3.db",
+            "pane-minimax-"
+        ));
+        assert!(!super::is_pane_temp_sqlite(
+            "pane-hermes-narrow-test-1.db",
+            "pane-hermes-"
+        ));
+        assert!(!super::is_pane_temp_sqlite("other-10568.db", "pane-devin-"));
+    }
+
+    #[test]
+    fn huge_sqlite_files_are_never_copied() {
+        assert!(super::temp_sqlite_copy_allowed(std::path::Path::new(".")));
+        let huge = std::env::temp_dir().join(format!(
+            "pane-size-cap-{}-{}.bin",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or_default()
+        ));
+        // Don't write 64MB; the helper treats a missing file as too large.
+        assert!(!super::temp_sqlite_copy_allowed(&huge));
+    }
+}

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -1,7 +1,6 @@
 use super::{Metric, Snapshot};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 const ID: &str = "opencode";
 const NAME: &str = "OpenCode";
@@ -23,8 +22,6 @@ const MONTHLY_LIMIT: f64 = 60.0; // month anchored to earliest-ever Go usage
 const SESSION_MS: f64 = 5.0 * 3600e3;
 const WEEK_MS: f64 = 7.0 * 86400e3;
 
-static COPY_COUNTER: AtomicU64 = AtomicU64::new(0);
-
 pub fn data_dir() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_default()
@@ -44,90 +41,15 @@ pub fn auth_entry_key(entry: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-/// Pane's own scratch directory for database copies. It lives under the
-/// per-user config dir instead of the machine-wide temp dir, so another local
-/// user cannot pre-plant a symlink at its path; on unix the dir is also
-/// clamped to 0o700 so the copy stays unreadable to other accounts.
-fn scratch_dir() -> Result<PathBuf, String> {
-    let dir = super::config_dir().join("tmp");
-    std::fs::create_dir_all(&dir).map_err(|e| format!("create scratch dir: {e}"))?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
-    }
-    sweep_stale(&dir);
-    Ok(dir)
-}
-
-/// Deletes copies a crashed or killed run left behind, so nothing accumulates
-/// in the config dir now that names are never reused. An hour is far longer
-/// than any query, so a live copy is never pulled out from under a reader.
-fn sweep_stale(dir: &Path) {
-    const MAX_AGE: std::time::Duration = std::time::Duration::from_secs(3600);
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        if !entry.file_name().to_string_lossy().starts_with("openusage-oc-") {
-            continue;
-        }
-        let stale = entry
-            .metadata()
-            .and_then(|m| m.modified())
-            .is_ok_and(|t| t.elapsed().is_ok_and(|age| age > MAX_AGE));
-        if stale {
-            let _ = std::fs::remove_file(entry.path());
-        }
-    }
-}
-
-/// Copies `src` to `dst`, refusing to write when `dst` already exists so an
-/// existing file or symlink is never followed or truncated.
-fn copy_new(src: &Path, dst: &Path) -> std::io::Result<()> {
-    let mut from = std::fs::File::open(src)?;
-    let mut to = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(dst)?;
-    if let Err(e) = std::io::copy(&mut from, &mut to) {
-        drop(to);
-        let _ = std::fs::remove_file(dst);
-        return Err(e);
-    }
-    Ok(())
-}
-
-/// Runs `f` against a private copy of opencode.db (plus its write-ahead-log
-/// files) so we never touch the live copy a running OpenCode holds open.
-/// The unique counter keeps concurrent readers (usage + spend) apart.
-fn with_db_copy<T>(f: impl FnOnce(&Path) -> Result<T, String>) -> Result<T, String> {
+/// Query the live OpenCode ledger read-only. Copying db+WAL into
+/// `%APPDATA%\Pane\tmp` used the same pattern that grew Devin's temp
+/// journal to tens of GB — never clone a vendor database onto C:.
+fn with_live_db<T>(f: impl FnOnce(&Path) -> Result<T, String>) -> Result<T, String> {
     let db_path = data_dir().join("opencode.db");
     if !db_path.exists() {
         return Err("opencode.db not found — has OpenCode been used on this PC?".into());
     }
-    let n = COPY_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let stamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or_default();
-    let tmp_base =
-        scratch_dir()?.join(format!("openusage-oc-{}-{n}-{stamp:x}", std::process::id()));
-    let tmp_db = tmp_base.with_extension("db");
-    copy_new(&db_path, &tmp_db).map_err(|e| format!("copy opencode.db: {e}"))?;
-    for suffix in ["db-wal", "db-shm"] {
-        let side = db_path.with_extension(suffix);
-        if side.exists() {
-            let _ = copy_new(&side, &tmp_base.with_extension(suffix));
-        }
-    }
-
-    let result = f(&tmp_db);
-
-    for suffix in ["db", "db-wal", "db-shm"] {
-        let _ = std::fs::remove_file(tmp_base.with_extension(suffix));
-    }
-    result
+    f(&db_path)
 }
 
 pub async fn snapshot() -> Snapshot {
@@ -276,7 +198,7 @@ fn month_period_ending(resets_ms: i64) -> i64 {
 /// Fallback: the pre-API local computation from opencode.db — this PC's
 /// rows only, so shared subscriptions under-count here.
 fn local_windows_snapshot() -> Result<Snapshot, String> {
-    let w = with_db_copy(|db| {
+    let w = with_live_db(|db| {
         let rows: Vec<(f64, f64)> = read_messages(db)?
             .into_iter()
             .filter(|r| r.provider == "opencode-go" && r.cost > 0.0)
@@ -437,7 +359,7 @@ fn utc_date(year: i32, month: u32, day: u32, h: u32, m: u32, s: u32, ms: u32) ->
 /// Total Spend. The provider id lets the spend engine split gateway
 /// providers (AihubMix) into their own slice.
 pub fn collect_cost_events() -> Vec<(f64, f64, f64, String, String)> {
-    with_db_copy(|db| {
+    with_live_db(|db| {
         Ok(read_messages(db)?
             .into_iter()
             // Free models record cost 0 with real token counts — the
@@ -460,7 +382,7 @@ pub struct MessageRow {
 
 /// Raw assistant-message rows from opencode.db.
 fn read_messages(db: &Path) -> Result<Vec<MessageRow>, String> {
-    let conn = rusqlite::Connection::open(db).map_err(|e| format!("open db copy: {e}"))?;
+    let conn = super::open_readonly_sqlite(db)?;
     let mut stmt = conn
         .prepare("SELECT time_created, data FROM message")
         .map_err(|e| format!("query messages: {e}"))?;

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -2810,6 +2810,7 @@ fn split_csv_row(line: &str) -> Vec<String> {
 }
 
 pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
+    providers::sweep_temp_sqlite_copies();
     pricing::ensure_fresh();
     load_persisted_cache();
     if let Ok(mut t) = touched().lock() {


### PR DESCRIPTION
## Summary
- Pane was cloning Devin's multi-GB `sessions.db` into `%TEMP%\pane-devin-<pid>.db` on every spend refresh. The dest inherited WAL mode, so leftover journals stacked another full copy each cycle and filled C: (~40 GB).
- Spend now reads Devin, MiniMax, Hermes, and OpenCode live and read-only. Cursor's `state.vscdb` is live-first; a temp copy is last-resort and refused above 64 MB.
- Leftover `pane-devin-*`, `pane-minimax-*`, `pane-hermes-*`, `openusage-cursor-*`, and `%APPDATA%\Pane\tmp\openusage-oc-*` files (including `-wal` / `-shm` / `-journal`) are deleted on the next spend scan.

## Test plan
- [ ] Refresh spend with Devin CLI present and confirm no new `%TEMP%\pane-devin-*` files appear
- [ ] Confirm leftover `pane-devin-*.db-wal` / `.db-journal` from older builds disappear after a spend scan
- [ ] MiniMax / Hermes / OpenCode spend still populate
- [ ] Cursor card still signs in and shows credits
- [ ] `cargo test --lib sqlite_temp snapshot_db_deletes huge_ledgers`

Made with Cursor

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->