### PR TITLE
Price GPT-6 Astra and Gemini 3.8 Flash; Esc hides the popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased
 
 ### Fixed
+- **GPT-6 Astra and Gemini 3.8 Flash spend again.** Those slugs were
+  still missing from the baked price table, so Cursor/Codex/Claude
+  tiles dropped them into the unpriced ⚠ bucket. Astra is OpenAI's
+  $10/$50 list (long-context $20/$75 above 272k on Codex); Gemini 3.8
+  Flash is Google's $0.75/$3.75 introductory API rate.
+- **Esc on the dashboard hides the popover.** Customize and Settings
+  still back out first. IME candidate-window Esc is ignored.
 - **Devin spend no longer fills the C: temp folder.** Pane used to copy
   the whole Devin CLI sessions database into `%TEMP%\pane-devin-<pid>.db`
   on every spend refresh. That file is often multiple GB and stays in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
   still missing from the baked price table, so Cursor/Codex/Claude
   tiles dropped them into the unpriced ⚠ bucket. Astra is OpenAI's
   $10/$50 list (long-context $20/$75 above 272k on Codex); Gemini 3.8
-  Flash is Google's $0.75/$3.75 introductory API rate.
+  Flash is Google's $0.75/$3.75 introductory API rate. Dated Codex
+  slugs (`gpt-6-astra-2026-09-01`) use the same Astra card. Cached
+  unpriced totals from before this update are discarded.
 - **Esc on the dashboard hides the popover.** Customize and Settings
   still back out first. IME candidate-window Esc is ignored.
 - **Devin spend no longer fills the C: temp folder.** Pane used to copy

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2484,6 +2484,20 @@ fn set_webview_memory_level(window: &tauri::WebviewWindow, low: bool) {
     });
 }
 
+/// Hide the dashboard without the tray-click reopen dance. Esc on the
+/// dashboard (and the hide half of the tray toggle) both land here so
+/// the webview still drops to the low-memory target.
+#[tauri::command]
+fn hide_popover(app: tauri::AppHandle) {
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+    if window.is_visible().unwrap_or(false) {
+        let _ = window.hide();
+        set_webview_memory_level(&window, true);
+    }
+}
+
 fn toggle_popover(app: &tauri::AppHandle, click: tauri::PhysicalPosition<f64>) {
     let Some(window) = app.get_webview_window("main") else {
         return;
@@ -2558,7 +2572,8 @@ pub fn run() {
             set_shortcut,
             codex_redeem_credit,
             install_update,
-            check_update
+            check_update,
+            hide_popover
         ])
         .setup(|app| {
             spawn_update_checker(app.handle());

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -858,6 +858,24 @@ fn builtin_price(canonical: &str) -> Option<Price> {
             cache_write_200k: Some(4.0),
             ..Price::flat(2.0, 6.0, 0.5, 2.0)
         }),
+        // GPT-6 Astra — OpenAI list (developers.openai.com/api/docs/models/gpt-6-astra):
+        // $10 / $50 / $1 cache read / $12.50 cache write. Prompts above
+        // 272k (Codex path) or 200k (generic request_cost) bill the
+        // whole request at $20 / $75 / $2 / $25. Public catalogs do not
+        // carry this slug yet; without a baked row, spend tiles go blank.
+        "gpt-6-astra" => Some(Price {
+            input_200k: Some(20.0),
+            output_200k: Some(75.0),
+            cache_read_200k: Some(2.0),
+            cache_write_200k: Some(25.0),
+            ..Price::flat(10.0, 50.0, 1.0, 12.5)
+        }),
+        // Gemini 3.8 Flash — Google API list through 2026-12-31
+        // (ai.google.dev/gemini-api/docs/pricing): $0.75 in / $3.75 out /
+        // $0.075 cache read / $0.75 cache write. Cursor effort tails
+        // (-high, -xhigh) peel in resolve(); preview is its own SKU.
+        "gemini-3.8-flash" | "gemini-3-8-flash" | "gemini-3.8-flash-preview"
+        | "cursor-gemini-3.8-flash" => Some(Price::flat(0.75, 3.75, 0.075, 0.75)),
         _ => None,
     }
 }
@@ -1083,6 +1101,43 @@ mod tests {
         let fast = super::resolve(&store, "grok-4.6-fast", 0).unwrap();
         assert_eq!((fast.input, fast.output, fast.cache_read), (4.0, 12.0, 1.0));
         assert_eq!(fast.input_200k, Some(8.0));
+    }
+
+    #[test]
+    fn gpt6_astra_and_gemini_38_flash_price_before_catalogs() {
+        let store = super::Store::default();
+        for slug in ["gpt-6-astra", "openai/gpt-6-astra", "gpt-6-astra-high"] {
+            let p = super::resolve(&store, slug, 0)
+                .unwrap_or_else(|| panic!("{slug} did not price"));
+            assert_eq!(
+                (p.input, p.output, p.cache_read, p.cache_write),
+                (10.0, 50.0, 1.0, 12.5),
+                "{slug}"
+            );
+            assert_eq!(
+                (p.input_200k, p.output_200k, p.cache_read_200k),
+                (Some(20.0), Some(75.0), Some(2.0)),
+                "{slug}"
+            );
+        }
+        let fast = super::resolve(&store, "gpt-6-astra-fast", 0).unwrap();
+        assert_eq!((fast.input, fast.output, fast.cache_read), (20.0, 100.0, 2.0));
+
+        for slug in [
+            "gemini-3.8-flash",
+            "google/gemini-3.8-flash",
+            "gemini-3.8-flash-high",
+            "gemini-3.8-flash-preview",
+            "cursor-gemini-3.8-flash",
+        ] {
+            let p = super::resolve(&store, slug, 0)
+                .unwrap_or_else(|| panic!("{slug} did not price"));
+            assert_eq!(
+                (p.input, p.output, p.cache_read, p.cache_write),
+                (0.75, 3.75, 0.075, 0.75),
+                "{slug}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -166,7 +166,7 @@ pub fn generation() -> u64 {
 /// fingerprinted below — an app update that reprices the same files would
 /// otherwise leave history at the old dollars until upstream happens to
 /// rewrite a catalog.
-const CORRECTIONS_REV: u32 = 10; // 10: AihubMix Qwen3.8-Max-0902 snapshot pricing
+const CORRECTIONS_REV: u32 = 11; // 11: GPT-6 Astra + Gemini 3.8 Flash baked rates
 
 /// The corrections revision on its own — the spend cache treats a changed
 /// revision as a hard discard (the *code* that prices changed), while a

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -1349,7 +1349,18 @@ fn codex_line(st: &mut CodexFileState, line: &str, data: &mut FileData) {
         _ => (rate_source.clone(), false),
     };
     let lower = rate_source.to_lowercase();
-    let base_price = probe_lookup(&rate_model);
+    // Date-stamped Codex names ("gpt-6-astra-2026-09-01") miss the exact
+    // builtin. Strip the stamp before the price lookup so Astra (and any
+    // later dated GPT) uses the baked card, not generic GPT-5 rates.
+    // The breakdown still records the original `model` name.
+    let dated = codex_dated_base(&rate_model.to_lowercase());
+    let base_price = probe_lookup(&rate_model).or_else(|| {
+        if !rate_model.eq_ignore_ascii_case(&dated) {
+            probe_lookup(&dated)
+        } else {
+            None
+        }
+    });
     let price = base_price
         .or_else(|| if alias_fast { probe_lookup(&rate_source) } else { None })
         .or_else(|| {
@@ -1366,8 +1377,6 @@ fn codex_line(st: &mut CodexFileState, line: &str, data: &mut FileData) {
         note_unpriced(data, ts, &model, tokens);
         return;
     };
-
-    let dated = codex_dated_base(&rate_model.to_lowercase());
     let mut threshold = 200_000.0;
     if let Some((i, o, cr)) = codex_long_context(&dated) {
         p.input_200k = Some(i);
@@ -2164,6 +2173,24 @@ mod tests {
         assert_ne!(doc.version, PERSIST_VERSION);
     }
 
+    /// Astra/Gemini baked rates bumped CORRECTIONS_REV. A cache written
+    /// under 10 would load without probe replay and keep unpriced totals
+    /// if the revision still matched.
+    #[test]
+    fn stale_corrections_revision_is_not_current() {
+        assert!(
+            pricing::corrections_rev() >= 11,
+            "Astra/Gemini rates must bump CORRECTIONS_REV"
+        );
+        let stale = r#"{"version":3,"pricing_stamp":"x","corrections":10,"entries":[]}"#;
+        let doc: PersistFile = serde_json::from_str(stale).unwrap();
+        assert_ne!(
+            doc.corrections,
+            pricing::corrections_rev(),
+            "rev 10 must not match the live corrections revision"
+        );
+    }
+
     // ---- Price probes: catalog-refresh revalidation ------------------------
 
     /// Probes replay against the live catalog: an unknown model recorded as
@@ -2460,6 +2487,71 @@ mod tests {
         assert_eq!(codex_dated_base("gpt-6-astra-2026-09-01"), "gpt-6-astra");
         assert_eq!(codex_long_context("gpt-6-astra"), Some((20.0, 75.0, 2.0)));
         assert_eq!(codex_priority_multiplier("gpt-6-astra", "gpt-6-astra"), 2.0);
+    }
+
+    fn dated_astra_session(model: &str, input: f64, output: f64, fast: bool) -> FileData {
+        let mut lines = vec![
+            json!({"timestamp": "2026-09-01T10:00:00Z", "type": "turn_context",
+                   "payload": {"model": model}})
+            .to_string(),
+        ];
+        if fast {
+            lines.push(
+                json!({"timestamp": "2026-09-01T10:00:00Z", "type": "event_msg",
+                       "payload": {"type": "thread_settings_applied",
+                                   "thread_settings": {"service_tier": "fast"}}})
+                .to_string(),
+            );
+        }
+        lines.push(token_count_line(
+            "2026-09-01T10:00:01Z",
+            Some((input, output)),
+            (input, output),
+        ));
+        codex_run(&lines)
+    }
+
+    /// Date-stamped Astra must use the baked $10/$50 card (and $20/$75
+    /// above 272k), not generic GPT-5 rates. Fast is 2×. The breakdown
+    /// keeps the dated name.
+    #[test]
+    fn dated_astra_uses_builtin_rates_below_and_above_272k() {
+        let low_in = 1_000.0;
+        let high_in = 273_000.0;
+        let out = 1_000.0;
+        let expect_low = (low_in * 10.0 + out * 50.0) / 1e6;
+        let expect_high = (high_in * 20.0 + out * 75.0) / 1e6;
+        let generic_low = (low_in * 1.25 + out * 10.0) / 1e6;
+
+        for model in ["gpt-6-astra-2026-09-01", "gpt-6-astra-20260901"] {
+            let standard = dated_astra_session(model, low_in, out, false);
+            assert!(standard.unpriced.is_empty(), "{model}: {:?}", standard.unpriced);
+            assert!(
+                standard.days.keys().all(|(_, m)| m == model),
+                "{model} breakdown renamed: {:?}",
+                standard.days.keys().collect::<Vec<_>>()
+            );
+            let got = cost_sum(&standard);
+            assert!(
+                (got - expect_low).abs() < 1e-9,
+                "{model} low cost {got}, want {expect_low} (generic GPT would be {generic_low})"
+            );
+
+            let fast = dated_astra_session(model, low_in, out, true);
+            assert!((cost_sum(&fast) / got - 2.0).abs() < 1e-9, "{model} fast low");
+
+            let high = dated_astra_session(model, high_in, out, false);
+            let got_high = cost_sum(&high);
+            assert!(
+                (got_high - expect_high).abs() < 1e-9,
+                "{model} high cost {got_high}, want {expect_high}"
+            );
+            let fast_high = dated_astra_session(model, high_in, out, true);
+            assert!(
+                (cost_sum(&fast_high) / got_high - 2.0).abs() < 1e-9,
+                "{model} fast high"
+            );
+        }
     }
 
     // ---- Claude: advisor iterations, sidechain dedup, synthetic ----------

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -1182,7 +1182,8 @@ fn codex_priority_multiplier(dated: &str, rate_model: &str) -> f64 {
     }
     match dated {
         "gpt-5.5" | "gpt-5.5-pro" => 2.5,
-        "gpt-5.4" | "gpt-5.4-pro" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna" => 2.0,
+        "gpt-5.4" | "gpt-5.4-pro" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna"
+        | "gpt-6-astra" => 2.0,
         _ => {
             let m = probe_fast_multiplier(rate_model);
             if m == 1.0 { 2.0 } else { m }
@@ -1202,6 +1203,7 @@ fn codex_long_context(dated: &str) -> Option<(f64, f64, f64)> {
         // base rates (terra used to share gpt-5.4's row).
         "gpt-5.6-terra" => Some((4.0, 18.0, 0.4)),
         "gpt-5.6-luna" => Some((0.4, 1.8, 0.04)),
+        "gpt-6-astra" => Some((20.0, 75.0, 2.0)),
         _ => None,
     }
 }
@@ -2455,6 +2457,9 @@ mod tests {
         assert_eq!(codex_dated_base("gpt-5.6-sol-20260601"), "gpt-5.6-sol");
         assert_eq!(codex_dated_base("gpt-5.6-sol"), "gpt-5.6-sol");
         assert_eq!(codex_dated_base("gpt-4-0125-preview"), "gpt-4-0125-preview");
+        assert_eq!(codex_dated_base("gpt-6-astra-2026-09-01"), "gpt-6-astra");
+        assert_eq!(codex_long_context("gpt-6-astra"), Some((20.0, 75.0, 2.0)));
+        assert_eq!(codex_priority_multiplier("gpt-6-astra", "gpt-6-astra"), 2.0);
     }
 
     // ---- Claude: advisor iterations, sidechain dedup, synthetic ----------

--- a/src/main.ts
+++ b/src/main.ts
@@ -4220,10 +4220,15 @@ window.addEventListener("DOMContentLoaded", () => {
       e.preventDefault();
       undoLayout();
     }
-    // Esc backs out of Customize/Settings (Mac parity).
-    if (e.key === "Escape") {
-      setDrawer(false);
-      setSettings(false);
+    // Esc backs out of Customize/Settings; on the dashboard it hides the
+    // popover (Mac parity). IME candidate cancel must not close anything.
+    if (e.key === "Escape" && !e.isComposing && e.keyCode !== 229) {
+      if (customizeOpen || document.body.classList.contains("settings-open")) {
+        setDrawer(false);
+        setSettings(false);
+      } else {
+        void invoke("hide_popover");
+      }
     }
     // Ctrl+R refreshes data — and must NOT reload the webview.
     if (e.ctrlKey && e.key.toLowerCase() === "r") {


### PR DESCRIPTION
## Summary
- Bake GPT-6 Astra (OpenAI $10/$50, Codex long-context $20/$75 above 272k) and Gemini 3.8 Flash (Google $0.75/$3.75) so Cursor/Codex/Claude spend no longer drops those slugs into the unpriced warning.
- Esc on the dashboard hides the popover (Customize/Settings still back out first). IME candidate-window Esc is ignored.

## Test plan
- [x] Local install of same-numbered 0.4.46; jazii confirmed
- [ ] Esc on the dashboard hides Pane; tray click brings it back
- [ ] Esc in Settings/Customize backs out first, second Esc hides
- [ ] Astra / Gemini 3.8 Flash spend rows show dollars when those models were used
- [x] `cargo test --lib gpt6_astra_and_gemini` and `codex_dated_base_strips`

Made with Cursor

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->