### PR TITLE
Harden credential files: capped reads, symlink-safe writes, redacted errors

### DIFF
--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const ID: &str = "claude";
 const NAME: &str = "Claude";
+const MAX_CRED_BYTES: u64 = 64 * 1024;
 
 fn default_dir() -> PathBuf {
     std::env::var("CLAUDE_CONFIG_DIR")
@@ -78,34 +79,14 @@ fn identity_from(doc: &Value) -> Option<(String, Option<String>)> {
     Some((uuid.to_string(), label))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::identity_from;
-    use serde_json::json;
-
-    #[test]
-    fn claude_identity_extraction_is_validation() {
-        // Org name wins the label; email is the fallback.
-        let org = json!({"oauthAccount": {"accountUuid": "u-1",
-            "organizationName": "Acme", "emailAddress": "a@b.c"}});
-        assert_eq!(identity_from(&org), Some(("u-1".into(), Some("Acme".into()))));
-        let email_only = json!({"oauthAccount": {"accountUuid": "u-2",
-            "organizationName": "  ", "emailAddress": "a@b.c"}});
-        assert_eq!(identity_from(&email_only), Some(("u-2".into(), Some("a@b.c".into()))));
-        // No uuid → no identity → no card (a dir that can't name its
-        // account never becomes one).
-        assert_eq!(identity_from(&json!({"oauthAccount": {}})), None);
-        assert_eq!(identity_from(&json!({})), None);
-    }
-}
-
 /// Extra Claude logins beyond the default config dir: dot-dirs in the home
 /// folder plus dirs under ~/.config that hold a `.credentials.json` with a
 /// claudeAiOauth entry (how a second account is kept via CLAUDE_CONFIG_DIR).
-/// Identity extraction is validation (upstream's rule): a dir that can't
-/// name its account never becomes a card, and a dir naming an already-seen
-/// account is just another source of it — skipped, so duplicate cards are
-/// structurally impossible.
+/// Extraction alone is not validation: a dir that can't name its account
+/// never becomes a card, a dir naming an already-seen account is skipped
+/// (duplicate cards stay structurally impossible), and the uuid must clear
+/// scoped_id_charset before it becomes `claude@<hash8>` — the frontend
+/// interpolates that id into HTML attributes.
 pub fn discover_extra_accounts() -> Vec<ClaudeAccount> {
     let default = default_dir();
     let default_identity = dir_identity(&default);
@@ -130,6 +111,9 @@ pub fn discover_extra_accounts() -> Vec<ClaudeAccount> {
             continue;
         }
         let Some((uuid, label)) = dir_identity(&dir) else { continue };
+        if !scoped_id_charset(&uuid) {
+            continue;
+        }
         if seen.iter().any(|u| u == &uuid) {
             continue;
         }
@@ -176,7 +160,7 @@ async fn fetch(dir: &std::path::Path, id: &str, name: &str) -> Result<Snapshot, 
         ));
     }
 
-    let raw = std::fs::read_to_string(&path).map_err(|e| format!("read credentials: {e}"))?;
+    let raw = super::read_small_text(&path, MAX_CRED_BYTES, "credentials")?;
     let mut doc: Value = serde_json::from_str(&raw).map_err(|e| format!("parse credentials: {e}"))?;
     let oauth = doc
         .get("claudeAiOauth")
@@ -205,59 +189,69 @@ async fn fetch(dir: &std::path::Path, id: &str, name: &str) -> Result<Snapshot, 
         if refresh.is_empty() {
             return Err("token expired and no refresh token present — run `claude` and log in again".into());
         }
-        let resp = http()
-            .post("https://platform.claude.com/v1/oauth/token")
-            .json(&json!({
-                "grant_type": "refresh_token",
-                "refresh_token": refresh,
-                "client_id": CLIENT_ID,
-            }))
-            .send()
-            .await
-            .map_err(|e| format!("token refresh: {e}"))?;
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            // A rejected refresh token isn't transient: another app (Claude
-            // Code itself, or a second machine) rotated it and this copy is
-            // dead. Only a fresh CLI sign-in mints a working pair — say so
-            // instead of leaving a bare HTTP code on the card.
-            if body.contains("invalid_grant") {
-                return Err(
-                    "Claude sign-in was rotated by another app — run `claude` in a terminal once and Pane recovers automatically"
-                        .into(),
-                );
-            }
-            return Err(format!("token refresh failed: HTTP {status}"));
+        // Refresh rotates the CLI's refresh token. If we can't write it back
+        // (a planted symlink), don't call the token endpoint — that would
+        // sign the CLI out from under the user; a still-valid access token
+        // just skips the refresh.
+        let writable = is_regular_file(&path);
+        if !writable && access.is_empty() {
+            return Err(
+                "Claude credentials are not a regular file — run `claude` in a terminal".into(),
+            );
         }
-        let tok: Value = resp.json().await.map_err(|e| format!("token refresh parse: {e}"))?;
-        let new_access = tok
-            .get("access_token")
-            .and_then(Value::as_str)
-            .ok_or("refresh response missing access_token")?
-            .to_string();
-        let new_refresh = tok
-            .get("refresh_token")
-            .and_then(Value::as_str)
-            .unwrap_or(&refresh)
-            .to_string();
-        let expires_in = tok.get("expires_in").and_then(Value::as_i64).unwrap_or(3600);
+        if writable {
+            let resp = http()
+                .post("https://platform.claude.com/v1/oauth/token")
+                .json(&json!({
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh,
+                    "client_id": CLIENT_ID,
+                }))
+                .send()
+                .await
+                .map_err(|e| format!("token refresh: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                // A rejected refresh token isn't transient: another app (Claude
+                // Code itself, or a second machine) rotated it and this copy is
+                // dead. Only a fresh CLI sign-in mints a working pair — say so
+                // instead of leaving a bare HTTP code on the card.
+                if body.contains("invalid_grant") {
+                    return Err(
+                        "Claude sign-in was rotated by another app — run `claude` in a terminal once and Pane recovers automatically"
+                            .into(),
+                    );
+                }
+                return Err(format!("token refresh failed: HTTP {status}"));
+            }
+            let tok: Value = resp.json().await.map_err(|e| format!("token refresh parse: {e}"))?;
+            let new_access = tok
+                .get("access_token")
+                .and_then(Value::as_str)
+                .ok_or("refresh response missing access_token")?
+                .to_string();
+            let new_refresh = tok
+                .get("refresh_token")
+                .and_then(Value::as_str)
+                .unwrap_or(&refresh)
+                .to_string();
+            let expires_in = tok.get("expires_in").and_then(Value::as_i64).unwrap_or(3600);
 
-        access = new_access.clone();
+            access = new_access.clone();
 
-        // Refresh tokens rotate on use — write the new pair back so Claude Code
-        // itself stays logged in.
-        if let Some(entry) = doc.get_mut("claudeAiOauth").filter(|v| v.is_object()) {
-            entry["accessToken"] = Value::from(new_access);
-            entry["refreshToken"] = Value::from(new_refresh);
-            entry["expiresAt"] = Value::from(now_ms + expires_in * 1000);
-            // Keep a copy of the CLI's own file before touching it, so a bad
-            // write can never cost the user their login.
-            let _ = std::fs::copy(&path, path.with_extension("json.pane-bak"));
-            let tmp = path.with_extension("json.tmp");
-            std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
-                .and_then(|_| std::fs::rename(&tmp, &path))
-                .map_err(|e| format!("write refreshed credentials: {e}"))?;
+            // Refresh tokens rotate on use — write the new pair back so Claude Code
+            // itself stays logged in.
+            if let Some(entry) = doc.get_mut("claudeAiOauth").filter(|v| v.is_object()) {
+                entry["accessToken"] = Value::from(new_access);
+                entry["refreshToken"] = Value::from(new_refresh);
+                entry["expiresAt"] = Value::from(now_ms + expires_in * 1000);
+                backup_credentials(&path);
+                let tmp = path.with_extension("json.tmp");
+                std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
+                    .and_then(|_| std::fs::rename(&tmp, &path))
+                    .map_err(|e| format!("write refreshed credentials: {e}"))?;
+            }
         }
     }
 
@@ -364,4 +358,59 @@ fn push_window(metrics: &mut Vec<Metric>, node: Option<&Value>, label: &str, per
     let Some(used) = node.get("utilization").and_then(Value::as_f64) else { return };
     let resets_at = parse_reset(node.get("resets_at"));
     metrics.push(Metric::progress(label, used, None).with_reset(resets_at, Some(period_ms)));
+}
+
+/// The account uuid becomes `claude@<hash8>`, which the frontend
+/// interpolates into HTML attributes — only [A-Za-z0-9-] is safe there.
+fn scoped_id_charset(raw: &str) -> bool {
+    !raw.is_empty() && raw.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+}
+
+fn is_regular_file(path: &std::path::Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .ok()
+        .is_some_and(|m| m.is_file() && !m.file_type().is_symlink())
+}
+
+/// Keep a copy of the CLI's own file before touching it, so a bad write can
+/// never cost the user their login. A planted symlink at the backup path is
+/// unlinked first — never write through it.
+fn backup_credentials(path: &std::path::Path) {
+    let bak = path.with_extension("json.pane-bak");
+    if std::fs::symlink_metadata(&bak)
+        .ok()
+        .is_some_and(|m| m.file_type().is_symlink())
+    {
+        let _ = std::fs::remove_file(&bak);
+    }
+    let _ = std::fs::copy(path, &bak);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{identity_from, scoped_id_charset};
+    use serde_json::json;
+
+    #[test]
+    fn claude_identity_extraction() {
+        // Org name wins the label; email is the fallback.
+        let org = json!({"oauthAccount": {"accountUuid": "u-1",
+            "organizationName": "Acme", "emailAddress": "a@b.c"}});
+        assert_eq!(identity_from(&org), Some(("u-1".into(), Some("Acme".into()))));
+        let email_only = json!({"oauthAccount": {"accountUuid": "u-2",
+            "organizationName": "  ", "emailAddress": "a@b.c"}});
+        assert_eq!(identity_from(&email_only), Some(("u-2".into(), Some("a@b.c".into()))));
+        // No uuid → no identity → no card (a dir that can't name its
+        // account never becomes one).
+        assert_eq!(identity_from(&json!({"oauthAccount": {}})), None);
+        assert_eq!(identity_from(&json!({})), None);
+    }
+
+    #[test]
+    fn scoped_id_charset_is_html_attribute_safe() {
+        assert!(scoped_id_charset("b3f1c2d4-9a8b-4c5d-8e9f-aabbccddeeff"));
+        assert!(!scoped_id_charset(""));
+        assert!(!scoped_id_charset("evil\"><script>"));
+        assert!(!scoped_id_charset("with space"));
+    }
 }

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -103,10 +103,14 @@ pub fn discover_extra_accounts() -> Vec<ClaudeAccount> {
         if dir == default {
             continue;
         }
-        let has_oauth = std::fs::read_to_string(dir.join(".credentials.json"))
-            .ok()
-            .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
-            .is_some_and(|doc| doc.get("claudeAiOauth").is_some());
+        let has_oauth = super::read_small_text(
+            &dir.join(".credentials.json"),
+            MAX_CRED_BYTES,
+            "credentials",
+        )
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .is_some_and(|doc| doc.get("claudeAiOauth").is_some());
         if !has_oauth {
             continue;
         }
@@ -189,14 +193,14 @@ async fn fetch(dir: &std::path::Path, id: &str, name: &str) -> Result<Snapshot, 
         if refresh.is_empty() {
             return Err("token expired and no refresh token present — run `claude` and log in again".into());
         }
-        // Refresh rotates the CLI's refresh token. If we can't write it back
-        // (a planted symlink), don't call the token endpoint — that would
-        // sign the CLI out from under the user; a still-valid access token
-        // just skips the refresh.
-        let writable = is_regular_file(&path);
+        // Refresh rotates the CLI's refresh token. If the write-back can't
+        // safely replace the live file (planted symlink, read-only dir),
+        // don't call the token endpoint — that would sign the CLI out from
+        // under the user; a still-valid access token just skips the refresh.
+        let writable = can_stage_write(&path);
         if !writable && access.is_empty() {
             return Err(
-                "Claude credentials are not a regular file — run `claude` in a terminal".into(),
+                "Claude credentials cannot be updated safely — run `claude` in a terminal".into(),
             );
         }
         if writable {
@@ -249,7 +253,11 @@ async fn fetch(dir: &std::path::Path, id: &str, name: &str) -> Result<Snapshot, 
                 backup_credentials(&path);
                 let tmp = path.with_extension("json.tmp");
                 std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
-                    .and_then(|_| std::fs::rename(&tmp, &path))
+                    .map_err(|e| format!("write refreshed credentials: {e}"))?;
+                // Lock the new pair down to this user before it replaces the
+                // live file (the preflight probe proved this fs accepts it).
+                super::onenewapi::store::restrict_owner_only(&tmp)
+                    .and_then(|_| std::fs::rename(&tmp, &path).map_err(|e| e.to_string()))
                     .map_err(|e| format!("write refreshed credentials: {e}"))?;
             }
         }
@@ -370,6 +378,38 @@ fn is_regular_file(path: &std::path::Path) -> bool {
     std::fs::symlink_metadata(path)
         .ok()
         .is_some_and(|m| m.is_file() && !m.file_type().is_symlink())
+}
+
+/// Refresh preflight: the write-back must be able to replace the live
+/// file — rotating the refresh token without a working write-back signs
+/// the CLI out. A planted symlink at the predictable tmp path is
+/// unlinked (never its target), then a create + owner-lock probe proves
+/// the directory accepts the full staging chain.
+fn can_stage_write(path: &std::path::Path) -> bool {
+    if !is_regular_file(path) {
+        return false;
+    }
+    let tmp = path.with_extension("json.tmp");
+    match std::fs::symlink_metadata(&tmp) {
+        Ok(m) if m.file_type().is_symlink() => {
+            if std::fs::remove_file(&tmp).is_err() {
+                return false;
+            }
+        }
+        Ok(m) if !m.is_file() => return false,
+        _ => {}
+    }
+    let existed = tmp.is_file();
+    let ok = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(&tmp)
+        .is_ok()
+        && super::onenewapi::store::restrict_owner_only(&tmp).is_ok();
+    if !existed {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    ok
 }
 
 /// Keep a copy of the CLI's own file before touching it, so a bad write can

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -193,17 +193,18 @@ async fn fetch(dir: &std::path::Path, id: &str, name: &str) -> Result<Snapshot, 
         if refresh.is_empty() {
             return Err("token expired and no refresh token present — run `claude` and log in again".into());
         }
-        // Refresh rotates the CLI's refresh token. If the write-back can't
-        // safely replace the live file (planted symlink, read-only dir),
-        // don't call the token endpoint — that would sign the CLI out from
-        // under the user; a still-valid access token just skips the refresh.
-        let writable = can_stage_write(&path);
-        if !writable && access.is_empty() {
+        // Refresh rotates the CLI's refresh token. Stage the write-back
+        // BEFORE the token call: if the refreshed pair can't replace the
+        // live file, the rotation would sign the CLI out from under the
+        // user. Only a token whose expiry is still in the future may skip
+        // the refresh; an expired one would just earn a vendor rejection.
+        let staged = stage_credentials_tmp(&path);
+        if staged.is_none() && (access.is_empty() || expires_at <= now_ms) {
             return Err(
                 "Claude credentials cannot be updated safely — run `claude` in a terminal".into(),
             );
         }
-        if writable {
+        if let Some(staged) = staged {
             let resp = http()
                 .post("https://platform.claude.com/v1/oauth/token")
                 .json(&json!({
@@ -251,13 +252,12 @@ async fn fetch(dir: &std::path::Path, id: &str, name: &str) -> Result<Snapshot, 
                 entry["refreshToken"] = Value::from(new_refresh);
                 entry["expiresAt"] = Value::from(now_ms + expires_in * 1000);
                 backup_credentials(&path);
-                let tmp = path.with_extension("json.tmp");
-                std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
+                // The tmp was created fresh and owner-locked at staging.
+                staged
+                    .write(&serde_json::to_string_pretty(&doc).unwrap_or(raw))
                     .map_err(|e| format!("write refreshed credentials: {e}"))?;
-                // Lock the new pair down to this user before it replaces the
-                // live file (the preflight probe proved this fs accepts it).
-                super::onenewapi::store::restrict_owner_only(&tmp)
-                    .and_then(|_| std::fs::rename(&tmp, &path).map_err(|e| e.to_string()))
+                staged
+                    .commit(&path)
                     .map_err(|e| format!("write refreshed credentials: {e}"))?;
             }
         }
@@ -380,36 +380,47 @@ fn is_regular_file(path: &std::path::Path) -> bool {
         .is_some_and(|m| m.is_file() && !m.file_type().is_symlink())
 }
 
-/// Refresh preflight: the write-back must be able to replace the live
-/// file — rotating the refresh token without a working write-back signs
-/// the CLI out. A planted symlink at the predictable tmp path is
-/// unlinked (never its target), then a create + owner-lock probe proves
-/// the directory accepts the full staging chain.
-fn can_stage_write(path: &std::path::Path) -> bool {
+/// Proof the refreshed credential pair can replace the live file BEFORE the
+/// rotating token call: any leftover or planted file at the predictable tmp
+/// path is removed outright (a symlink or hardlink redirect is never written
+/// through), a fresh tmp is created with create_new and owner-locked, and it
+/// stays staged until commit so nothing can be planted in the gap. Drop
+/// removes the tmp when the refresh never lands.
+struct StagedTmp(std::path::PathBuf);
+
+impl StagedTmp {
+    fn write(&self, contents: &str) -> std::io::Result<()> {
+        std::fs::write(&self.0, contents)
+    }
+    fn commit(self, live: &std::path::Path) -> std::io::Result<()> {
+        std::fs::rename(&self.0, live)?;
+        std::mem::forget(self);
+        Ok(())
+    }
+}
+
+impl Drop for StagedTmp {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn stage_credentials_tmp(path: &std::path::Path) -> Option<StagedTmp> {
     if !is_regular_file(path) {
-        return false;
+        return None;
     }
     let tmp = path.with_extension("json.tmp");
-    match std::fs::symlink_metadata(&tmp) {
-        Ok(m) if m.file_type().is_symlink() => {
-            if std::fs::remove_file(&tmp).is_err() {
-                return false;
-            }
-        }
-        Ok(m) if !m.is_file() => return false,
-        _ => {}
+    if std::fs::symlink_metadata(&tmp).is_ok() && std::fs::remove_file(&tmp).is_err() {
+        return None;
     }
-    let existed = tmp.is_file();
-    let ok = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .open(&tmp)
-        .is_ok()
-        && super::onenewapi::store::restrict_owner_only(&tmp).is_ok();
-    if !existed {
+    if std::fs::OpenOptions::new().write(true).create_new(true).open(&tmp).is_err() {
+        return None;
+    }
+    if super::onenewapi::store::restrict_owner_only(&tmp).is_err() {
         let _ = std::fs::remove_file(&tmp);
+        return None;
     }
-    ok
+    Some(StagedTmp(tmp))
 }
 
 /// Keep a copy of the CLI's own file before touching it, so a bad write can
@@ -452,5 +463,37 @@ mod tests {
         assert!(!scoped_id_charset(""));
         assert!(!scoped_id_charset("evil\"><script>"));
         assert!(!scoped_id_charset("with space"));
+    }
+
+    #[test]
+    fn staging_discards_leftover_tmp_and_cleans_up() {
+        use super::stage_credentials_tmp;
+        let dir = std::env::temp_dir().join(format!("pane-stage-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let live = dir.join("creds.json");
+        std::fs::write(&live, "{}").unwrap();
+
+        // No live credential file → no staging.
+        assert!(stage_credentials_tmp(&dir.join("missing.json")).is_none());
+
+        // A stale leftover at the predictable tmp path is removed outright —
+        // never truncated into, so unrelated data is never clobbered by a
+        // credential write.
+        let tmp = live.with_extension("json.tmp");
+        std::fs::write(&tmp, b"unrelated data").unwrap();
+        {
+            let staged = stage_credentials_tmp(&live).expect("staging must succeed");
+            assert_eq!(std::fs::read_to_string(&tmp).unwrap(), "");
+            staged.write("{\"new\":1}").unwrap();
+            staged.commit(&live).unwrap();
+        }
+        assert_eq!(std::fs::read_to_string(&live).unwrap(), "{\"new\":1}");
+
+        // A staged tmp whose refresh never lands is cleaned up on drop.
+        let staged = stage_credentials_tmp(&live).unwrap();
+        drop(staged);
+        assert!(!tmp.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/providers/codebuff.rs
+++ b/src-tauri/src/providers/codebuff.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 
 const ID: &str = "codebuff";
 const NAME: &str = "Codebuff";
+const MAX_CRED_BYTES: u64 = 64 * 1024;
 
 pub async fn snapshot() -> Snapshot {
     match fetch().await {
@@ -15,7 +16,8 @@ pub async fn snapshot() -> Snapshot {
 /// former name): { "default": { "authToken": … } } or a top-level authToken.
 fn cli_token() -> Option<String> {
     let path = dirs::home_dir()?.join(".config").join("manicode").join("credentials.json");
-    let doc: Value = serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()?;
+    let raw = super::read_small_text(&path, MAX_CRED_BYTES, "credentials").ok()?;
+    let doc: Value = serde_json::from_str(&raw).ok()?;
     doc.pointer("/default/authToken")
         .or_else(|| doc.get("authToken"))
         .and_then(Value::as_str)

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -211,17 +211,18 @@ async fn load_access(dir: &std::path::Path) -> Result<Access, String> {
         if refresh.is_empty() {
             return Err("access token expired and no refresh token — run `codex login` again".into());
         }
-        // Refresh rotates the CLI's refresh token. If the write-back can't
-        // safely replace the live file (planted symlink, read-only dir),
-        // don't call the token endpoint — that would sign the CLI out from
-        // under the user; a still-valid access token just skips the refresh.
-        let writable = can_stage_write(&path);
-        if !writable && access.is_empty() {
+        // Refresh rotates the CLI's refresh token. Stage the write-back
+        // BEFORE the token call: if the refreshed pair can't replace the
+        // live file, the rotation would sign the CLI out from under the
+        // user. Only a token whose expiry is still in the future may skip
+        // the refresh; an expired one would just earn a vendor rejection.
+        let staged = stage_credentials_tmp(&path);
+        if staged.is_none() && (access.is_empty() || exp <= Utc::now().timestamp()) {
             return Err(
                 "Codex credentials cannot be updated safely — run `codex login` in a terminal".into(),
             );
         }
-        if writable {
+        if let Some(staged) = staged {
             let resp = http()
                 .post("https://auth.openai.com/oauth/token")
                 .json(&json!({
@@ -255,13 +256,12 @@ async fn load_access(dir: &std::path::Path) -> Result<Access, String> {
                 }
                 doc["last_refresh"] = Value::from(Utc::now().to_rfc3339());
                 backup_credentials(&path);
-                let tmp = path.with_extension("json.tmp");
-                std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
+                // The tmp was created fresh and owner-locked at staging.
+                staged
+                    .write(&serde_json::to_string_pretty(&doc).unwrap_or(raw))
                     .map_err(|e| format!("write refreshed auth.json: {e}"))?;
-                // Lock the new pair down to this user before it replaces the
-                // live file (the preflight probe proved this fs accepts it).
-                super::onenewapi::store::restrict_owner_only(&tmp)
-                    .and_then(|_| std::fs::rename(&tmp, &path).map_err(|e| e.to_string()))
+                staged
+                    .commit(&path)
                     .map_err(|e| format!("write refreshed auth.json: {e}"))?;
             }
         }
@@ -580,36 +580,47 @@ fn is_regular_file(path: &std::path::Path) -> bool {
         .is_some_and(|m| m.is_file() && !m.file_type().is_symlink())
 }
 
-/// Refresh preflight: the write-back must be able to replace the live
-/// file — rotating the refresh token without a working write-back signs
-/// the CLI out. A planted symlink at the predictable tmp path is
-/// unlinked (never its target), then a create + owner-lock probe proves
-/// the directory accepts the full staging chain.
-fn can_stage_write(path: &std::path::Path) -> bool {
+/// Proof the refreshed credential pair can replace the live file BEFORE the
+/// rotating token call: any leftover or planted file at the predictable tmp
+/// path is removed outright (a symlink or hardlink redirect is never written
+/// through), a fresh tmp is created with create_new and owner-locked, and it
+/// stays staged until commit so nothing can be planted in the gap. Drop
+/// removes the tmp when the refresh never lands.
+struct StagedTmp(std::path::PathBuf);
+
+impl StagedTmp {
+    fn write(&self, contents: &str) -> std::io::Result<()> {
+        std::fs::write(&self.0, contents)
+    }
+    fn commit(self, live: &std::path::Path) -> std::io::Result<()> {
+        std::fs::rename(&self.0, live)?;
+        std::mem::forget(self);
+        Ok(())
+    }
+}
+
+impl Drop for StagedTmp {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn stage_credentials_tmp(path: &std::path::Path) -> Option<StagedTmp> {
     if !is_regular_file(path) {
-        return false;
+        return None;
     }
     let tmp = path.with_extension("json.tmp");
-    match std::fs::symlink_metadata(&tmp) {
-        Ok(m) if m.file_type().is_symlink() => {
-            if std::fs::remove_file(&tmp).is_err() {
-                return false;
-            }
-        }
-        Ok(m) if !m.is_file() => return false,
-        _ => {}
+    if std::fs::symlink_metadata(&tmp).is_ok() && std::fs::remove_file(&tmp).is_err() {
+        return None;
     }
-    let existed = tmp.is_file();
-    let ok = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .open(&tmp)
-        .is_ok()
-        && super::onenewapi::store::restrict_owner_only(&tmp).is_ok();
-    if !existed {
+    if std::fs::OpenOptions::new().write(true).create_new(true).open(&tmp).is_err() {
+        return None;
+    }
+    if super::onenewapi::store::restrict_owner_only(&tmp).is_err() {
         let _ = std::fs::remove_file(&tmp);
+        return None;
     }
-    ok
+    Some(StagedTmp(tmp))
 }
 
 /// Keep a copy of the CLI's own file before touching it, so a bad write can

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -34,7 +34,7 @@ fn dir_identity(dir: &std::path::Path) -> Option<(String, Option<String>)> {
 }
 
 fn read_auth(dir: &std::path::Path) -> Option<Value> {
-    let raw = std::fs::read_to_string(dir.join("auth.json")).ok()?;
+    let raw = super::read_small_text(&dir.join("auth.json"), MAX_CRED_BYTES, "auth.json").ok()?;
     serde_json::from_str(&raw).ok()
 }
 
@@ -211,14 +211,14 @@ async fn load_access(dir: &std::path::Path) -> Result<Access, String> {
         if refresh.is_empty() {
             return Err("access token expired and no refresh token — run `codex login` again".into());
         }
-        // Refresh rotates the CLI's refresh token. If we can't write it back
-        // (a planted symlink), don't call the token endpoint — that would
-        // sign the CLI out from under the user; a still-valid access token
-        // just skips the refresh.
-        let writable = is_regular_file(&path);
+        // Refresh rotates the CLI's refresh token. If the write-back can't
+        // safely replace the live file (planted symlink, read-only dir),
+        // don't call the token endpoint — that would sign the CLI out from
+        // under the user; a still-valid access token just skips the refresh.
+        let writable = can_stage_write(&path);
         if !writable && access.is_empty() {
             return Err(
-                "Codex credentials are not a regular file — run `codex login` in a terminal".into(),
+                "Codex credentials cannot be updated safely — run `codex login` in a terminal".into(),
             );
         }
         if writable {
@@ -257,7 +257,11 @@ async fn load_access(dir: &std::path::Path) -> Result<Access, String> {
                 backup_credentials(&path);
                 let tmp = path.with_extension("json.tmp");
                 std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
-                    .and_then(|_| std::fs::rename(&tmp, &path))
+                    .map_err(|e| format!("write refreshed auth.json: {e}"))?;
+                // Lock the new pair down to this user before it replaces the
+                // live file (the preflight probe proved this fs accepts it).
+                super::onenewapi::store::restrict_owner_only(&tmp)
+                    .and_then(|_| std::fs::rename(&tmp, &path).map_err(|e| e.to_string()))
                     .map_err(|e| format!("write refreshed auth.json: {e}"))?;
             }
         }
@@ -574,6 +578,38 @@ fn is_regular_file(path: &std::path::Path) -> bool {
     std::fs::symlink_metadata(path)
         .ok()
         .is_some_and(|m| m.is_file() && !m.file_type().is_symlink())
+}
+
+/// Refresh preflight: the write-back must be able to replace the live
+/// file — rotating the refresh token without a working write-back signs
+/// the CLI out. A planted symlink at the predictable tmp path is
+/// unlinked (never its target), then a create + owner-lock probe proves
+/// the directory accepts the full staging chain.
+fn can_stage_write(path: &std::path::Path) -> bool {
+    if !is_regular_file(path) {
+        return false;
+    }
+    let tmp = path.with_extension("json.tmp");
+    match std::fs::symlink_metadata(&tmp) {
+        Ok(m) if m.file_type().is_symlink() => {
+            if std::fs::remove_file(&tmp).is_err() {
+                return false;
+            }
+        }
+        Ok(m) if !m.is_file() => return false,
+        _ => {}
+    }
+    let existed = tmp.is_file();
+    let ok = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(&tmp)
+        .is_ok()
+        && super::onenewapi::store::restrict_owner_only(&tmp).is_ok();
+    if !existed {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    ok
 }
 
 /// Keep a copy of the CLI's own file before touching it, so a bad write can

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const ID: &str = "codex";
 const NAME: &str = "Codex";
+const MAX_CRED_BYTES: u64 = 64 * 1024;
 
 fn default_home() -> PathBuf {
     std::env::var("CODEX_HOME")
@@ -104,6 +105,9 @@ pub fn discover_extra_accounts() -> Vec<CodexAccount> {
             continue;
         }
         let Some((account_id, email)) = identity_from(&doc) else { continue };
+        if !scoped_id_charset(&account_id) {
+            continue;
+        }
         if seen.iter().any(|a| a == &account_id) {
             continue;
         }
@@ -157,7 +161,7 @@ struct Access {
 /// token. Shared by the usage fetch and the reset-credit redeem command.
 async fn load_access(dir: &std::path::Path) -> Result<Access, String> {
     let path = dir.join("auth.json");
-    let raw = std::fs::read_to_string(&path).map_err(|e| format!("read auth.json: {e}"))?;
+    let raw = super::read_small_text(&path, MAX_CRED_BYTES, "auth.json")?;
     let mut doc: Value = serde_json::from_str(&raw).map_err(|e| format!("parse auth.json: {e}"))?;
     let tokens = doc
         .get("tokens")
@@ -207,45 +211,55 @@ async fn load_access(dir: &std::path::Path) -> Result<Access, String> {
         if refresh.is_empty() {
             return Err("access token expired and no refresh token — run `codex login` again".into());
         }
-        let resp = http()
-            .post("https://auth.openai.com/oauth/token")
-            .json(&json!({
-                "client_id": CLIENT_ID,
-                "grant_type": "refresh_token",
-                "refresh_token": refresh,
-                "scope": "openid profile email",
-            }))
-            .send()
-            .await
-            .map_err(|e| format!("token refresh: {e}"))?;
-        if !resp.status().is_success() {
-            return Err(format!("token refresh failed: HTTP {}", resp.status()));
+        // Refresh rotates the CLI's refresh token. If we can't write it back
+        // (a planted symlink), don't call the token endpoint — that would
+        // sign the CLI out from under the user; a still-valid access token
+        // just skips the refresh.
+        let writable = is_regular_file(&path);
+        if !writable && access.is_empty() {
+            return Err(
+                "Codex credentials are not a regular file — run `codex login` in a terminal".into(),
+            );
         }
-        let tok: Value = resp.json().await.map_err(|e| format!("token refresh parse: {e}"))?;
-        let new_access = tok
-            .get("access_token")
-            .and_then(Value::as_str)
-            .ok_or("refresh response missing access_token")?
-            .to_string();
-
-        access = new_access.clone();
-
-        if let Some(t) = doc.get_mut("tokens").filter(|v| v.is_object()) {
-            t["access_token"] = Value::from(new_access);
-            if let Some(r) = tok.get("refresh_token").and_then(Value::as_str) {
-                t["refresh_token"] = Value::from(r);
+        if writable {
+            let resp = http()
+                .post("https://auth.openai.com/oauth/token")
+                .json(&json!({
+                    "client_id": CLIENT_ID,
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh,
+                    "scope": "openid profile email",
+                }))
+                .send()
+                .await
+                .map_err(|e| format!("token refresh: {e}"))?;
+            if !resp.status().is_success() {
+                return Err(format!("token refresh failed: HTTP {}", resp.status()));
             }
-            if let Some(i) = tok.get("id_token").and_then(Value::as_str) {
-                t["id_token"] = Value::from(i);
+            let tok: Value = resp.json().await.map_err(|e| format!("token refresh parse: {e}"))?;
+            let new_access = tok
+                .get("access_token")
+                .and_then(Value::as_str)
+                .ok_or("refresh response missing access_token")?
+                .to_string();
+
+            access = new_access.clone();
+
+            if let Some(t) = doc.get_mut("tokens").filter(|v| v.is_object()) {
+                t["access_token"] = Value::from(new_access);
+                if let Some(r) = tok.get("refresh_token").and_then(Value::as_str) {
+                    t["refresh_token"] = Value::from(r);
+                }
+                if let Some(i) = tok.get("id_token").and_then(Value::as_str) {
+                    t["id_token"] = Value::from(i);
+                }
+                doc["last_refresh"] = Value::from(Utc::now().to_rfc3339());
+                backup_credentials(&path);
+                let tmp = path.with_extension("json.tmp");
+                std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
+                    .and_then(|_| std::fs::rename(&tmp, &path))
+                    .map_err(|e| format!("write refreshed auth.json: {e}"))?;
             }
-            doc["last_refresh"] = Value::from(Utc::now().to_rfc3339());
-            // Keep a copy of the CLI's own file before touching it, so a bad
-            // write can never cost the user their login.
-            let _ = std::fs::copy(&path, path.with_extension("json.pane-bak"));
-            let tmp = path.with_extension("json.tmp");
-            std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
-                .and_then(|_| std::fs::rename(&tmp, &path))
-                .map_err(|e| format!("write refreshed auth.json: {e}"))?;
         }
     }
 
@@ -399,71 +413,6 @@ fn credits_balance(usage: &Value) -> Option<f64> {
         })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{credits_balance, identity_from, openai_provenance};
-    use base64::Engine;
-    use serde_json::json;
-
-    fn fake_id_token(claims: serde_json::Value) -> String {
-        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .encode(serde_json::to_vec(&claims).unwrap());
-        format!("x.{payload}.y")
-    }
-
-    #[test]
-    fn provenance_requires_openais_claim_namespace() {
-        // A foreign auth.json with the right field SHAPE but no OpenAI
-        // claim — the misclassification case — must not pass.
-        let foreign = json!({"tokens": {"account_id": "some-other-account",
-            "access_token": "foreign-access", "refresh_token": "foreign-refresh"}});
-        assert!(!openai_provenance(&foreign));
-        // Even with a JWT id_token, foreign claims don't count.
-        let foreign_jwt = json!({"tokens": {"account_id": "acct",
-            "id_token": fake_id_token(json!({"iss": "https://example.com"}))}});
-        assert!(!openai_provenance(&foreign_jwt));
-        // A real Codex login carries OpenAI's claim namespace.
-        let real = json!({"tokens": {"account_id": "acct",
-            "id_token": fake_id_token(json!({
-                "https://api.openai.com/auth": {"chatgpt_account_id": "acct"}}))}});
-        assert!(openai_provenance(&real));
-        assert!(!openai_provenance(&json!({})));
-    }
-
-    #[test]
-    fn codex_identity_extraction_is_validation() {
-        // account_id field wins; email claim labels the card.
-        let direct = json!({"tokens": {"account_id": "acct-1",
-            "id_token": fake_id_token(json!({"email": "e@corp.com"}))}});
-        assert_eq!(identity_from(&direct), Some(("acct-1".into(), Some("e@corp.com".into()))));
-        // Empty account_id falls through to the id_token's ChatGPT claim.
-        let via_claim = json!({"tokens": {"account_id": "",
-            "id_token": fake_id_token(json!({
-                "https://api.openai.com/auth": {"chatgpt_account_id": "acct-2"}}))}});
-        assert_eq!(identity_from(&via_claim), Some(("acct-2".into(), None)));
-        // Neither → no identity → no card.
-        let anonymous = json!({"tokens": {"access_token": "k"}});
-        assert_eq!(identity_from(&anonymous), None);
-        assert_eq!(identity_from(&json!({})), None);
-    }
-
-    #[test]
-    fn credit_balance_parses_number_and_string_spellings() {
-        // String balance (the shape rollout logs show) — the bug that made
-        // a freshly bought balance vanish from the card entirely.
-        let s = json!({"credits": {"has_credits": true, "balance": "2500"}});
-        assert_eq!(credits_balance(&s), Some(2500.0));
-        // Number balance.
-        let n = json!({"credits": {"has_credits": true, "balance": 125.0}});
-        assert_eq!(credits_balance(&n), Some(125.0));
-        // No balance field, explicitly no credits → explicit zero row.
-        let none = json!({"credits": {"has_credits": false}});
-        assert_eq!(credits_balance(&none), Some(0.0));
-        // No credits object at all → no row.
-        assert_eq!(credits_balance(&json!({})), None);
-    }
-}
-
 const CREDITS_URL: &str = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
 
 /// Epoch seconds, epoch ms, or RFC3339 → epoch ms.
@@ -613,4 +562,103 @@ fn push_window_inner(metrics: &mut Vec<Metric>, node: Option<&Value>, label_in: 
     // normalization because it masked real early usage; near-empty windows
     // are kept calm on the pacing side instead.
     metrics.push(Metric::progress(label, used, None).with_reset(resets_at, Some(period_ms)));
+}
+
+/// The account id becomes `codex@<hash8>`, which the frontend interpolates
+/// into HTML attributes — only [A-Za-z0-9-] is safe there.
+fn scoped_id_charset(raw: &str) -> bool {
+    !raw.is_empty() && raw.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+}
+
+fn is_regular_file(path: &std::path::Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .ok()
+        .is_some_and(|m| m.is_file() && !m.file_type().is_symlink())
+}
+
+/// Keep a copy of the CLI's own file before touching it, so a bad write can
+/// never cost the user their login. A planted symlink at the backup path is
+/// unlinked first — never write through it.
+fn backup_credentials(path: &std::path::Path) {
+    let bak = path.with_extension("json.pane-bak");
+    if std::fs::symlink_metadata(&bak)
+        .ok()
+        .is_some_and(|m| m.file_type().is_symlink())
+    {
+        let _ = std::fs::remove_file(&bak);
+    }
+    let _ = std::fs::copy(path, &bak);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{credits_balance, identity_from, openai_provenance, scoped_id_charset};
+    use base64::Engine;
+    use serde_json::json;
+
+    fn fake_id_token(claims: serde_json::Value) -> String {
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&claims).unwrap());
+        format!("x.{payload}.y")
+    }
+
+    #[test]
+    fn provenance_requires_openais_claim_namespace() {
+        // A foreign auth.json with the right field SHAPE but no OpenAI
+        // claim — the misclassification case — must not pass.
+        let foreign = json!({"tokens": {"account_id": "some-other-account",
+            "access_token": "foreign-access", "refresh_token": "foreign-refresh"}});
+        assert!(!openai_provenance(&foreign));
+        // Even with a JWT id_token, foreign claims don't count.
+        let foreign_jwt = json!({"tokens": {"account_id": "acct",
+            "id_token": fake_id_token(json!({"iss": "https://example.com"}))}});
+        assert!(!openai_provenance(&foreign_jwt));
+        // A real Codex login carries OpenAI's claim namespace.
+        let real = json!({"tokens": {"account_id": "acct",
+            "id_token": fake_id_token(json!({
+                "https://api.openai.com/auth": {"chatgpt_account_id": "acct"}}))}});
+        assert!(openai_provenance(&real));
+        assert!(!openai_provenance(&json!({})));
+    }
+
+    #[test]
+    fn codex_identity_extraction() {
+        // account_id field wins; email claim labels the card.
+        let direct = json!({"tokens": {"account_id": "acct-1",
+            "id_token": fake_id_token(json!({"email": "e@corp.com"}))}});
+        assert_eq!(identity_from(&direct), Some(("acct-1".into(), Some("e@corp.com".into()))));
+        // Empty account_id falls through to the id_token's ChatGPT claim.
+        let via_claim = json!({"tokens": {"account_id": "",
+            "id_token": fake_id_token(json!({
+                "https://api.openai.com/auth": {"chatgpt_account_id": "acct-2"}}))}});
+        assert_eq!(identity_from(&via_claim), Some(("acct-2".into(), None)));
+        // Neither → no identity → no card.
+        let anonymous = json!({"tokens": {"access_token": "k"}});
+        assert_eq!(identity_from(&anonymous), None);
+        assert_eq!(identity_from(&json!({})), None);
+    }
+
+    #[test]
+    fn scoped_id_charset_is_html_attribute_safe() {
+        assert!(scoped_id_charset("b3f1c2d4-9a8b-4c5d-8e9f-aabbccddeeff"));
+        assert!(!scoped_id_charset(""));
+        assert!(!scoped_id_charset("evil\"><script>"));
+        assert!(!scoped_id_charset("with space"));
+    }
+
+    #[test]
+    fn credit_balance_parses_number_and_string_spellings() {
+        // String balance (the shape rollout logs show) — the bug that made
+        // a freshly bought balance vanish from the card entirely.
+        let s = json!({"credits": {"has_credits": true, "balance": "2500"}});
+        assert_eq!(credits_balance(&s), Some(2500.0));
+        // Number balance.
+        let n = json!({"credits": {"has_credits": true, "balance": 125.0}});
+        assert_eq!(credits_balance(&n), Some(125.0));
+        // No balance field, explicitly no credits → explicit zero row.
+        let none = json!({"credits": {"has_credits": false}});
+        assert_eq!(credits_balance(&none), Some(0.0));
+        // No credits object at all → no row.
+        assert_eq!(credits_balance(&json!({})), None);
+    }
 }

--- a/src-tauri/src/providers/copilot.rs
+++ b/src-tauri/src/providers/copilot.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 const ID: &str = "copilot";
 const NAME: &str = "Copilot";
+const MAX_CRED_BYTES: u64 = 64 * 1024;
 
 /// GitHub tokens can come from Copilot's editor config or the GitHub CLI.
 /// Every source is scoped to github.com: this snapshot only ever talks to
@@ -20,7 +21,7 @@ fn find_token() -> Option<String> {
         candidates.push(home.join(".config").join("github-copilot").join("hosts.json"));
     }
     for path in candidates {
-        let Ok(raw) = std::fs::read_to_string(&path) else { continue };
+        let Ok(raw) = super::read_small_text(&path, MAX_CRED_BYTES, "credentials") else { continue };
         if let Some(tok) = copilot_json_token(&raw) {
             return Some(tok);
         }
@@ -167,6 +168,27 @@ async fn fetch() -> Result<Snapshot, String> {
     Ok(Snapshot::ok(ID, NAME, plan, metrics))
 }
 
+fn push_quota(metrics: &mut Vec<Metric>, node: Option<&Value>, label: &str, resets_at: Option<i64>) {
+    const MONTH_MS: i64 = 30 * 86_400_000;
+    let Some(node) = node else { return };
+    if node.get("unlimited").and_then(Value::as_bool) == Some(true) {
+        metrics.push(Metric::text(label, "Unlimited".into()));
+        return;
+    }
+    let Some(percent_remaining) = node.get("percent_remaining").and_then(Value::as_f64) else {
+        return;
+    };
+    let detail = (|| {
+        let remaining = node.get("remaining").and_then(Value::as_f64)?;
+        let entitlement = node.get("entitlement").and_then(Value::as_f64)?;
+        Some(format!("{remaining:.0} of {entitlement:.0} left"))
+    })();
+    metrics.push(
+        Metric::progress(label, 100.0 - percent_remaining, detail)
+            .with_reset(resets_at, Some(MONTH_MS)),
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::{copilot_json_token, hosts_yml_token};
@@ -227,25 +249,4 @@ mod tests {
             eprintln!("  {}: used={:?} value={:?}", m.label, m.used_percent, m.value);
         }
     }
-}
-
-fn push_quota(metrics: &mut Vec<Metric>, node: Option<&Value>, label: &str, resets_at: Option<i64>) {
-    const MONTH_MS: i64 = 30 * 86_400_000;
-    let Some(node) = node else { return };
-    if node.get("unlimited").and_then(Value::as_bool) == Some(true) {
-        metrics.push(Metric::text(label, "Unlimited".into()));
-        return;
-    }
-    let Some(percent_remaining) = node.get("percent_remaining").and_then(Value::as_f64) else {
-        return;
-    };
-    let detail = (|| {
-        let remaining = node.get("remaining").and_then(Value::as_f64)?;
-        let entitlement = node.get("entitlement").and_then(Value::as_f64)?;
-        Some(format!("{remaining:.0} of {entitlement:.0} left"))
-    })();
-    metrics.push(
-        Metric::progress(label, 100.0 - percent_remaining, detail)
-            .with_reset(resets_at, Some(MONTH_MS)),
-    );
 }

--- a/src-tauri/src/providers/copilot.rs
+++ b/src-tauri/src/providers/copilot.rs
@@ -32,7 +32,7 @@ fn find_token() -> Option<String> {
     let mut usernames: Vec<String> = Vec::new();
     if let Ok(appdata) = std::env::var("APPDATA") {
         let hosts = PathBuf::from(appdata).join("GitHub CLI").join("hosts.yml");
-        if let Ok(raw) = std::fs::read_to_string(&hosts) {
+        if let Ok(raw) = super::read_small_text(&hosts, MAX_CRED_BYTES, "hosts.yml") {
             if let Some(tok) = hosts_yml_token(&raw, &mut usernames) {
                 return Some(tok);
             }

--- a/src-tauri/src/providers/kilo.rs
+++ b/src-tauri/src/providers/kilo.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 
 const ID: &str = "kilo";
 const NAME: &str = "Kilo";
+const MAX_CRED_BYTES: u64 = 64 * 1024;
 
 pub async fn snapshot() -> Snapshot {
     match fetch().await {
@@ -14,7 +15,8 @@ pub async fn snapshot() -> Snapshot {
 /// The Kilo CLI keeps its session at ~/.local/share/kilo/auth.json → kilo.access
 fn cli_token() -> Option<String> {
     let path = dirs::home_dir()?.join(".local").join("share").join("kilo").join("auth.json");
-    let doc: Value = serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()?;
+    let raw = super::read_small_text(&path, MAX_CRED_BYTES, "credentials").ok()?;
+    let doc: Value = serde_json::from_str(&raw).ok()?;
     doc.pointer("/kilo/access").and_then(Value::as_str).map(str::to_string)
 }
 
@@ -176,7 +178,7 @@ fn urlencoding_min(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     /// Live probe against this machine's real Kilo session: prints the raw
-    /// tRPC response (status + first 2000 chars) so shape changes can be
+    /// tRPC response (status + first 200 chars) so shape changes can be
     /// diagnosed. Run: cargo test --lib kilo -- --ignored --nocapture
     #[test]
     #[ignore]
@@ -193,6 +195,6 @@ mod tests {
             (r.status().as_u16(), r.text().await.unwrap_or_default())
         });
         eprintln!("kilo probe: HTTP {status}");
-        eprintln!("{}", body.chars().take(2000).collect::<String>());
+        eprintln!("{}", body.chars().take(200).collect::<String>());
     }
 }

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -239,18 +239,19 @@ async fn load_access(path: &Path, force: bool) -> Result<String, String> {
             "token expired and no refresh token present — run `kimi login` in a terminal".into(),
         );
     }
-    // Refresh rotates the CLI's refresh token. If the write-back can't
-    // safely replace the live file (planted symlink, read-only dir),
-    // don't call the token endpoint — that would sign the CLI out from
-    // under the user.
-    if !can_write_creds(path) {
-        if !access.is_empty() && !force {
+    // Refresh rotates the CLI's refresh token. Stage the write-back BEFORE
+    // the token call: if the refreshed pair can't replace the live file,
+    // the rotation would sign the CLI out from under the user. Only a token
+    // whose expiry is still in the future may skip the refresh; an expired
+    // one would just earn a vendor rejection.
+    let Some(staged) = stage_credentials_tmp(path) else {
+        if !access.is_empty() && expires_ms > now_ms && !force {
             return Ok(access);
         }
         return Err(
             "Kimi Code credentials cannot be updated safely — run `kimi login` in a terminal".into(),
         );
-    }
+    };
 
     let form = [
         ("grant_type", "refresh_token"),
@@ -298,12 +299,12 @@ async fn load_access(path: &Path, force: bool) -> Result<String, String> {
         // The CLI stores unix seconds (sometimes with a fractional part).
         doc["expires_at"] = Value::from((now_ms / 1000) + expires_in);
         backup_credentials(path);
-        let tmp = path.with_extension("json.tmp");
-        std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
+        // The tmp was created fresh and owner-locked at staging.
+        staged
+            .write(&serde_json::to_string_pretty(&doc).unwrap_or(raw))
             .map_err(|e| format!("write refreshed credentials: {e}"))?;
-        // Lock the new pair down to this user before it replaces the live file.
-        super::onenewapi::store::restrict_owner_only(&tmp)
-            .and_then(|_| std::fs::rename(&tmp, path).map_err(|e| e.to_string()))
+        staged
+            .commit(path)
             .map_err(|e| format!("write refreshed credentials: {e}"))?;
         // Refresh landed — the backup holds the previous token pair, so don't
         // leave it on disk. A failed write above returns before this.
@@ -312,36 +313,47 @@ async fn load_access(path: &Path, force: bool) -> Result<String, String> {
     Ok(access)
 }
 
-/// Refresh preflight: the write-back must be able to replace the live
-/// file — rotating the refresh token without a working write-back signs
-/// the CLI out. A planted symlink at the predictable tmp path is unlinked
-/// (never its target), then a create + owner-lock probe proves the
-/// directory accepts the full staging chain.
-fn can_write_creds(path: &Path) -> bool {
+/// Proof the refreshed credential pair can replace the live file BEFORE the
+/// rotating token call: any leftover or planted file at the predictable tmp
+/// path is removed outright (a symlink or hardlink redirect is never written
+/// through), a fresh tmp is created with create_new and owner-locked, and it
+/// stays staged until commit so nothing can be planted in the gap. Drop
+/// removes the tmp when the refresh never lands.
+struct StagedTmp(PathBuf);
+
+impl StagedTmp {
+    fn write(&self, contents: &str) -> std::io::Result<()> {
+        std::fs::write(&self.0, contents)
+    }
+    fn commit(self, live: &Path) -> std::io::Result<()> {
+        std::fs::rename(&self.0, live)?;
+        std::mem::forget(self);
+        Ok(())
+    }
+}
+
+impl Drop for StagedTmp {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn stage_credentials_tmp(path: &Path) -> Option<StagedTmp> {
     if !is_regular_file(path) {
-        return false;
+        return None;
     }
     let tmp = path.with_extension("json.tmp");
-    match std::fs::symlink_metadata(&tmp) {
-        Ok(m) if m.file_type().is_symlink() => {
-            if std::fs::remove_file(&tmp).is_err() {
-                return false;
-            }
-        }
-        Ok(m) if !m.is_file() => return false,
-        _ => {}
+    if std::fs::symlink_metadata(&tmp).is_ok() && std::fs::remove_file(&tmp).is_err() {
+        return None;
     }
-    let existed = tmp.is_file();
-    let ok = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .open(&tmp)
-        .is_ok()
-        && super::onenewapi::store::restrict_owner_only(&tmp).is_ok();
-    if !existed {
+    if std::fs::OpenOptions::new().write(true).create_new(true).open(&tmp).is_err() {
+        return None;
+    }
+    if super::onenewapi::store::restrict_owner_only(&tmp).is_err() {
         let _ = std::fs::remove_file(&tmp);
+        return None;
     }
-    ok
+    Some(StagedTmp(tmp))
 }
 
 fn is_regular_file(path: &Path) -> bool {

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -296,11 +296,17 @@ async fn load_access(path: &Path, force: bool) -> Result<String, String> {
         doc["expires_in"] = Value::from(expires_in);
         // The CLI stores unix seconds (sometimes with a fractional part).
         doc["expires_at"] = Value::from((now_ms / 1000) + expires_in);
-        let _ = std::fs::copy(path, path.with_extension("json.pane-bak"));
+        backup_credentials(path);
         let tmp = path.with_extension("json.tmp");
         std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
-            .and_then(|_| std::fs::rename(&tmp, path))
             .map_err(|e| format!("write refreshed credentials: {e}"))?;
+        // Lock the new pair down to this user before it replaces the live file.
+        super::onenewapi::store::restrict_owner_only(&tmp)
+            .and_then(|_| std::fs::rename(&tmp, path).map_err(|e| e.to_string()))
+            .map_err(|e| format!("write refreshed credentials: {e}"))?;
+        // Refresh landed — the backup holds the previous token pair, so don't
+        // leave it on disk. A failed write above returns before this.
+        let _ = std::fs::remove_file(path.with_extension("json.pane-bak"));
     }
     Ok(access)
 }
@@ -313,6 +319,20 @@ fn is_regular_file(path: &Path) -> bool {
     std::fs::symlink_metadata(path)
         .ok()
         .is_some_and(|m| m.is_file() && !m.file_type().is_symlink())
+}
+
+/// Keep a copy of the CLI's own file before touching it, so a bad write can
+/// never cost the user their login. A planted symlink at the backup path is
+/// unlinked first — never write through it.
+fn backup_credentials(path: &Path) {
+    let bak = path.with_extension("json.pane-bak");
+    if std::fs::symlink_metadata(&bak)
+        .ok()
+        .is_some_and(|m| m.file_type().is_symlink())
+    {
+        let _ = std::fs::remove_file(&bak);
+    }
+    let _ = std::fs::copy(path, &bak);
 }
 
 async fn bounded_text(resp: reqwest::Response, max_bytes: usize) -> String {
@@ -422,7 +442,7 @@ fn map_membership_level(raw: &str) -> Option<String> {
         }
         "ADVANCED" | "ALLEGRO" => "Allegro".into(),
         "PREMIUM" | "VIVACE" => "Vivace".into(),
-        other if other.is_empty() => return None,
+        "" => return None,
         other => title_case(other),
     })
 }

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -239,15 +239,16 @@ async fn load_access(path: &Path, force: bool) -> Result<String, String> {
             "token expired and no refresh token present — run `kimi login` in a terminal".into(),
         );
     }
-    // Refresh rotates the CLI's refresh token. If we can't write it back
-    // (a planted symlink), don't call the token endpoint — that would
-    // sign the CLI out from under the user.
+    // Refresh rotates the CLI's refresh token. If the write-back can't
+    // safely replace the live file (planted symlink, read-only dir),
+    // don't call the token endpoint — that would sign the CLI out from
+    // under the user.
     if !can_write_creds(path) {
         if !access.is_empty() && !force {
             return Ok(access);
         }
         return Err(
-            "Kimi Code credentials are not a regular file — run `kimi login` in a terminal".into(),
+            "Kimi Code credentials cannot be updated safely — run `kimi login` in a terminal".into(),
         );
     }
 
@@ -311,8 +312,36 @@ async fn load_access(path: &Path, force: bool) -> Result<String, String> {
     Ok(access)
 }
 
+/// Refresh preflight: the write-back must be able to replace the live
+/// file — rotating the refresh token without a working write-back signs
+/// the CLI out. A planted symlink at the predictable tmp path is unlinked
+/// (never its target), then a create + owner-lock probe proves the
+/// directory accepts the full staging chain.
 fn can_write_creds(path: &Path) -> bool {
-    is_regular_file(path)
+    if !is_regular_file(path) {
+        return false;
+    }
+    let tmp = path.with_extension("json.tmp");
+    match std::fs::symlink_metadata(&tmp) {
+        Ok(m) if m.file_type().is_symlink() => {
+            if std::fs::remove_file(&tmp).is_err() {
+                return false;
+            }
+        }
+        Ok(m) if !m.is_file() => return false,
+        _ => {}
+    }
+    let existed = tmp.is_file();
+    let ok = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(&tmp)
+        .is_ok()
+        && super::onenewapi::store::restrict_owner_only(&tmp).is_ok();
+    if !existed {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    ok
 }
 
 fn is_regular_file(path: &Path) -> bool {

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -221,10 +221,17 @@ pub(crate) fn read_small_text(
     if meta.file_type().is_symlink() || !meta.is_file() {
         return Err(format!("{what} is not a regular file"));
     }
-    if meta.len() > max_bytes {
+    // Read through a bounded reader — a file that grows or is swapped after
+    // the metadata check still can't exceed the cap.
+    let file = std::fs::File::open(path).map_err(|e| format!("read {what}: {e}"))?;
+    let mut limited = std::io::Read::take(file, max_bytes + 1);
+    let mut text = String::new();
+    std::io::Read::read_to_string(&mut limited, &mut text)
+        .map_err(|e| format!("read {what}: {e}"))?;
+    if text.len() as u64 > max_bytes {
         return Err(format!("{what} is unexpectedly large — not reading it"));
     }
-    std::fs::read_to_string(path).map_err(|e| format!("read {what}: {e}"))
+    Ok(text)
 }
 
 /// Where Pane keeps its own settings, e.g. saved API keys:

--- a/src-tauri/src/providers/onenewapi/mod.rs
+++ b/src-tauri/src/providers/onenewapi/mod.rs
@@ -2,7 +2,7 @@ mod billing;
 mod fingerprint;
 pub(super) mod ids;
 mod snapshot;
-pub(super) mod store;
+pub(crate) mod store;
 pub(super) mod url;
 
 use serde::Serialize;
@@ -135,14 +135,6 @@ pub async fn create_site_at(
     store::insert_site(path, &name, &normalized, display)
 }
 
-pub async fn update_site(
-    id: String,
-    name: Option<String>,
-    base_url: Option<String>,
-) -> Result<SiteDto, String> {
-    update_site_at(&store_path(), &id, name, base_url).await
-}
-
 pub(crate) fn normalize_site_url(base_url: &str) -> Result<String, String> {
     Ok(url::normalize_base_url(base_url)?.origin)
 }
@@ -170,6 +162,7 @@ where
     )
 }
 
+#[cfg(test)]
 pub async fn update_site_at(
     path: &Path,
     id: &str,
@@ -198,11 +191,6 @@ pub async fn update_site_at(
     store::update_site(path, id, name, new_url, display)
 }
 
-pub fn delete_site(id: String) -> Result<(), String> {
-    let _lock = lock_store_mutation()?;
-    store::delete_site(&store_path(), &id)
-}
-
 pub(crate) fn delete_site_consistently<Cleanup>(id: String, cleanup: Cleanup) -> Result<(), String>
 where
     Cleanup: FnOnce() -> Result<(), String>,
@@ -226,16 +214,6 @@ pub fn create_key(site_id: String, label: String, api_key: String) -> Result<Cre
     store::create_key(&store_path(), &site_id, &label, &api_key)
 }
 
-pub fn update_key(
-    site_id: String,
-    key_id: String,
-    label: Option<String>,
-    api_key: Option<String>,
-) -> Result<SiteDto, String> {
-    let _lock = lock_store_mutation()?;
-    store::update_key(&store_path(), &site_id, &key_id, label, api_key)
-}
-
 pub(crate) fn update_key_consistently<Cleanup>(
     site_id: String,
     key_id: String,
@@ -251,11 +229,6 @@ where
         |path| store::update_key(path, &site_id, &key_id, label, api_key),
         cleanup,
     )
-}
-
-pub fn delete_key(site_id: String, key_id: String) -> Result<SiteDto, String> {
-    let _lock = lock_store_mutation()?;
-    store::delete_key(&store_path(), &site_id, &key_id)
 }
 
 pub(crate) fn delete_key_consistently<Cleanup>(

--- a/src-tauri/src/providers/onenewapi/snapshot.rs
+++ b/src-tauri/src/providers/onenewapi/snapshot.rs
@@ -535,8 +535,8 @@ mod tests {
             .filter_map(|c| c.authorization.as_deref())
             .collect();
         auths.sort_unstable();
-        assert!(auths.iter().any(|a| *a == "Bearer sk-a"));
-        assert!(auths.iter().any(|a| *a == "Bearer sk-b"));
+        assert!(auths.contains(&"Bearer sk-a"));
+        assert!(auths.contains(&"Bearer sk-b"));
         assert!(captured.iter().all(|c| {
             c.authorization.as_deref() == Some("Bearer sk-a")
                 || c.authorization.as_deref() == Some("Bearer sk-b")

--- a/src-tauri/src/providers/onenewapi/store.rs
+++ b/src-tauri/src/providers/onenewapi/store.rs
@@ -79,12 +79,12 @@ pub fn load(path: &Path) -> Result<StoreFile, String> {
         });
     }
     if path.is_file() {
-        let _ = restrict_owner_only(path);
+        restrict_owner_only(path)?;
     }
     let raw = super::super::read_small_text(path, 1_048_576, "onenewapi.json")?;
     let raw = raw.trim_start_matches('\u{feff}');
     let doc: StoreFile =
-        serde_json::from_str(raw).map_err(|e| format!("onenewapi.json is unreadable: {e}"))?;
+        serde_json::from_str(raw).map_err(|_| "onenewapi.json is unreadable".to_string())?;
     if doc.version != 1 {
         return Err(format!(
             "onenewapi.json has unsupported version {}",
@@ -448,6 +448,7 @@ pub fn update_site(
     Ok(dto)
 }
 
+#[cfg(test)]
 pub fn set_display_unit(path: &Path, id: &str, display: DisplayUnit) -> Result<(), String> {
     let mut doc = load(path)?;
     let site = doc

--- a/src-tauri/src/providers/sub2api/snapshot.rs
+++ b/src-tauri/src/providers/sub2api/snapshot.rs
@@ -331,8 +331,9 @@ fn parse(body: &serde_json::Value) -> Result<(Option<String>, Vec<Metric>), Stri
             .filter(|s| !s.trim().is_empty())
             .unwrap_or("Subscription")
             .to_string()
-    } else if (mode == Some("unrestricted") || legacy) && balance.is_some() && !conflict {
-        let balance = balance.unwrap();
+    } else if let Some(balance) =
+        balance.filter(|_| (mode == Some("unrestricted") || legacy) && !conflict)
+    {
         let unit = body.get("unit").and_then(|v| v.as_str()).unwrap_or("USD");
         let amount = if unit == "USD" {
             format!("${balance:.2}")
@@ -361,7 +362,7 @@ fn parse(body: &serde_json::Value) -> Result<(Option<String>, Vec<Metric>), Stri
     };
     apply_status(body, &mut metrics);
     summaries(body, &mut metrics);
-    Ok((Some(plan.into()), metrics))
+    Ok((Some(plan), metrics))
 }
 
 fn apply_status(body: &serde_json::Value, metrics: &mut Vec<Metric>) {


### PR DESCRIPTION
## What

Security-audit fixes for credential storage across providers:

- **Capped, symlink-aware credential reads** — Claude, Codex, Kilo, Codebuff, and Copilot token files now load via the existing `read_small_text` helper (regular-file check + 64 KiB cap) instead of uncapped `read_to_string`.
- **Symlink-safe write-backs** — Claude/Codex token refresh write-backs refuse symlinked credential files before calling the token endpoint (a refresh rotates the CLI's refresh token server-side, so a failed write-back would sign the CLI out); `.pane-bak` backups unlink a planted symlink at the backup path before copying.
- **Scoped account IDs validated** — `accountUuid` / `account_id` from Claude/Codex credential files are checked against `[A-Za-z0-9-]+` before becoming `provider@hash8` IDs that the frontend interpolates into HTML attributes (frontend-side escaping lands in the webview PR — defense in depth).
- **Kimi `.pane-bak` cleanup** — the pre-refresh token backup is deleted after a successful refresh write instead of keeping the old token pair on disk forever; the refreshed file is written owner-only.
- **One/New API store** — parse errors no longer echo serde detail that can quote key fragments; load-time DACL re-tighten is now fail-closed like Sub2API; `store` module widened to `pub(crate)` (the core PR calls `atomic_write` from `lib.rs`); dead helpers deleted or `#[cfg(test)]`-gated.

## Tests

- New: `scoped_id_charset_is_html_attribute_safe` in claude/codex; existing store ACL/redaction suites unchanged and green.
- `cargo test --lib` green on the combined branch (362 passed); this PR is a whole-file subset of it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->