### PR TITLE
Release 0.4.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.47 — 2026-09-07
 
 ### Fixed
 - **GPT-6 Astra and Gemini 3.8 Flash spend again.** Those slugs were

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,13 @@
 # Roadmap — full Mac parity (and beyond)
 
-**Status (v0.4.46, 2026-09-02): every wave below is shipped, and the
+**Status (v0.4.47, 2026-09-07): every wave below is shipped, and the
 post-launch releases keep going.** Pane has full feature parity with the
 macOS original plus 22 providers, multi-site One/New API key management,
 Kimi Code plan keys without a CLI login, resilient modern Cursor plan
 fallbacks, English/Chinese/Russian UI, signed CI updates, live model
 pricing, and a Mac-parity design pass (inset cards, wedge spend donut,
-in-popover drag reorder, curated share cards). The primary site is now
-`trypane.xyz`; app-side updater migration is on main for the next release.
+in-popover drag reorder, curated share cards). The primary site is
+`trypane.xyz`, and this cut ships the app-side updater order.
 What comes next is demand-driven — open an issue for the provider or
 feature you're missing. Candidates on deck: Windsurf and JetBrains AI
 providers, a Re-detect Tools button, tray "Bars" icon style, and code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.46",
+  "version": "0.4.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.46",
+      "version": "0.4.47",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.46",
+  "version": "0.4.47",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.46"
+version = "0.4.47"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.46"
+version = "0.4.47"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.46",
+  "version": "0.4.47",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Version bump to **0.4.47**: `tauri.conf.json`, `package.json`, `Cargo.toml`, both lockfiles, ROADMAP status line.
- CHANGELOG Unreleased retitled **0.4.47 — 2026-09-07**. Prior **0.4.46** header kept.

Ships on main: #189 GPT-6 Astra and Gemini 3.8 Flash prices plus Esc hides the popover, #187 Devin/MiniMax/Hermes/OpenCode no longer copy SQLite ledgers into Temp, #179 trypane.xyz site and updater order.

No Grok Bot work in this cut. No local install — jazii will take the in-app update.

## Test plan
- [ ] Release CI publishes `v0.4.47` installer + `latest.json`
- [ ] `trypane.xyz/api/update?current=0.4.46` serves 0.4.47
- [ ] Winget workflow opens the version PR
- [ ] CHANGELOG on the GitHub release lists Astra/Gemini, Esc, Devin temp, trypane.xyz

Made with Cursor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->