### PR TITLE
Harden provider network clients: no redirects/proxy on loopback, allowlisted token endpoints

### DIFF
--- a/src-tauri/src/providers/antigravity.rs
+++ b/src-tauri/src/providers/antigravity.rs
@@ -183,10 +183,14 @@ fn discover_language_servers() -> Vec<LanguageServer> {
 // ---------------------------------------------------------------------------
 
 /// The LS uses a self-signed cert on loopback; this client is only ever
-/// pointed at 127.0.0.1.
+/// pointed at 127.0.0.1. A legit server never redirects (a redirect would
+/// carry the csrf header cross-origin) and plaintext loopback must never
+/// ride a proxy.
 fn ls_client() -> reqwest::Client {
     reqwest::Client::builder()
         .danger_accept_invalid_certs(true)
+        .redirect(reqwest::redirect::Policy::none())
+        .no_proxy()
         .timeout(Duration::from_secs(10))
         .build()
         .unwrap_or_else(|_| super::http())

--- a/src-tauri/src/providers/devin.rs
+++ b/src-tauri/src/providers/devin.rs
@@ -7,6 +7,16 @@ const NAME: &str = "Devin";
 // Mirrors the Mac app's DevinUsageClient — the server expects an IDE-shaped
 // client identity and the Connect RPC protocol header.
 const COMPAT_VERSION: &str = "1.108.2";
+/// The vendor default — the only host that may receive the API key.
+const DEFAULT_SERVER_URL: &str = "https://server.codeium.com";
+
+/// The API key rides every status request; a planted api_server_url in
+/// credentials.toml would exfiltrate it. Vendor host over https only.
+fn is_trusted_server(url: &str) -> bool {
+    reqwest::Url::parse(url)
+        .map(|u| u.scheme() == "https" && u.host_str() == Some("server.codeium.com"))
+        .unwrap_or(false)
+}
 
 fn credentials_paths() -> Vec<PathBuf> {
     let mut paths = Vec::new();
@@ -119,13 +129,12 @@ mod tests {
             .unwrap();
         println!("status: {}", resp.status());
         let body: Value = resp.json().await.unwrap();
-        println!(
-            "planStatus: {}",
-            serde_json::to_string_pretty(
-                body.pointer("/userStatus/planStatus").unwrap_or(&Value::Null)
-            )
-            .unwrap()
-        );
+        let dump = serde_json::to_string_pretty(
+            body.pointer("/userStatus/planStatus").unwrap_or(&Value::Null),
+        )
+        .unwrap();
+        let dump: String = dump.chars().take(200).collect();
+        println!("planStatus: {dump}");
     }
 }
 
@@ -148,9 +157,17 @@ async fn fetch() -> Result<Snapshot, String> {
     let server = doc
         .get("api_server_url")
         .and_then(toml::Value::as_str)
-        .unwrap_or("https://server.codeium.com")
-        .trim_end_matches('/')
-        .to_string();
+        .unwrap_or(DEFAULT_SERVER_URL)
+        .trim_end_matches('/');
+    if !is_trusted_server(server) {
+        eprintln!(
+            "[pane] devin: credentials.toml api_server_url is not {DEFAULT_SERVER_URL} — skipping status request"
+        );
+        return Err(
+            "Devin credentials point at an unexpected server — sign in with the Devin CLI again".into(),
+        );
+    }
+    let server = server.to_string();
 
     let resp = http()
         .post(format!(
@@ -334,13 +351,18 @@ pub fn collect_usage_events() -> Vec<UsageEvent> {
     }
 }
 
+/// sessions.db keeps one row per message per branch and can be GBs; cap
+/// the scan so a bloated db can't pin a refresh. Real data is far below.
+const MAX_MESSAGE_ROWS: usize = 2_000_000;
+
 fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
     let conn = super::open_readonly_sqlite(db)?;
     let mut stmt = conn
-        .prepare(
+        .prepare(&format!(
             "SELECT m.session_id, m.chat_message, m.created_at, s.model
-             FROM message_nodes m JOIN sessions s ON s.id = m.session_id",
-        )
+             FROM message_nodes m JOIN sessions s ON s.id = m.session_id
+             LIMIT {MAX_MESSAGE_ROWS}"
+        ))
         .map_err(|e| format!("query messages: {e}"))?;
     let rows = stmt
         .query_map([], |row| {
@@ -355,7 +377,9 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
 
     let mut seen = std::collections::HashSet::new();
     let mut out = Vec::new();
+    let mut scanned = 0usize;
     for row in rows.flatten() {
+        scanned += 1;
         let (session_id, chat_message, node_created_s, model) = row;
         let Ok(msg) = serde_json::from_str::<Value>(&chat_message) else { continue };
         if msg.get("role").and_then(Value::as_str) != Some("assistant") {
@@ -398,6 +422,11 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
             cache_read: num("cache_read_tokens"),
             cache_write: num("cache_creation_tokens"),
         });
+    }
+    if scanned >= MAX_MESSAGE_ROWS {
+        eprintln!(
+            "[pane] devin: sessions.db exceeds {MAX_MESSAGE_ROWS} rows — usage beyond the cap is not counted"
+        );
     }
     Ok(out)
 }

--- a/src-tauri/src/providers/devin.rs
+++ b/src-tauri/src/providers/devin.rs
@@ -1,4 +1,4 @@
-use super::{http, Metric, Snapshot};
+use super::{http, http_no_redirect, Metric, Snapshot};
 use serde_json::{json, Value};
 use std::path::PathBuf;
 
@@ -169,7 +169,9 @@ async fn fetch() -> Result<Snapshot, String> {
     }
     let server = server.to_string();
 
-    let resp = http()
+    // The body carries the API key: never follow redirects — a 307/308
+    // re-sends the body to the redirect target cross-origin.
+    let resp = http_no_redirect()
         .post(format!(
             "{server}/exa.seat_management_pb.SeatManagementService/GetUserStatus"
         ))
@@ -352,7 +354,9 @@ pub fn collect_usage_events() -> Vec<UsageEvent> {
 }
 
 /// sessions.db keeps one row per message per branch and can be GBs; cap
-/// the scan so a bloated db can't pin a refresh. Real data is far below.
+/// the scan so a bloated db can't pin a refresh. Newest-first ordering
+/// makes the cap deterministic: the oldest rows are dropped, never the
+/// recent ones. Real data is far below.
 const MAX_MESSAGE_ROWS: usize = 2_000_000;
 
 fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
@@ -361,6 +365,7 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
         .prepare(&format!(
             "SELECT m.session_id, m.chat_message, m.created_at, s.model
              FROM message_nodes m JOIN sessions s ON s.id = m.session_id
+             ORDER BY m.created_at DESC
              LIMIT {MAX_MESSAGE_ROWS}"
         ))
         .map_err(|e| format!("query messages: {e}"))?;
@@ -425,7 +430,7 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<UsageEvent>, String> {
     }
     if scanned >= MAX_MESSAGE_ROWS {
         eprintln!(
-            "[pane] devin: sessions.db exceeds {MAX_MESSAGE_ROWS} rows — usage beyond the cap is not counted"
+            "[pane] devin: sessions.db exceeds {MAX_MESSAGE_ROWS} rows — keeping newest rows, oldest usage is dropped"
         );
     }
     Ok(out)

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -1,4 +1,4 @@
-use super::{http, Metric, Snapshot};
+use super::{http, http_no_redirect, Metric, Snapshot};
 use chrono::{DateTime, Duration, Utc};
 use prost::Message;
 use serde_json::Value;
@@ -36,6 +36,52 @@ fn is_regular_file(path: &std::path::Path) -> bool {
     std::fs::symlink_metadata(path)
         .ok()
         .is_some_and(|m| m.is_file() && !m.file_type().is_symlink())
+}
+
+/// Refresh preflight: the write-back must be able to replace the live
+/// file — rotating the refresh token without a working write-back signs
+/// the CLI out. A planted symlink at the predictable tmp path is
+/// unlinked (never its target), then a create + owner-lock probe proves
+/// the directory accepts the full staging chain.
+fn can_stage_write(path: &std::path::Path) -> bool {
+    if !is_regular_file(path) {
+        return false;
+    }
+    let tmp = path.with_extension("json.tmp");
+    match std::fs::symlink_metadata(&tmp) {
+        Ok(m) if m.file_type().is_symlink() => {
+            if std::fs::remove_file(&tmp).is_err() {
+                return false;
+            }
+        }
+        Ok(m) if !m.is_file() => return false,
+        _ => {}
+    }
+    let existed = tmp.is_file();
+    let ok = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(&tmp)
+        .is_ok()
+        && super::onenewapi::store::restrict_owner_only(&tmp).is_ok();
+    if !existed {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    ok
+}
+
+/// Keep a copy of the CLI's own file before touching it, so a bad write can
+/// never cost the user their login. A planted symlink at the backup path is
+/// unlinked first — never write through it.
+fn backup_credentials(path: &std::path::Path) {
+    let bak = path.with_extension("json.pane-bak");
+    if std::fs::symlink_metadata(&bak)
+        .ok()
+        .is_some_and(|m| m.file_type().is_symlink())
+    {
+        let _ = std::fs::remove_file(&bak);
+    }
+    let _ = std::fs::copy(path, &bak);
 }
 
 pub async fn snapshot() -> Snapshot {
@@ -97,12 +143,13 @@ async fn fetch() -> Result<Snapshot, String> {
             );
             return Err("Grok token expired — run the Grok CLI once to sign in again".into());
         };
-        // Refresh rotates the CLI's token pair. If we can't write it back
-        // (a planted symlink), don't call the token endpoint — that would
-        // sign the CLI out from under the user.
-        if !is_regular_file(&path) {
+        // Refresh rotates the CLI's token pair. If the write-back can't
+        // safely replace the live file (planted symlink, read-only dir),
+        // don't call the token endpoint — that would sign the CLI out from
+        // under the user.
+        if !can_stage_write(&path) {
             return Err(
-                "Grok credentials are not a regular file — run the Grok CLI once to sign in again".into(),
+                "Grok credentials cannot be updated safely — run the Grok CLI once to sign in again".into(),
             );
         }
         let form = [
@@ -110,14 +157,16 @@ async fn fetch() -> Result<Snapshot, String> {
             ("refresh_token", refresh_token.as_str()),
             ("client_id", client_id.as_str()),
         ];
-        let mut resp = http()
+        // The form carries the refresh token: never follow redirects — a
+        // 307/308 re-sends the body to the redirect target cross-origin.
+        let mut resp = http_no_redirect()
             .post(format!("{issuer}/oauth2/token"))
             .form(&form)
             .send()
             .await
             .map_err(|e| format!("token refresh: {e}"))?;
         if resp.status().as_u16() == 404 {
-            resp = http()
+            resp = http_no_redirect()
                 .post(format!("{issuer}/oauth/token"))
                 .form(&form)
                 .send()
@@ -149,11 +198,16 @@ async fn fetch() -> Result<Snapshot, String> {
             }
             e["expires_at"] = Value::from((Utc::now() + Duration::seconds(expires_in)).to_rfc3339());
             // Keep a copy of the CLI's own file before touching it, so a bad
-            // write can never cost the user their login.
-            let _ = std::fs::copy(&path, path.with_extension("json.pane-bak"));
+            // write can never cost the user their login. A planted symlink at
+            // the backup path is unlinked first — never write through it.
+            backup_credentials(&path);
             let tmp = path.with_extension("json.tmp");
             std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
-                .and_then(|_| std::fs::rename(&tmp, &path))
+                .map_err(|e| format!("write refreshed auth.json: {e}"))?;
+            // Lock the new pair down to this user before it replaces the
+            // live file (the preflight probe proved this fs accepts it).
+            super::onenewapi::store::restrict_owner_only(&tmp)
+                .and_then(|_| std::fs::rename(&tmp, &path).map_err(|e| e.to_string()))
                 .map_err(|e| format!("write refreshed auth.json: {e}"))?;
         }
     }

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -38,36 +38,47 @@ fn is_regular_file(path: &std::path::Path) -> bool {
         .is_some_and(|m| m.is_file() && !m.file_type().is_symlink())
 }
 
-/// Refresh preflight: the write-back must be able to replace the live
-/// file — rotating the refresh token without a working write-back signs
-/// the CLI out. A planted symlink at the predictable tmp path is
-/// unlinked (never its target), then a create + owner-lock probe proves
-/// the directory accepts the full staging chain.
-fn can_stage_write(path: &std::path::Path) -> bool {
+/// Proof the refreshed credential pair can replace the live file BEFORE the
+/// rotating token call: any leftover or planted file at the predictable tmp
+/// path is removed outright (a symlink or hardlink redirect is never written
+/// through), a fresh tmp is created with create_new and owner-locked, and it
+/// stays staged until commit so nothing can be planted in the gap. Drop
+/// removes the tmp when the refresh never lands.
+struct StagedTmp(std::path::PathBuf);
+
+impl StagedTmp {
+    fn write(&self, contents: &str) -> std::io::Result<()> {
+        std::fs::write(&self.0, contents)
+    }
+    fn commit(self, live: &std::path::Path) -> std::io::Result<()> {
+        std::fs::rename(&self.0, live)?;
+        std::mem::forget(self);
+        Ok(())
+    }
+}
+
+impl Drop for StagedTmp {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn stage_credentials_tmp(path: &std::path::Path) -> Option<StagedTmp> {
     if !is_regular_file(path) {
-        return false;
+        return None;
     }
     let tmp = path.with_extension("json.tmp");
-    match std::fs::symlink_metadata(&tmp) {
-        Ok(m) if m.file_type().is_symlink() => {
-            if std::fs::remove_file(&tmp).is_err() {
-                return false;
-            }
-        }
-        Ok(m) if !m.is_file() => return false,
-        _ => {}
+    if std::fs::symlink_metadata(&tmp).is_ok() && std::fs::remove_file(&tmp).is_err() {
+        return None;
     }
-    let existed = tmp.is_file();
-    let ok = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .open(&tmp)
-        .is_ok()
-        && super::onenewapi::store::restrict_owner_only(&tmp).is_ok();
-    if !existed {
+    if std::fs::OpenOptions::new().write(true).create_new(true).open(&tmp).is_err() {
+        return None;
+    }
+    if super::onenewapi::store::restrict_owner_only(&tmp).is_err() {
         let _ = std::fs::remove_file(&tmp);
+        return None;
     }
-    ok
+    Some(StagedTmp(tmp))
 }
 
 /// Keep a copy of the CLI's own file before touching it, so a bad write can
@@ -143,15 +154,14 @@ async fn fetch() -> Result<Snapshot, String> {
             );
             return Err("Grok token expired — run the Grok CLI once to sign in again".into());
         };
-        // Refresh rotates the CLI's token pair. If the write-back can't
-        // safely replace the live file (planted symlink, read-only dir),
-        // don't call the token endpoint — that would sign the CLI out from
-        // under the user.
-        if !can_stage_write(&path) {
+        // Refresh rotates the CLI's token pair. Stage the write-back BEFORE
+        // the token call: if the refreshed pair can't replace the live
+        // file, the rotation would sign the CLI out from under the user.
+        let Some(staged) = stage_credentials_tmp(&path) else {
             return Err(
                 "Grok credentials cannot be updated safely — run the Grok CLI once to sign in again".into(),
             );
-        }
+        };
         let form = [
             ("grant_type", "refresh_token"),
             ("refresh_token", refresh_token.as_str()),
@@ -201,13 +211,12 @@ async fn fetch() -> Result<Snapshot, String> {
             // write can never cost the user their login. A planted symlink at
             // the backup path is unlinked first — never write through it.
             backup_credentials(&path);
-            let tmp = path.with_extension("json.tmp");
-            std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or(raw))
+            // The tmp was created fresh and owner-locked at staging.
+            staged
+                .write(&serde_json::to_string_pretty(&doc).unwrap_or(raw))
                 .map_err(|e| format!("write refreshed auth.json: {e}"))?;
-            // Lock the new pair down to this user before it replaces the
-            // live file (the preflight probe proved this fs accepts it).
-            super::onenewapi::store::restrict_owner_only(&tmp)
-                .and_then(|_| std::fs::rename(&tmp, &path).map_err(|e| e.to_string()))
+            staged
+                .commit(&path)
                 .map_err(|e| format!("write refreshed auth.json: {e}"))?;
         }
     }
@@ -597,6 +606,34 @@ fn metrics_from_tokens(tokens: Vec<ResetToken>) -> Vec<Metric> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn staging_discards_leftover_tmp_and_cleans_up() {
+        let dir = std::env::temp_dir().join(format!("pane-grok-stage-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let live = dir.join("auth.json");
+        std::fs::write(&live, "{}").unwrap();
+
+        // No live credential file → no staging.
+        assert!(stage_credentials_tmp(&dir.join("missing.json")).is_none());
+
+        // A stale leftover (writable or not) at the predictable tmp path is
+        // removed outright — never reused, never written through.
+        let tmp = live.with_extension("json.tmp");
+        std::fs::write(&tmp, b"unrelated data").unwrap();
+        let staged = stage_credentials_tmp(&live).expect("staging must succeed");
+        assert_eq!(std::fs::read_to_string(&tmp).unwrap(), "");
+        staged.write("{\"new\":1}").unwrap();
+        staged.commit(&live).unwrap();
+        assert_eq!(std::fs::read_to_string(&live).unwrap(), "{\"new\":1}");
+
+        // A staged tmp whose refresh never lands is cleaned up on drop.
+        let staged = stage_credentials_tmp(&live).unwrap();
+        drop(staged);
+        assert!(!tmp.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     /// The exact shape xAI returns right after a weekly rollover (captured
     /// live 2026-07-19): zero usage means creditUsagePercent is omitted.

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -12,9 +12,30 @@ const EMPTY_GRPC_WEB_MESSAGE: [u8; 5] = [0, 0, 0, 0, 0];
 const MAX_RESET_CREDITS_BODY: usize = 64 * 1024;
 const PROTO_TIMESTAMP_MIN_SECONDS: i64 = -62_135_596_800;
 const PROTO_TIMESTAMP_MAX_SECONDS: i64 = 253_402_300_799;
+const MAX_AUTH_BYTES: u64 = 64 * 1024;
+const DEFAULT_OIDC_ISSUER: &str = "https://auth.x.ai";
 
 fn auth_path() -> PathBuf {
     dirs::home_dir().unwrap_or_default().join(".grok").join("auth.json")
+}
+
+/// The refresh token is POSTed to `{issuer}/oauth2/token` — a planted
+/// oidc_issuer in auth.json would exfiltrate it. Trust only the vendor
+/// host over https; anything else skips the refresh.
+fn trusted_oidc_issuer(raw: Option<&str>) -> Option<String> {
+    let issuer = raw.unwrap_or(DEFAULT_OIDC_ISSUER).trim_end_matches('/');
+    match reqwest::Url::parse(issuer) {
+        Ok(u) if u.scheme() == "https" && u.host_str() == Some("auth.x.ai") => {
+            Some(issuer.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn is_regular_file(path: &std::path::Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .ok()
+        .is_some_and(|m| m.is_file() && !m.file_type().is_symlink())
 }
 
 pub async fn snapshot() -> Snapshot {
@@ -33,7 +54,7 @@ async fn fetch() -> Result<Snapshot, String> {
             "Grok CLI sign-in not found (~\\.grok\\auth.json).",
         ));
     }
-    let raw = std::fs::read_to_string(&path).map_err(|e| format!("read auth.json: {e}"))?;
+    let raw = super::read_small_text(&path, MAX_AUTH_BYTES, "auth.json")?;
     let mut doc: Value = serde_json::from_str(&raw).map_err(|e| format!("parse auth.json: {e}"))?;
 
     // auth.json maps "<issuer>::<account-uuid>" to the account entry.
@@ -53,12 +74,7 @@ async fn fetch() -> Result<Snapshot, String> {
         .and_then(Value::as_str)
         .unwrap_or_default()
         .to_string();
-    let issuer = entry
-        .get("oidc_issuer")
-        .and_then(Value::as_str)
-        .unwrap_or("https://auth.x.ai")
-        .trim_end_matches('/')
-        .to_string();
+    let issuer = trusted_oidc_issuer(entry.get("oidc_issuer").and_then(Value::as_str));
     let client_id = entry
         .get("oidc_client_id")
         .and_then(Value::as_str)
@@ -74,6 +90,20 @@ async fn fetch() -> Result<Snapshot, String> {
     if token.is_empty() || expired {
         if refresh_token.is_empty() || client_id.is_empty() {
             return Err("Grok token expired — run the Grok CLI once to sign in again".into());
+        }
+        let Some(issuer) = issuer else {
+            eprintln!(
+                "[pane] grok: auth.json oidc_issuer is not {DEFAULT_OIDC_ISSUER} — skipping token refresh"
+            );
+            return Err("Grok token expired — run the Grok CLI once to sign in again".into());
+        };
+        // Refresh rotates the CLI's token pair. If we can't write it back
+        // (a planted symlink), don't call the token endpoint — that would
+        // sign the CLI out from under the user.
+        if !is_regular_file(&path) {
+            return Err(
+                "Grok credentials are not a regular file — run the Grok CLI once to sign in again".into(),
+            );
         }
         let form = [
             ("grant_type", "refresh_token"),

--- a/src-tauri/src/providers/ollama.rs
+++ b/src-tauri/src/providers/ollama.rs
@@ -1,9 +1,21 @@
-use super::{http, Metric, Snapshot};
+use super::{Metric, Snapshot};
 use serde_json::Value;
 
 const ID: &str = "ollama";
 const NAME: &str = "Ollama";
 const BASE: &str = "http://127.0.0.1:11434";
+
+/// Plaintext loopback only, so it must never ride a proxy (env or
+/// configured) — a dedicated no-proxy client rather than the shared one.
+fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .user_agent("Pane-Windows/0.3")
+        .timeout(std::time::Duration::from_secs(20))
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .no_proxy()
+        .build()
+        .expect("failed to build http client")
+}
 
 pub async fn snapshot() -> Snapshot {
     match fetch().await {
@@ -14,7 +26,7 @@ pub async fn snapshot() -> Snapshot {
 
 async fn fetch() -> Result<Snapshot, String> {
     // No credentials — either the local server answers or it doesn't.
-    let version = match http().get(format!("{BASE}/api/version")).send().await {
+    let version = match client().get(format!("{BASE}/api/version")).send().await {
         Ok(resp) if resp.status().is_success() => resp
             .json::<Value>()
             .await
@@ -31,7 +43,7 @@ async fn fetch() -> Result<Snapshot, String> {
 
     let mut metrics = Vec::new();
 
-    if let Ok(resp) = http().get(format!("{BASE}/api/tags")).send().await {
+    if let Ok(resp) = client().get(format!("{BASE}/api/tags")).send().await {
         if let Ok(doc) = resp.json::<Value>().await {
             let models = doc.get("models").and_then(Value::as_array).cloned().unwrap_or_default();
             let bytes: u64 =
@@ -43,7 +55,7 @@ async fn fetch() -> Result<Snapshot, String> {
         }
     }
 
-    if let Ok(resp) = http().get(format!("{BASE}/api/ps")).send().await {
+    if let Ok(resp) = client().get(format!("{BASE}/api/ps")).send().await {
         if let Ok(doc) = resp.json::<Value>().await {
             let names: Vec<String> = doc
                 .get("models")

--- a/src-tauri/src/providers/qwen.rs
+++ b/src-tauri/src/providers/qwen.rs
@@ -168,63 +168,6 @@ fn parse_quota(doc: &Value) -> Option<Snapshot> {
     Some(Snapshot::ok(ID, NAME, plan, metrics))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Live diagnostic (ignored): shows what each console/header attempt
-    /// returns so quota-auth failures can be debugged without ever
-    /// printing the key. Run:
-    ///   cargo test qwen_quota_live_probe -- --ignored --nocapture
-    #[tokio::test]
-    #[ignore]
-    async fn qwen_quota_live_probe() {
-        let Some(key) = find_api_key() else {
-            println!("no key found");
-            return;
-        };
-        for console in CONSOLES {
-            for header in ["authorization", "x-api-key", "x-dashscope-api-key"] {
-                let value =
-                    if header == "authorization" { format!("Bearer {key}") } else { key.clone() };
-                let resp = http()
-                    .post(format!("{console}{RPC_QUERY}"))
-                    .header(header, value)
-                    .header("accept", "application/json")
-                    .json(&serde_json::json!({}))
-                    .send()
-                    .await;
-                match resp {
-                    Ok(r) => {
-                        let status = r.status();
-                        let body = r.text().await.unwrap_or_default();
-                        let trimmed: String = body.chars().take(300).collect();
-                        println!("{console} [{header}] -> {status}: {trimmed}");
-                    }
-                    Err(e) => println!("{console} [{header}] -> error: {e}"),
-                }
-            }
-        }
-        // Does the coding endpoint itself expose quota via response headers?
-        for base in
-            ["https://coding-intl.dashscope.aliyuncs.com/v1", "https://coding.dashscope.aliyuncs.com/v1"]
-        {
-            match http().get(format!("{base}/models")).bearer_auth(&key).send().await {
-                Ok(r) => {
-                    println!("{base}/models -> {}", r.status());
-                    for (name, value) in r.headers() {
-                        let n = name.as_str().to_ascii_lowercase();
-                        if n.contains("limit") || n.contains("quota") || n.contains("remain") || n.contains("usage") {
-                            println!("  header {n}: {:?}", value);
-                        }
-                    }
-                }
-                Err(e) => println!("{base}/models -> error: {e}"),
-            }
-        }
-    }
-}
-
 /// Fallback card from the CLI's own per-request ledger: request and token
 /// counts for today and the current month. No percentages — the plan's
 /// limits aren't knowable locally.
@@ -263,4 +206,62 @@ fn local_ledger() -> Option<Snapshot> {
             Metric::text("Requests this month", format!("{mon_req}")),
         ],
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Live diagnostic (ignored): shows what each console/header attempt
+    /// returns so quota-auth failures can be debugged without ever
+    /// printing the key. Run:
+    ///   cargo test qwen_quota_live_probe -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore]
+    async fn qwen_quota_live_probe() {
+        let Some(key) = find_api_key() else {
+            println!("no key found");
+            return;
+        };
+        for console in CONSOLES {
+            for header in ["authorization", "x-api-key", "x-dashscope-api-key"] {
+                let value =
+                    if header == "authorization" { format!("Bearer {key}") } else { key.clone() };
+                let resp = http()
+                    .post(format!("{console}{RPC_QUERY}"))
+                    .header(header, value)
+                    .header("accept", "application/json")
+                    .json(&serde_json::json!({}))
+                    .send()
+                    .await;
+                match resp {
+                    Ok(r) => {
+                        let status = r.status();
+                        let body = r.text().await.unwrap_or_default();
+                        let trimmed: String = body.chars().take(200).collect();
+                        println!("{console} [{header}] -> {status}: {trimmed}");
+                    }
+                    Err(e) => println!("{console} [{header}] -> error: {e}"),
+                }
+            }
+        }
+        // Does the coding endpoint itself expose quota via response headers?
+        for base in
+            ["https://coding-intl.dashscope.aliyuncs.com/v1", "https://coding.dashscope.aliyuncs.com/v1"]
+        {
+            match http().get(format!("{base}/models")).bearer_auth(&key).send().await {
+                Ok(r) => {
+                    println!("{base}/models -> {}", r.status());
+                    for (name, value) in r.headers() {
+                        let n = name.as_str().to_ascii_lowercase();
+                        if n.contains("limit") || n.contains("quota") || n.contains("remain") || n.contains("usage") {
+                            let v: String = format!("{value:?}").chars().take(200).collect();
+                            println!("  header {n}: {v}");
+                        }
+                    }
+                }
+                Err(e) => println!("{base}/models -> error: {e}"),
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What

Security-audit fixes for provider HTTP clients:

- **Antigravity** — the `danger_accept_invalid_certs` loopback client used reqwest's default redirect policy: a 307/308 would re-send the request — including the custom `x-codeium-csrf-token` header, which reqwest does not strip — to an arbitrary target with TLS verification off. The client now refuses redirects (a legit language server never redirects) and bypasses env proxies.
- **Ollama** — the plaintext `http://127.0.0.1` client honored `HTTP_PROXY` env vars; it now uses its own `.no_proxy()` client.
- **Grok** — the token-refresh URL was built from `oidc_issuer` in `~/.grok/auth.json`; the issuer is now validated (https + `auth.x.ai` only) before the refresh token is POSTed. `auth.json` reads go through the capped helper and the write-back refuses symlinked files.
- **Devin** — `api_server_url` from `credentials.toml` is validated (https + `server.codeium.com`) before the API key is attached; the usage-events SELECT is capped at 2M rows with a diagnostic.
- **Live-probe test dumps** (Devin, Qwen) truncated to 200 chars.

## Tests

- Existing suites unchanged and green on the combined branch (362 passed); this PR is a whole-file subset of it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->