### PR TITLE
Bump rusqlite past FTS5 CVEs and bound SQLite ledger reads

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,18 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,7 +851,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1055,7 +1043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1629,11 +1617,11 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "ahash",
+ "foldhash",
 ]
 
 [[package]]
@@ -1641,14 +1629,17 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "a596f1b20ed2cc5ecac41a164aaebc7258057060f06c0cf7a2ba3991ee7990fb"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2219,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2362,7 +2353,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2716,6 +2707,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "dirs 6.0.0",
+ "getrandom 0.2.17",
  "prost",
  "regex",
  "reqwest 0.12.28",
@@ -3117,7 +3109,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3374,10 +3366,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.32.1"
+name = "rsqlite-vfs"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator",
@@ -3385,6 +3387,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -3412,7 +3415,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3469,7 +3472,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3872,7 +3875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3921,6 +3924,18 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4477,7 +4492,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4876,7 +4891,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4905,7 +4920,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5314,7 +5329,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,7 +35,8 @@ tokio = { version = "1", features = ["macros", "process", "sync", "time"] }
 chrono = "0.4"
 base64 = "0.22"
 dirs = "6"
-rusqlite = { version = "0.32", features = ["bundled", "backup"] }
+getrandom = "0.2"
+rusqlite = { version = "0.40", features = ["bundled", "backup"] }
 toml = "0.8"
 regex = "1"
 prost = "0.13" # Grok GetRemainingResets protobuf codec

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -29,8 +29,8 @@ fn read_pair(conn: &rusqlite::Connection) -> Result<(Option<String>, Option<Stri
 }
 
 /// Cursor stores its session token in SQLite. Prefer a live read-only
-/// open (WAL-safe, no temp file). A full copy into `%TEMP%` is the last
-/// resort and is refused when the file is over the shared size cap.
+/// open (WAL-safe, no temp file). A copy into `%TEMP%` is the last resort,
+/// capped as it is written — a size pre-check would race the copy.
 fn read_state_values() -> Result<(Option<String>, Option<String>), String> {
     let Some(db_path) = state_db_path() else {
         return Ok((None, None));
@@ -53,15 +53,7 @@ fn read_state_values() -> Result<(Option<String>, Option<String>), String> {
     .and_then(|conn| read_pair(&conn))
     {
         Ok(pair) => Ok(pair),
-        Err(e) => {
-            if !super::temp_sqlite_copy_allowed(&db_path) {
-                return Err(format!(
-                    "read state.vscdb: {e}; temp copy refused (file over {} bytes)",
-                    super::MAX_TEMP_SQLITE_BYTES
-                ));
-            }
-            read_state_from_capped_copy(&db_path, e.to_string())
-        }
+        Err(e) => read_state_from_capped_copy(&db_path, e.to_string()),
     }
 }
 
@@ -77,7 +69,11 @@ fn read_state_from_capped_copy(
             .map(|d| d.as_nanos())
             .unwrap_or_default()
     ));
-    match std::fs::copy(db_path, &tmp) {
+    match copy_capped(db_path, &tmp, super::MAX_TEMP_SQLITE_BYTES) {
+        Ok(copied) if copied > super::MAX_TEMP_SQLITE_BYTES => Err(format!(
+            "read state.vscdb: {live_err}; temp copy refused (file over {} bytes)",
+            super::MAX_TEMP_SQLITE_BYTES
+        )),
         Ok(_) => {
             let result = rusqlite::Connection::open_with_flags(
                 &tmp,
@@ -87,10 +83,28 @@ fn read_state_from_capped_copy(
             let _ = std::fs::remove_file(&tmp);
             result.map_err(|e| format!("read state.vscdb copy: {e}"))
         }
-        Err(e) => Err(format!(
-            "read state.vscdb: {live_err}; copy: {e}"
-        )),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(format!("read state.vscdb: {live_err}; copy: {e}"))
+        }
     }
+}
+
+/// `std::fs::copy` with a hard byte ceiling: reads through `take(cap + 1)`
+/// so a source that grows — or is swapped — after any size check still
+/// cannot write past the cap. A copy that trips the cap is deleted and the
+/// returned count (> cap) tells the caller to refuse it.
+fn copy_capped(src: &std::path::Path, dst: &std::path::Path, cap: u64) -> std::io::Result<u64> {
+    use std::io::Read as _;
+    let mut reader = std::io::BufReader::new(std::fs::File::open(src)?).take(cap + 1);
+    let mut writer = std::fs::File::create(dst)?;
+    let copied = std::io::copy(&mut reader, &mut writer)?;
+    if copied > cap {
+        // Windows refuses to unlink an open handle.
+        drop(writer);
+        let _ = std::fs::remove_file(dst);
+    }
+    Ok(copied)
 }
 
 /// Values in ItemTable are sometimes stored as JSON strings ("\"abc\"").
@@ -1125,6 +1139,52 @@ mod tests {
     fn bonus_zero_hides() {
         assert!(bonus_metric(&json!({"bonusSpend": 0}), Some(10.0)).is_none());
         assert!(bonus_metric(&json!({}), Some(10.0)).is_none());
+    }
+
+    #[test]
+    fn capped_copy_stops_at_the_cap_and_cleans_up() {
+        let pid = std::process::id();
+        let src = std::env::temp_dir().join(format!("pane-cursor-cap-src-{pid}.bin"));
+        let dst = std::env::temp_dir().join(format!("pane-cursor-cap-dst-{pid}.bin"));
+        std::fs::write(&src, vec![7u8; 4096]).unwrap();
+
+        // Over the cap: the reader stops at cap + 1 and the partial copy
+        // is deleted.
+        let copied = copy_capped(&src, &dst, 1024).unwrap();
+        assert_eq!(copied, 1025);
+        assert!(!dst.exists(), "over-cap temp copy must be removed");
+
+        // Under the cap: a byte-exact copy.
+        let copied = copy_capped(&src, &dst, 8192).unwrap();
+        assert_eq!(copied, 4096);
+        assert_eq!(std::fs::read(&dst).unwrap(), vec![7u8; 4096]);
+
+        let _ = std::fs::remove_file(&src);
+        let _ = std::fs::remove_file(&dst);
+    }
+
+    #[test]
+    fn temp_copy_fallback_reads_a_real_state_db() {
+        let src = std::env::temp_dir().join(format!(
+            "pane-cursor-state-test-{}.vscdb",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&src);
+        let conn = rusqlite::Connection::open(&src).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT);
+             INSERT INTO ItemTable VALUES
+                ('cursorAuth/accessToken', 'acc'),
+                ('cursorAuth/refreshToken', 'ref');",
+        )
+        .unwrap();
+        drop(conn);
+
+        let (access, refresh) =
+            read_state_from_capped_copy(&src, "live open failed".into()).expect("copy reads");
+        assert_eq!(access.as_deref(), Some("acc"));
+        assert_eq!(refresh.as_deref(), Some("ref"));
+        let _ = std::fs::remove_file(&src);
     }
 }
 

--- a/src-tauri/src/providers/hermes.rs
+++ b/src-tauri/src/providers/hermes.rs
@@ -266,6 +266,7 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<HermesUsage>, String> {
                 COALESCE(actual_cost_usd, 0.0), COALESCE(estimated_cost_usd, 0.0),
                 {session_expr}, {url_expr}, {task_expr}
          FROM session_model_usage
+         ORDER BY last_seen DESC
          LIMIT {max_rows}"
     );
     let mut stmt = conn
@@ -294,7 +295,7 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<HermesUsage>, String> {
     let events: Vec<HermesUsage> = rows.flatten().collect();
     if events.len() as u64 >= super::MAX_LEDGER_ROWS {
         eprintln!(
-            "[pane] hermes: session_model_usage hit the {}-row read cap — spend totals are truncated",
+            "[pane] hermes: session_model_usage hit the {}-row read cap — keeping newest rows, oldest usage is dropped",
             super::MAX_LEDGER_ROWS
         );
     }

--- a/src-tauri/src/providers/hermes.rs
+++ b/src-tauri/src/providers/hermes.rs
@@ -256,13 +256,17 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<HermesUsage>, String> {
         "''"
     };
     // last_seen/first_seen are epoch seconds as REAL; costs may be NULL.
+    // Everything interpolated into this SQL is a fixed literal — never
+    // ledger data.
+    let max_rows = super::MAX_LEDGER_ROWS;
     let sql = format!(
         "SELECT last_seen, model, billing_provider,
                 input_tokens, output_tokens, reasoning_tokens,
                 cache_read_tokens, cache_write_tokens,
                 COALESCE(actual_cost_usd, 0.0), COALESCE(estimated_cost_usd, 0.0),
                 {session_expr}, {url_expr}, {task_expr}
-         FROM session_model_usage"
+         FROM session_model_usage
+         LIMIT {max_rows}"
     );
     let mut stmt = conn
         .prepare(&sql)
@@ -287,7 +291,14 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<HermesUsage>, String> {
             })
         })
         .map_err(|e| format!("read session_model_usage: {e}"))?;
-    Ok(rows.flatten().collect())
+    let events: Vec<HermesUsage> = rows.flatten().collect();
+    if events.len() as u64 >= super::MAX_LEDGER_ROWS {
+        eprintln!(
+            "[pane] hermes: session_model_usage hit the {}-row read cap — spend totals are truncated",
+            super::MAX_LEDGER_ROWS
+        );
+    }
+    Ok(events)
 }
 
 fn table_columns(conn: &rusqlite::Connection) -> Result<Vec<String>, String> {

--- a/src-tauri/src/providers/minimax.rs
+++ b/src-tauri/src/providers/minimax.rs
@@ -317,6 +317,7 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
             "SELECT ts, model, input_tokens, output_tokens, reasoning_tokens,
                     cache_read_tokens, cache_write_tokens, cost_usd
              FROM token_usage
+             ORDER BY ts DESC
              LIMIT {}",
             super::MAX_LEDGER_ROWS
         ))
@@ -338,7 +339,7 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
     let events: Vec<UsageEvent> = rows.flatten().collect();
     if events.len() as u64 >= super::MAX_LEDGER_ROWS {
         eprintln!(
-            "[pane] minimax: token_usage hit the {}-row read cap — spend totals are truncated",
+            "[pane] minimax: token_usage hit the {}-row read cap — keeping newest rows, oldest usage is dropped",
             super::MAX_LEDGER_ROWS
         );
     }

--- a/src-tauri/src/providers/minimax.rs
+++ b/src-tauri/src/providers/minimax.rs
@@ -313,11 +313,13 @@ pub(crate) fn snapshot_db(src_path: &std::path::Path, dst_path: &std::path::Path
 fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
     let conn = super::open_readonly_sqlite(db)?;
     let mut stmt = conn
-        .prepare(
+        .prepare(&format!(
             "SELECT ts, model, input_tokens, output_tokens, reasoning_tokens,
                     cache_read_tokens, cache_write_tokens, cost_usd
-             FROM token_usage",
-        )
+             FROM token_usage
+             LIMIT {}",
+            super::MAX_LEDGER_ROWS
+        ))
         .map_err(|e| format!("query token_usage: {e}"))?;
     let rows = stmt
         .query_map([], |row| {
@@ -333,7 +335,14 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
             })
         })
         .map_err(|e| format!("read token_usage: {e}"))?;
-    Ok(rows.flatten().collect())
+    let events: Vec<UsageEvent> = rows.flatten().collect();
+    if events.len() as u64 >= super::MAX_LEDGER_ROWS {
+        eprintln!(
+            "[pane] minimax: token_usage hit the {}-row read cap — spend totals are truncated",
+            super::MAX_LEDGER_ROWS
+        );
+    }
+    Ok(events)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -434,6 +434,15 @@ pub fn stored_api_key(provider: &str, env_vars: &[&str]) -> Option<String> {
 /// never be cloned onto C:.
 pub(crate) const MAX_TEMP_SQLITE_BYTES: u64 = 64 * 1024 * 1024;
 
+/// Row cap for full-table ledger reads (Hermes, MiniMax, OpenCode). Real
+/// ledgers never get near it; a runaway vendor db must not materialize an
+/// unbounded Vec.
+pub(crate) const MAX_LEDGER_ROWS: u64 = 2_000_000;
+
+// Test-only: production callers enforce the cap on the copy as it is
+// written — a size pre-check races the copy. Minimax's test-only snapshot
+// helper still uses this.
+#[cfg(test)]
 pub(crate) fn temp_sqlite_copy_allowed(path: &std::path::Path) -> bool {
     std::fs::metadata(path)
         .map(|m| m.len())

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -384,7 +384,10 @@ pub struct MessageRow {
 fn read_messages(db: &Path) -> Result<Vec<MessageRow>, String> {
     let conn = super::open_readonly_sqlite(db)?;
     let mut stmt = conn
-        .prepare("SELECT time_created, data FROM message")
+        .prepare(&format!(
+            "SELECT time_created, data FROM message LIMIT {}",
+            super::MAX_LEDGER_ROWS
+        ))
         .map_err(|e| format!("query messages: {e}"))?;
 
     let rows = stmt
@@ -393,9 +396,11 @@ fn read_messages(db: &Path) -> Result<Vec<MessageRow>, String> {
         })
         .map_err(|e| format!("read messages: {e}"))?;
 
+    let mut scanned: u64 = 0;
     let mut out = Vec::new();
-    for row in rows.flatten() {
-        let (time_created, data) = row;
+    for row in rows {
+        scanned += 1;
+        let Ok((time_created, data)) = row else { continue };
         let Ok(msg) = serde_json::from_str::<Value>(&data) else { continue };
         if msg.get("role").and_then(Value::as_str) != Some("assistant") {
             continue;
@@ -421,6 +426,12 @@ fn read_messages(db: &Path) -> Result<Vec<MessageRow>, String> {
             .filter_map(|p| msg.pointer(p).and_then(Value::as_f64))
             .sum::<f64>();
         out.push(MessageRow { ts, cost, tokens, provider, model });
+    }
+    if scanned >= super::MAX_LEDGER_ROWS {
+        eprintln!(
+            "[pane] opencode: message table hit the {}-row read cap — spend totals are truncated",
+            super::MAX_LEDGER_ROWS
+        );
     }
     Ok(out)
 }

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -385,7 +385,7 @@ fn read_messages(db: &Path) -> Result<Vec<MessageRow>, String> {
     let conn = super::open_readonly_sqlite(db)?;
     let mut stmt = conn
         .prepare(&format!(
-            "SELECT time_created, data FROM message LIMIT {}",
+            "SELECT time_created, data FROM message ORDER BY time_created DESC LIMIT {}",
             super::MAX_LEDGER_ROWS
         ))
         .map_err(|e| format!("query messages: {e}"))?;
@@ -429,7 +429,7 @@ fn read_messages(db: &Path) -> Result<Vec<MessageRow>, String> {
     }
     if scanned >= super::MAX_LEDGER_ROWS {
         eprintln!(
-            "[pane] opencode: message table hit the {}-row read cap — spend totals are truncated",
+            "[pane] opencode: message table hit the {}-row read cap — keeping newest rows, oldest usage is dropped",
             super::MAX_LEDGER_ROWS
         );
     }

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -199,12 +199,17 @@ fn month_period_ending(resets_ms: i64) -> i64 {
 /// rows only, so shared subscriptions under-count here.
 fn local_windows_snapshot() -> Result<Snapshot, String> {
     let w = with_live_db(|db| {
-        let rows: Vec<(f64, f64)> = read_messages(db)?
+        let (msgs, capped) = read_messages(db)?;
+        let rows: Vec<(f64, f64)> = msgs
             .into_iter()
             .filter(|r| r.provider == "opencode-go" && r.cost > 0.0)
             .map(|r| (r.ts, r.cost))
             .collect();
-        Ok(go_windows(&rows, chrono::Utc::now().timestamp_millis() as f64))
+        // The monthly anchor is the earliest-ever Go row; when the row cap
+        // dropped the oldest rows, recover it with the bounded oldest-first
+        // probe instead of re-anchoring on the newest window's edge.
+        let anchor = if capped { earliest_go_anchor(db) } else { None };
+        Ok(go_windows(&rows, anchor, chrono::Utc::now().timestamp_millis() as f64))
     })?;
     let metrics = vec![
         Metric::progress(
@@ -245,7 +250,7 @@ struct GoWindows {
 /// week (Monday 00:00 start), and a month anchored to the day-of-month and
 /// time-of-day of the earliest-ever local Go usage (calendar month when
 /// there is none). Pure and UTC-based, so it unit-tests deterministically.
-fn go_windows(rows: &[(f64, f64)], now_ms: f64) -> GoWindows {
+fn go_windows(rows: &[(f64, f64)], anchor_override: Option<f64>, now_ms: f64) -> GoWindows {
     let sum_range = |start: f64, end: f64| -> f64 {
         let total: f64 =
             rows.iter().filter(|(ts, _)| *ts >= start && *ts < end).map(|(_, c)| c).sum();
@@ -268,8 +273,13 @@ fn go_windows(rows: &[(f64, f64)], now_ms: f64) -> GoWindows {
     let week_end = week_start + WEEK_MS;
     let weekly = sum_range(week_start, week_end);
 
-    // Monthly cycle anchor: the earliest-ever Go row on this machine.
-    let anchor_ms = rows.iter().map(|(ts, _)| *ts).fold(f64::INFINITY, f64::min);
+    // Monthly cycle anchor: the earliest-ever Go row on this machine. When
+    // the row cap dropped the oldest rows, the caller passes the probed
+    // anchor explicitly.
+    let anchor_ms = match anchor_override {
+        Some(a) => a,
+        None => rows.iter().map(|(ts, _)| *ts).fold(f64::INFINITY, f64::min),
+    };
     let (month_start, month_end) = anchored_month_bounds(
         now_ms,
         if anchor_ms.is_finite() { Some(anchor_ms) } else { None },
@@ -361,6 +371,7 @@ fn utc_date(year: i32, month: u32, day: u32, h: u32, m: u32, s: u32, ms: u32) ->
 pub fn collect_cost_events() -> Vec<(f64, f64, f64, String, String)> {
     with_live_db(|db| {
         Ok(read_messages(db)?
+            .0
             .into_iter()
             // Free models record cost 0 with real token counts — the
             // tokens are usage facts and count at their true $0 price.
@@ -381,7 +392,7 @@ pub struct MessageRow {
 }
 
 /// Raw assistant-message rows from opencode.db.
-fn read_messages(db: &Path) -> Result<Vec<MessageRow>, String> {
+fn read_messages(db: &Path) -> Result<(Vec<MessageRow>, bool), String> {
     let conn = super::open_readonly_sqlite(db)?;
     let mut stmt = conn
         .prepare(&format!(
@@ -433,7 +444,43 @@ fn read_messages(db: &Path) -> Result<Vec<MessageRow>, String> {
             super::MAX_LEDGER_ROWS
         );
     }
-    Ok(out)
+    Ok((out, scanned >= super::MAX_LEDGER_ROWS))
+}
+
+/// The monthly cycle anchors on the earliest-ever Go row — which the
+/// newest-first cap in read_messages intentionally drops. When (and only
+/// when) the cap binds, find the anchor with a small oldest-first probe:
+/// bounded regardless of table size, skipped entirely on normal DBs.
+fn earliest_go_anchor(db: &Path) -> Option<f64> {
+    const MAX_ANCHOR_PROBE_ROWS: u64 = 100_000;
+    let conn = super::open_readonly_sqlite(db).ok()?;
+    let mut stmt = conn
+        .prepare(&format!(
+            "SELECT time_created, data FROM message ORDER BY time_created ASC LIMIT {MAX_ANCHOR_PROBE_ROWS}"
+        ))
+        .ok()?;
+    let rows = stmt
+        .query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)))
+        .ok()?;
+    for row in rows.flatten() {
+        let (time_created, data) = row;
+        let Ok(msg) = serde_json::from_str::<Value>(&data) else { continue };
+        if msg.get("role").and_then(Value::as_str) != Some("assistant")
+            || msg.get("providerID").and_then(Value::as_str) != Some("opencode-go")
+        {
+            continue;
+        }
+        if msg.get("cost").and_then(Value::as_f64).unwrap_or(0.0) <= 0.0 {
+            continue;
+        }
+        return Some(
+            msg.pointer("/time/completed")
+                .or_else(|| msg.pointer("/time/created"))
+                .and_then(Value::as_f64)
+                .unwrap_or(time_created as f64),
+        );
+    }
+    None
 }
 
 
@@ -505,7 +552,7 @@ mod tests {
         // Two rows inside the rolling 5h window; reset = oldest + 5h.
         let now = ms("2026-07-28T12:00:00Z");
         let rows = [(ms("2026-07-28T09:00:00Z"), 2.0), (ms("2026-07-28T11:00:00Z"), 1.0)];
-        let w = go_windows(&rows, now);
+        let w = go_windows(&rows, None, now);
         assert!((w.session - 3.0).abs() < 1e-9);
         assert_eq!(w.session_resets_at, ms("2026-07-28T14:00:00Z") as i64);
     }
@@ -513,7 +560,7 @@ mod tests {
     #[test]
     fn empty_session_resets_a_full_window_from_now() {
         let now = ms("2026-07-28T12:00:00Z");
-        let w = go_windows(&[], now);
+        let w = go_windows(&[], None, now);
         assert_eq!(w.session, 0.0);
         assert_eq!(w.session_resets_at, ms("2026-07-28T17:00:00Z") as i64);
     }
@@ -526,7 +573,7 @@ mod tests {
             (ms("2026-07-26T23:00:00Z"), 5.0), // Sunday: previous week
             (ms("2026-07-27T01:00:00Z"), 2.0), // Monday: this week
         ];
-        let w = go_windows(&rows, now);
+        let w = go_windows(&rows, None, now);
         assert!((w.weekly - 2.0).abs() < 1e-9, "rolling-7d would count 7.0");
         assert_eq!(w.weekly_resets_at, ms("2026-08-03T00:00:00Z") as i64);
     }
@@ -540,7 +587,20 @@ mod tests {
             (ms("2026-07-14T12:00:00Z"), 4.0), // before Jul 15: previous cycle
             (ms("2026-07-20T12:00:00Z"), 3.0), // current cycle
         ];
-        let w = go_windows(&rows, now);
+        let w = go_windows(&rows, None, now);
+        assert!((w.monthly - 3.0).abs() < 1e-9);
+        assert_eq!(w.monthly_resets_at, ms("2026-08-15T08:30:00Z") as i64);
+    }
+
+    /// When the row cap drops the oldest rows, the caller passes the probed
+    /// earliest-Go anchor explicitly so the monthly cycle stays put.
+    #[test]
+    fn monthly_anchor_survives_a_capped_row_window() {
+        let now = ms("2026-07-28T12:00:00Z");
+        // Only recent rows made it past the cap; the true anchor (Jun 15)
+        // is recovered separately and passed in.
+        let rows = [(ms("2026-07-20T12:00:00Z"), 3.0)];
+        let w = go_windows(&rows, Some(ms("2026-06-15T08:30:00Z")), now);
         assert!((w.monthly - 3.0).abs() < 1e-9);
         assert_eq!(w.monthly_resets_at, ms("2026-08-15T08:30:00Z") as i64);
     }
@@ -551,7 +611,7 @@ mod tests {
         // It has; use the 30th with "now" on the 28th: cycle began Jun 30.
         let now = ms("2026-07-28T12:00:00Z");
         let rows = [(ms("2026-05-30T10:00:00Z"), 1.0)];
-        let w = go_windows(&rows, now);
+        let w = go_windows(&rows, None, now);
         assert_eq!(w.monthly_resets_at, ms("2026-07-30T10:00:00Z") as i64);
         assert_eq!(
             w.monthly_period_ms,
@@ -564,7 +624,7 @@ mod tests {
         // Anchored to Jan 31; in February the cycle boundary clamps to Feb 28.
         let now = ms("2026-02-10T12:00:00Z");
         let rows = [(ms("2026-01-31T09:00:00Z"), 1.0)];
-        let w = go_windows(&rows, now);
+        let w = go_windows(&rows, None, now);
         assert_eq!(w.monthly_resets_at, ms("2026-02-28T09:00:00Z") as i64);
     }
 }

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -451,6 +451,13 @@ fn read_messages(db: &Path) -> Result<(Vec<MessageRow>, bool), String> {
 /// newest-first cap in read_messages intentionally drops. When (and only
 /// when) the cap binds, find the anchor with a small oldest-first probe:
 /// bounded regardless of table size, skipped entirely on normal DBs.
+///
+/// Known limitation: read_messages covers the newest MAX_LEDGER_ROWS and
+/// this probe covers the oldest MAX_ANCHOR_PROBE_ROWS, so a table with more
+/// than MAX_LEDGER_ROWS + MAX_ANCHOR_PROBE_ROWS rows leaves an unsearched
+/// middle band. If the earliest paid Go row falls in that band the monthly
+/// anchor lands late, shifting the reported billing boundary and reset time.
+/// Only reachable on an implausibly large local ledger (>2.1M rows).
 fn earliest_go_anchor(db: &Path) -> Option<f64> {
     const MAX_ANCHOR_PROBE_ROWS: u64 = 100_000;
     let conn = super::open_readonly_sqlite(db).ok()?;


### PR DESCRIPTION
## What

Security-audit fixes for the SQLite layer:

- **rusqlite 0.32 → 0.40.2** — bundled SQLite 3.46.0 → 3.53.2. CVE-2025-7709 (out-of-bounds access via corrupt FTS5 index, fixed in SQLite 3.50.3) was reachable: Pane opens third-party DBs (Cursor `state.vscdb`, Devin `sessions.db`, MiniMax, Hermes, OpenCode) as untrusted input, and a poisoned DB could define the queried name as a view over a corrupt FTS5 table. Also adds `getrandom 0.2` (consumed by the telemetry fix in the follow-up core PR).
- **Cursor temp-copy TOCTOU closed** — the 64 MB cap was pre-stat'd, then the file was copied; growth/swap between check and copy defeated it. The copy itself is now byte-capped (`io::copy` from a `take(cap+1)` reader); over-cap deletes the partial temp file and refuses exactly as before.
- **Ledger SELECTs bounded** — Hermes/MiniMax/OpenCode full-table reads get a 2M-row LIMIT + diagnostic; real data is far below the cap, so semantics are unchanged.

## How

- New shared `MAX_LEDGER_ROWS` const; `temp_sqlite_copy_allowed` becomes `#[cfg(test)]` (only test callers remain).
- Breaking-change sweep for rusqlite 0.32→0.40: no `Connection::execute`, no multi-statement `prepare`, no u64/usize ToSql, no vtab usage — no code changes needed. MSRV floor is now Rust 1.88 (CI builds on stable).

## Tests

- New: capped-copy tests (over-cap cleanup + end-to-end real DB read).
- `cargo test --lib` green on the combined branch (362 passed); this PR is a whole-file subset of it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->