### PR TITLE
Bound spend scanning and clamp supplement pricing

### DIFF
--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -191,6 +191,12 @@ pub fn corrections_rev() -> u32 {
 /// Router prose names, GPT-5.3–5.6 effort slugs). 64 silently dropped
 /// everything after `gpt-5.2`. Per-rule caps below still bound memory.
 const MAX_ALIAS_RULES: usize = 256;
+/// Bounds for what the supplement feed may claim — it is trusted by URL
+/// alone yet outranks both catalogs in resolve(). No real model prices
+/// above ~$600/M, and a fast tier outside 1×–10× is a corrupt feed, not
+/// a SKU. Entries outside the bounds are dropped, not clamped.
+const MAX_SUPPLEMENT_PRICE: f64 = 10_000.0;
+const MAX_FAST_MULTIPLIER: f64 = 10.0;
 
 /// Stable fingerprint of the effective pricing inputs: the on-disk catalog
 /// files plus this binary's corrections revision. The persistent spend
@@ -303,6 +309,10 @@ fn apply_supplement(store: &mut Store, doc: &Value) {
     store.supplement.clear();
     store.fast_multipliers.clear();
     store.alias_rules.clear();
+    // The feed is trusted by URL alone yet outranks both catalogs in
+    // resolve(), so every value it hands us is range-checked on the way
+    // in; drops are counted and reported once at the end.
+    let mut dropped = 0usize;
     if let Some(pricing) = doc.get("pricing").and_then(Value::as_object) {
         for (model, entry) in pricing {
             let get = |key: &str| entry.get(key).and_then(Value::as_f64);
@@ -311,14 +321,16 @@ fn apply_supplement(store: &mut Store, doc: &Value) {
             else {
                 continue;
             };
+            let cache_read = get("cache_read_per_million").unwrap_or(input);
+            let cache_write = get("cache_write_per_million").unwrap_or(input);
+            let plausible = |v: f64| v.is_finite() && (0.0..=MAX_SUPPLEMENT_PRICE).contains(&v);
+            if ![input, output, cache_read, cache_write].into_iter().all(plausible) {
+                dropped += 1;
+                continue;
+            }
             store.supplement.insert(
                 model.clone(),
-                Price::flat(
-                    input,
-                    output,
-                    get("cache_read_per_million").unwrap_or(input),
-                    get("cache_write_per_million").unwrap_or(input),
-                ),
+                Price::flat(input, output, cache_read, cache_write),
             );
         }
     }
@@ -326,7 +338,11 @@ fn apply_supplement(store: &mut Store, doc: &Value) {
     if let Some(mults) = doc.get("fast_multipliers").and_then(Value::as_object) {
         for (model, v) in mults {
             if let Some(m) = v.as_f64() {
-                store.fast_multipliers.insert(model.clone(), m);
+                if m.is_finite() && (1.0..=MAX_FAST_MULTIPLIER).contains(&m) {
+                    store.fast_multipliers.insert(model.clone(), m);
+                } else {
+                    dropped += 1;
+                }
             }
         }
     }
@@ -352,9 +368,9 @@ fn apply_supplement(store: &mut Store, doc: &Value) {
 
     // The supplement is fetched from a third-party URL, so cap what it can
     // feed us: at most MAX_ALIAS_RULES of at most 256 chars each, compiled
-    // with a bounded size. (Rust's regex engine is linear-time by design,
-    // so ReDoS-style backtracking blowups aren't possible; the caps bound
-    // memory and compile cost.)
+    // with a bounded size, with plain-slug targets. (Rust's regex engine is
+    // linear-time by design, so ReDoS-style backtracking blowups aren't
+    // possible; the caps bound memory and compile cost.)
     if let Some(rules) = doc.get("alias_rules").and_then(Value::as_array) {
         for rule in rules.iter().take(MAX_ALIAS_RULES) {
             let (Some(pattern), Some(canonical)) = (
@@ -363,7 +379,15 @@ fn apply_supplement(store: &mut Store, doc: &Value) {
             ) else {
                 continue;
             };
-            if pattern.len() > 256 || canonical.len() > 128 {
+            // Targets become model names inside resolve() — plain ASCII
+            // slugs only, so a rule can't smuggle control characters,
+            // spaces, or unicode lookalikes into lookups.
+            if pattern.len() > 256
+                || canonical.len() > 128
+                || canonical.is_empty()
+                || !canonical.bytes().all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'/' | b'_' | b'-'))
+            {
+                dropped += 1;
                 continue;
             }
             if let Ok(re) = regex::RegexBuilder::new(pattern)
@@ -373,6 +397,9 @@ fn apply_supplement(store: &mut Store, doc: &Value) {
                 store.alias_rules.push((re, canonical.to_string()));
             }
         }
+    }
+    if dropped > 0 {
+        eprintln!("[pane] pricing: supplement dropped {dropped} out-of-range entries");
     }
 }
 
@@ -665,7 +692,7 @@ fn resolve(s: &Store, model: &str, depth: u8) -> Option<Price> {
     if let Some(p) = s
         .litellm
         .iter()
-        .find(|(k, p)| k.rsplit('/').next() == Some(canonical.as_str()) && real(&p))
+        .find(|(k, p)| k.rsplit('/').next() == Some(canonical.as_str()) && real(p))
         .map(|(_, p)| *p)
     {
         return Some(p);
@@ -1369,6 +1396,67 @@ mod tests {
         assert!(store.alias_rules.iter().any(|(_, c)| c == "gpt-5.6-sol"));
     }
 
+    #[test]
+    fn supplement_drops_out_of_range_prices_and_multipliers() {
+        // The supplement outranks every catalog in resolve(), so a hostile
+        // or corrupt feed must not name its own dollars: nothing real
+        // exceeds ~$600/M, and fast tiers stay within 1x-10x.
+        let doc = serde_json::json!({
+            "pricing": {
+                "absurd-model": { "input_per_million": 50_000.0, "output_per_million": 1.0 },
+                "negative-model": { "input_per_million": -1.0, "output_per_million": 1.0 },
+                "bad-cache-model": { "input_per_million": 1.0, "output_per_million": 2.0,
+                                     "cache_read_per_million": 99_999.0 },
+                "ceiling-model": { "input_per_million": 10_000.0, "output_per_million": 10_000.0 },
+                "sane-model": { "input_per_million": 3.0, "output_per_million": 15.0,
+                                "cache_read_per_million": 0.3, "cache_write_per_million": 3.75 },
+                "free-model": { "input_per_million": 0.0, "output_per_million": 0.0 },
+            },
+            "fast_multipliers": {
+                "absurd-model": 500.0,
+                "negative-model": 0.5,   // <1: fast cheaper than standard is nonsense
+                "sane-model": 2.0,
+                "ceiling-lo": 1.0,
+                "ceiling-hi": 10.0,
+            },
+        });
+        let mut store = super::Store::default();
+        super::apply_supplement(&mut store, &doc);
+        for model in ["absurd-model", "negative-model", "bad-cache-model"] {
+            assert!(!store.supplement.contains_key(model), "{model}");
+        }
+        assert_eq!(store.fast_multipliers.get("absurd-model"), None);
+        assert_eq!(store.fast_multipliers.get("negative-model"), None);
+        let p = store.supplement.get("sane-model").unwrap();
+        assert_eq!((p.input, p.output, p.cache_read, p.cache_write), (3.0, 15.0, 0.3, 3.75));
+        assert_eq!(store.fast_multipliers.get("sane-model"), Some(&2.0));
+        // Bounds are inclusive: the 0/0 free placeholder and the (unlikely
+        // but in-range) ceiling values survive, so edge data never drops.
+        assert!(store.supplement.contains_key("free-model"));
+        assert!(store.supplement.contains_key("ceiling-model"));
+        assert_eq!(store.fast_multipliers.get("ceiling-lo"), Some(&1.0));
+        assert_eq!(store.fast_multipliers.get("ceiling-hi"), Some(&10.0));
+    }
+
+    #[test]
+    fn supplement_alias_targets_are_plain_ascii_slugs() {
+        // Targets land in resolve() as model names — anything but a plain
+        // slug (control chars, spaces, unicode lookalikes, empty) drops.
+        let doc = serde_json::json!({ "alias_rules": [
+            { "pattern": "^good$", "canonical": "gpt-5.6-sol" },
+            { "pattern": "^prefixed$", "canonical": "openai/gpt_5.6.sol" },
+            { "pattern": "^control$", "canonical": "gpt-5.6\n-fake" },
+            { "pattern": "^spaces$", "canonical": "not a slug" },
+            { "pattern": "^unicode$", "canonical": "gрt-5.6" },
+            { "pattern": "^empty$", "canonical": "" },
+            { "pattern": "^long$", "canonical": "x".repeat(200) },
+        ]});
+        let mut store = super::Store::default();
+        super::apply_supplement(&mut store, &doc);
+        let targets: Vec<&str> = store.alias_rules.iter().map(|(_, c)| c.as_str()).collect();
+        assert_eq!(targets, ["gpt-5.6-sol", "openai/gpt_5.6.sol"]);
+    }
+
     /// Live probe: fetches the three catalogs and resolves a few real slugs.
     /// Run via `cargo test --lib pricing -- --ignored --nocapture`.
     #[test]
@@ -1396,13 +1484,16 @@ mod tests {
             }
         }
         for model in &matrix {
-            match super::lookup(model) {
-                Some(p) => eprintln!(
+            // Cap each dump line: this runs with --nocapture straight to
+            // the terminal over data a third-party feed can influence.
+            let line = match super::lookup(model) {
+                Some(p) => format!(
                     "{model}: in=${:.2} out=${:.2} cr=${:.3} cw=${:.2} (per 1M)",
                     p.input, p.output, p.cache_read, p.cache_write
                 ),
-                None => eprintln!("{model}: UNPRICED"),
-            }
+                None => format!("{model}: UNPRICED"),
+            };
+            eprintln!("{line:.200}");
         }
     }
 }

--- a/src-tauri/src/providers/elevenlabs.rs
+++ b/src-tauri/src/providers/elevenlabs.rs
@@ -79,7 +79,7 @@ fn group(n: u64) -> String {
     let digits = n.to_string();
     let mut out = String::new();
     for (i, ch) in digits.chars().enumerate() {
-        if i > 0 && (digits.len() - i) % 3 == 0 {
+        if i > 0 && (digits.len() - i).is_multiple_of(3) {
             out.push(',');
         }
         out.push(ch);

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, SystemTime};
@@ -63,6 +63,20 @@ impl ProviderSpend {
 /// (local calendar day, model) → (cost, tokens). Day = days since CE.
 type DayMap = HashMap<(i32, String), (f64, f64)>;
 
+/// Longest model string admitted as a days/unpriced key. Same bound as
+/// catalog canonicals (MAX_PROBE_KEY), which every real model fits;
+/// longer names fold into OVERFLOW_MODEL_KEY.
+const MAX_MODEL_KEY: usize = MAX_PROBE_KEY;
+
+/// Distinct model keys one file may admit before extras fold into
+/// OVERFLOW_MODEL_KEY. Real session logs name a handful of models — the
+/// cap stops a hostile log from inflating the maps (and spend_cache.json).
+const MAX_MODELS_PER_FILE: usize = 4096;
+
+/// Fixed bucket for model names refused by the two caps above. Spend and
+/// token totals stay exact — only the per-model attribution merges.
+const OVERFLOW_MODEL_KEY: &str = "[over-limit model name]";
+
 /// Everything one file contributes: priced per-day totals plus the tally of
 /// unpriced (excluded) events per model name. Cached as a unit so exclusion
 /// counts survive the per-file cache.
@@ -70,6 +84,26 @@ type DayMap = HashMap<(i32, String), (f64, f64)>;
 struct FileData {
     days: DayMap,
     unpriced: HashMap<String, u64>,
+    /// Distinct model keys admitted by `model_key` during this file's
+    /// parse — the state behind MAX_MODELS_PER_FILE. Consulted only while
+    /// parsing; split helpers don't keep it in step.
+    models: HashSet<String>,
+}
+
+impl FileData {
+    /// Bounded key for a log-supplied model string: within both caps the
+    /// name passes through, otherwise OVERFLOW_MODEL_KEY. Model strings
+    /// come straight from the logs, so without this a hostile line could
+    /// key these maps (and spend_cache.json) with unbounded names.
+    fn model_key(&mut self, model: &str) -> String {
+        if model.len() <= MAX_MODEL_KEY
+            && (self.models.contains(model) || self.models.len() < MAX_MODELS_PER_FILE)
+        {
+            self.models.insert(model.to_string());
+            return model.to_string();
+        }
+        OVERFLOW_MODEL_KEY.to_string()
+    }
 }
 
 struct FileEntry {
@@ -205,7 +239,7 @@ fn cache() -> &'static Mutex<HashMap<PathBuf, FileEntry>> {
 // "Scanning session logs…" every day.
 // ---------------------------------------------------------------------------
 
-const PERSIST_VERSION: u32 = 3; // bump on cache format *or* parser-logic changes
+const PERSIST_VERSION: u32 = 4; // bump on cache format *or* parser-logic changes
 
 /// Set when any file was (re)parsed this run — nothing changed, nothing saved.
 static CACHE_DIRTY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
@@ -343,10 +377,8 @@ fn day_of_utc(ts: DateTime<Utc>) -> i32 {
 }
 
 fn add_event(data: &mut FileData, ts: DateTime<Utc>, model: &str, cost: f64, tokens: f64) {
-    let entry = data
-        .days
-        .entry((day_of_utc(ts), model.to_string()))
-        .or_insert((0.0, 0.0));
+    let key = data.model_key(model);
+    let entry = data.days.entry((day_of_utc(ts), key)).or_insert((0.0, 0.0));
     entry.0 += cost;
     entry.1 += tokens;
 }
@@ -354,8 +386,10 @@ fn add_event(data: &mut FileData, ts: DateTime<Utc>, model: &str, cost: f64, tok
 /// Tally an event no catalog can price: its tokens still count (they're
 /// measured, not guessed) at zero cost, so only the dollars under-report.
 fn note_unpriced(data: &mut FileData, ts: DateTime<Utc>, model: &str, tokens: f64) {
-    *data.unpriced.entry(model.to_string()).or_insert(0) += 1;
+    let key = data.model_key(model);
+    *data.unpriced.entry(key).or_insert(0) += 1;
     if tokens > 0.0 {
+        // add_event re-derives the same bounded key.
         add_event(data, ts, model, 0.0, tokens);
     }
 }
@@ -369,6 +403,7 @@ fn merge_data(target: &mut FileData, source: FileData) {
     for (model, count) in source.unpriced {
         *target.unpriced.entry(model).or_insert(0) += count;
     }
+    target.models.extend(source.models);
 }
 
 /// Ranked model list for one window: top models by cost, anything past the
@@ -455,6 +490,26 @@ const MAX_SCAN_DEPTH: usize = 16;
 /// tree (or `/`) can't stall the refresh thread.
 const MAX_SCAN_DIRS: usize = 20_000;
 
+/// Session logs larger than this are skipped whole, with a diagnostic — a
+/// multi-hundred-MB single "log" is a corrupt or hostile artifact, and
+/// reading it would stall the refresh thread.
+const MAX_LOG_FILE_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Stored bytes per JSONL line: a longer physical line is skipped and its
+/// remainder read-and-discarded, never kept. Legit Claude/Codex lines
+/// reach ~1 MB, so 4 MiB loses nothing real.
+const MAX_LINE_BYTES: usize = 4 * 1024 * 1024;
+
+/// Report a log skipped for exceeding MAX_LOG_FILE_BYTES.
+fn oversized_log(path: &Path, size: u64) {
+    eprintln!(
+        "[pane] spend: skipping {} — {} MiB exceeds the {} MiB log-file cap",
+        path.display(),
+        size / (1024 * 1024),
+        MAX_LOG_FILE_BYTES / (1024 * 1024),
+    );
+}
+
 /// All .jsonl files under `root` modified in the last 31 days.
 /// Symlinks and junctions are followed throughout: directories are resolved
 /// through links when recursing, and the recency check below reads the
@@ -521,11 +576,19 @@ fn recent_jsonl_files(root: &Path, out: &mut Vec<PathBuf>) {
                 {
                     // Target metadata, so a link's own ancient mtime can't
                     // hide a recently written log.
+                    if meta.len() > MAX_LOG_FILE_BYTES {
+                        oversized_log(&path, meta.len());
+                        continue;
+                    }
                     followed_link = true;
                     out.push(path);
                 }
             } else if path.extension().is_some_and(|e| e == "jsonl") {
                 let Ok(meta) = entry.metadata() else { continue };
+                if meta.len() > MAX_LOG_FILE_BYTES {
+                    oversized_log(&path, meta.len());
+                    continue;
+                }
                 if meta.modified().map(|m| m >= cutoff).unwrap_or(true) {
                     out.push(path);
                 }
@@ -552,6 +615,13 @@ fn recent_jsonl_files(root: &Path, out: &mut Vec<PathBuf>) {
 /// Parses one file into per-day totals, via the cache when unchanged.
 fn file_days(path: &Path, parse: &mut dyn FnMut(&str, &mut FileData)) -> FileData {
     let Ok(meta) = fs::metadata(path) else { return FileData::default() };
+    if meta.len() > MAX_LOG_FILE_BYTES {
+        // Also gated in recent_jsonl_files; this catches direct-path
+        // callers (grok's unified.jsonl). Not touched, so a stale cache
+        // entry for it is pruned on the next save.
+        oversized_log(path, meta.len());
+        return FileData::default();
+    }
     let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
     let size = meta.len();
 
@@ -592,10 +662,44 @@ fn file_days(path: &Path, parse: &mut dyn FnMut(&str, &mut FileData)) -> FileDat
             return FileData::default();
         }
     };
+    let mut reader = BufReader::new(file);
     let mut read_ok = true;
-    for line in BufReader::new(file).lines() {
-        match line {
-            Ok(line) => parse(&line, &mut data),
+    loop {
+        // One physical line, storing at most MAX_LINE_BYTES (+1 byte to
+        // detect overflow) — a hostile log must not make a single line
+        // allocate without bound.
+        let mut buf: Vec<u8> = Vec::new();
+        let read = reader
+            .by_ref()
+            .take(MAX_LINE_BYTES as u64 + 1)
+            .read_until(b'\n', &mut buf);
+        match read {
+            Ok(0) => break, // EOF
+            Ok(_) if buf.len() > MAX_LINE_BYTES && !buf.ends_with(b"\n") => {
+                // Overlong line: discard the rest of it without storing.
+                if skip_line_rest(&mut reader).is_err() {
+                    read_ok = false;
+                    break;
+                }
+            }
+            Ok(_) => {
+                // Same terminator handling as BufRead::lines().
+                if buf.ends_with(b"\n") {
+                    buf.pop();
+                    if buf.ends_with(b"\r") {
+                        buf.pop();
+                    }
+                }
+                match String::from_utf8(buf) {
+                    Ok(line) => parse(&line, &mut data),
+                    Err(_) => {
+                        // lines() treated invalid UTF-8 as a read error;
+                        // keep the file out of the cache the same way.
+                        read_ok = false;
+                        break;
+                    }
+                }
+            }
             Err(_) => {
                 read_ok = false;
                 break;
@@ -615,6 +719,27 @@ fn file_days(path: &Path, parse: &mut dyn FnMut(&str, &mut FileData)) -> FileDat
     }
     CACHE_DIRTY.store(true, std::sync::atomic::Ordering::Relaxed);
     data
+}
+
+/// Consume through the next '\n' (or EOF) using only the reader's own
+/// buffer — the unread tail of an overlong line.
+fn skip_line_rest(reader: &mut impl BufRead) -> std::io::Result<()> {
+    loop {
+        let buf = reader.fill_buf()?;
+        if buf.is_empty() {
+            return Ok(());
+        }
+        match buf.iter().position(|&b| b == b'\n') {
+            Some(i) => {
+                reader.consume(i + 1);
+                return Ok(());
+            }
+            None => {
+                let n = buf.len();
+                reader.consume(n);
+            }
+        }
+    }
 }
 
 fn parse_ts(value: Option<&Value>) -> Option<DateTime<Utc>> {
@@ -2079,6 +2204,86 @@ fn parse_csv_date(s: &str) -> Option<DateTime<Utc>> {
     None
 }
 
+/// Minimal CSV field splitter with quoted-field support.
+fn split_csv_row(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut field = String::new();
+    let mut in_quotes = false;
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '"' if in_quotes && chars.peek() == Some(&'"') => {
+                field.push('"');
+                chars.next();
+            }
+            '"' => in_quotes = !in_quotes,
+            ',' if !in_quotes => out.push(std::mem::take(&mut field)),
+            _ => field.push(c),
+        }
+    }
+    out.push(field);
+    out
+}
+
+pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
+    providers::sweep_temp_sqlite_copies();
+    pricing::ensure_fresh();
+    load_persisted_cache();
+    if let Ok(mut t) = touched().lock() {
+        t.clear();
+    }
+    let (pi_claude, pi_codex) = pi();
+    let (claude_sp, mut minimax_extra, mut qwen_via_claude, mut kimi_routed) =
+        claude(pi_claude);
+    // Extra Claude accounts: own spend cards, with their MiniMax/qwen/Kimi-
+    // routed rows folded into the same destinations as the default account's.
+    let (extra_claude_spends, mm2, qw2, km2) = claude_extra_accounts();
+    merge_data(&mut minimax_extra, mm2);
+    merge_data(&mut qwen_via_claude, qw2);
+    merge_data(&mut kimi_routed, km2);
+    // Hermes rows going to an existing slice merge into it (MiniMax via the
+    // extra-data path); the rest become their own spend entries.
+    let mut hermes_rest = Vec::new();
+    for (id, name, data) in hermes() {
+        if id == "minimax" {
+            merge_data(&mut minimax_extra, data);
+        } else {
+            hermes_rest.push(build_spend(id, name, data));
+        }
+    }
+    let (opencode_sp, mut aihubmix_data) = opencode();
+    merge_data(&mut aihubmix_data, qwen_via_claude);
+    let aihubmix_sp = build_spend("aihubmix", "AihubMix", aihubmix_data);
+    let (codex_sp, kimi_via_codex) = codex(pi_codex);
+    merge_data(&mut kimi_routed, kimi_via_codex);
+    let (extra_codex_spends, kimi_via_extra_codex) = codex_extra_accounts();
+    merge_data(&mut kimi_routed, kimi_via_extra_codex);
+    let mut list = vec![
+        claude_sp,
+        codex_sp,
+        grok(),
+        opencode_sp,
+        aihubmix_sp,
+        devin(),
+        minimax(minimax_extra),
+        kimi(kimi_routed),
+        qwen(),
+    ];
+    list.extend(extra_claude_spends);
+    list.extend(extra_codex_spends);
+    list.extend(hermes_rest);
+    if let Some(csv) = cursor_csv {
+        list.push(cursor_from_csv(&csv));
+    }
+    // Models nothing prices yet (new slugs ship often): flag the catalog
+    // to look for updates hourly instead of daily.
+    if list.iter().any(|sp| sp.unpriced > 0) {
+        pricing::note_unpriced();
+    }
+    save_persisted_cache();
+    list.into_iter().filter(ProviderSpend::has_data).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2297,6 +2502,111 @@ mod tests {
         let cached = cache().lock().unwrap().contains_key(&dir);
         let _ = fs::remove_dir_all(&dir);
         assert!(!cached, "unreadable path must not become a cache entry");
+    }
+
+    // ---- Input bounds: oversize lines, huge files, hostile model names ---
+
+    /// A line past MAX_LINE_BYTES is skipped without ever being stored;
+    /// the lines around it still parse and the file still caches (a
+    /// deliberate skip is not a read failure).
+    #[test]
+    fn oversize_lines_are_skipped_without_storing() {
+        let dir = std::env::temp_dir().join(format!("pane-bigline-{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        let path = dir.join("big-line.jsonl");
+        let ok = json!({"type": "usage.record", "model": "kimi-code/k3",
+            "usage": {"inputOther": 1000.0, "output": 1000.0},
+            "usageScope": "turn", "time": 1784208630652i64})
+        .to_string();
+        let huge = "x".repeat(MAX_LINE_BYTES + 1024);
+        fs::write(&path, format!("{ok}\n{huge}\n{ok}\n")).unwrap();
+
+        let mut seen: Vec<usize> = Vec::new();
+        let data = file_days(&path, &mut |line, data| {
+            seen.push(line.len());
+            kimi_line(line, data);
+        });
+        let cached = cache().lock().unwrap().contains_key(&path);
+        let _ = fs::remove_dir_all(&dir);
+
+        assert_eq!(seen, vec![ok.len(), ok.len()], "overlong line reached the parser");
+        assert_eq!(tokens_sum(&data), 4_000.0);
+        assert!(cached, "a skipped line must not poison the cache entry");
+    }
+
+    /// Files past MAX_LOG_FILE_BYTES are skipped: the walk won't list them,
+    /// and a direct-path caller gets nothing (and no cache entry).
+    #[test]
+    fn huge_log_files_are_skipped() {
+        let dir = std::env::temp_dir().join(format!("pane-hugefile-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("small.jsonl"), "{}\n").unwrap();
+        let huge_path = dir.join("huge.jsonl");
+        let huge = fs::File::create(&huge_path).unwrap();
+        huge.set_len(MAX_LOG_FILE_BYTES + 1).unwrap();
+        drop(huge);
+
+        let mut out = Vec::new();
+        recent_jsonl_files(&dir, &mut out);
+        assert!(out.iter().any(|p| p.ends_with("small.jsonl")));
+        assert!(!out.iter().any(|p| p.ends_with("huge.jsonl")), "oversize log must not be listed");
+
+        let mut parsed = false;
+        let data = file_days(&huge_path, &mut |_, _| parsed = true);
+        let cached = cache().lock().unwrap().contains_key(&huge_path);
+        let _ = fs::remove_dir_all(&dir);
+        assert!(!parsed && data.days.is_empty());
+        assert!(!cached, "oversize log must not become a cache entry");
+    }
+
+    /// A model string longer than MAX_MODEL_KEY can't key the maps (or the
+    /// persisted cache): it folds into the fixed overflow bucket while its
+    /// dollars and tokens still count.
+    #[test]
+    fn huge_model_names_fold_into_the_overflow_bucket() {
+        let ts = DateTime::from_timestamp_millis(1_784_208_630_652).unwrap();
+        let mut data = FileData::default();
+        let huge_a = format!("a{}", "x".repeat(10_000));
+        let huge_b = format!("b{}", "y".repeat(10_000));
+        add_event(&mut data, ts, &huge_a, 1.0, 100.0);
+        add_event(&mut data, ts, &huge_b, 2.0, 200.0);
+        note_unpriced(&mut data, ts, &huge_a, 50.0);
+
+        // Totals stay exact; only the attribution merged.
+        assert_eq!(cost_sum(&data), 3.0);
+        assert_eq!(tokens_sum(&data), 350.0);
+        assert_eq!(data.days.len(), 1);
+        assert!(data.days.keys().all(|(_, m)| m == OVERFLOW_MODEL_KEY));
+        assert_eq!(data.unpriced.get(OVERFLOW_MODEL_KEY), Some(&1));
+        assert!(data.unpriced.keys().all(|m| m.len() <= MAX_MODEL_KEY));
+
+        // Boundary: 128 chars is admitted, 129 folds.
+        let mut b = FileData::default();
+        let at_cap = "m".repeat(MAX_MODEL_KEY);
+        add_event(&mut b, ts, &at_cap, 1.0, 1.0);
+        assert!(b.days.keys().all(|(_, m)| m == &at_cap));
+        add_event(&mut b, ts, &"m".repeat(MAX_MODEL_KEY + 1), 1.0, 1.0);
+        assert!(b.days.keys().any(|(_, m)| m == OVERFLOW_MODEL_KEY));
+    }
+
+    /// One file naming endless distinct models folds everything past
+    /// MAX_MODELS_PER_FILE into the overflow bucket.
+    #[test]
+    fn unique_model_keys_cap_per_file() {
+        let ts = DateTime::from_timestamp_millis(1_784_208_630_652).unwrap();
+        let mut data = FileData::default();
+        for i in 0..MAX_MODELS_PER_FILE + 5 {
+            add_event(&mut data, ts, &format!("model-{i}"), 1.0, 1.0);
+        }
+        // 4096 admitted names plus the single overflow bucket.
+        assert_eq!(data.days.len(), MAX_MODELS_PER_FILE + 1);
+        let overflow = data
+            .days
+            .get(&(day_of_utc(ts), OVERFLOW_MODEL_KEY.to_string()))
+            .expect("overflow bucket");
+        assert_eq!(*overflow, (5.0, 5.0));
+        assert_eq!(cost_sum(&data), (MAX_MODELS_PER_FILE + 5) as f64);
     }
 
     #[test]
@@ -2603,7 +2913,7 @@ mod tests {
                         {"type": "message", "input_tokens": 1.0, "output_tokens": 291.0}
                     ]}}})
         .to_string();
-        let once = claude_run(&[line.clone()]);
+        let once = claude_run(std::slice::from_ref(&line));
         let models: HashSet<&str> = once.days.keys().map(|(_, m)| m.as_str()).collect();
         assert!(models.iter().any(|m| m.contains("fable")));
         assert!(models.iter().any(|m| m.contains("haiku")));
@@ -2907,109 +3217,37 @@ mod tests {
     #[test]
     #[ignore]
     fn live_probe() {
+        // Real export data is echoed here — cap every dump at 200 chars.
+        let clip = |s: String| s.chars().take(200).collect::<String>();
         let csv = tauri::async_runtime::block_on(crate::providers::cursor::fetch_usage_csv());
         eprintln!("cursor csv: {} bytes", csv.as_deref().map(str::len).unwrap_or(0));
         if let Some(c) = &csv {
-            eprintln!("csv header: {}", c.lines().next().unwrap_or(""));
+            eprintln!("{}", clip(format!("csv header: {}", c.lines().next().unwrap_or(""))));
             for row in c.lines().skip(1).take(3) {
                 let cells = super::split_csv_row(row);
                 eprintln!(
-                    "row: date={:?} parsed={} model={:?} in={:?} out={:?} total={:?} cost={:?}",
-                    cells.first(),
-                    cells.first().map(|d| super::parse_csv_date(d).is_some()).unwrap_or(false),
-                    cells.get(4),
-                    cells.get(6),
-                    cells.get(9),
-                    cells.get(10),
-                    cells.get(11),
+                    "{}",
+                    clip(format!(
+                        "row: date={:?} parsed={} model={:?} in={:?} out={:?} total={:?} cost={:?}",
+                        cells.first(),
+                        cells.first().map(|d| super::parse_csv_date(d).is_some()).unwrap_or(false),
+                        cells.get(4),
+                        cells.get(6),
+                        cells.get(9),
+                        cells.get(10),
+                        cells.get(11),
+                    ))
                 );
             }
         }
         for sp in super::collect(csv) {
             eprintln!(
-                "{}: today=${:.2} 30d=${:.2} tokens30={:.0} unpriced={} {:?}",
-                sp.id, sp.today.cost, sp.last30.cost, sp.last30.tokens, sp.unpriced, sp.unpriced_models
+                "{}",
+                clip(format!(
+                    "{}: today=${:.2} 30d=${:.2} tokens30={:.0} unpriced={} {:?}",
+                    sp.id, sp.today.cost, sp.last30.cost, sp.last30.tokens, sp.unpriced, sp.unpriced_models
+                ))
             );
         }
     }
-}
-
-/// Minimal CSV field splitter with quoted-field support.
-fn split_csv_row(line: &str) -> Vec<String> {
-    let mut out = Vec::new();
-    let mut field = String::new();
-    let mut in_quotes = false;
-    let mut chars = line.chars().peekable();
-    while let Some(c) = chars.next() {
-        match c {
-            '"' if in_quotes && chars.peek() == Some(&'"') => {
-                field.push('"');
-                chars.next();
-            }
-            '"' => in_quotes = !in_quotes,
-            ',' if !in_quotes => out.push(std::mem::take(&mut field)),
-            _ => field.push(c),
-        }
-    }
-    out.push(field);
-    out
-}
-
-pub fn collect(cursor_csv: Option<String>) -> Vec<ProviderSpend> {
-    providers::sweep_temp_sqlite_copies();
-    pricing::ensure_fresh();
-    load_persisted_cache();
-    if let Ok(mut t) = touched().lock() {
-        t.clear();
-    }
-    let (pi_claude, pi_codex) = pi();
-    let (claude_sp, mut minimax_extra, mut qwen_via_claude, mut kimi_routed) =
-        claude(pi_claude);
-    // Extra Claude accounts: own spend cards, with their MiniMax/qwen/Kimi-
-    // routed rows folded into the same destinations as the default account's.
-    let (extra_claude_spends, mm2, qw2, km2) = claude_extra_accounts();
-    merge_data(&mut minimax_extra, mm2);
-    merge_data(&mut qwen_via_claude, qw2);
-    merge_data(&mut kimi_routed, km2);
-    // Hermes rows going to an existing slice merge into it (MiniMax via the
-    // extra-data path); the rest become their own spend entries.
-    let mut hermes_rest = Vec::new();
-    for (id, name, data) in hermes() {
-        if id == "minimax" {
-            merge_data(&mut minimax_extra, data);
-        } else {
-            hermes_rest.push(build_spend(id, name, data));
-        }
-    }
-    let (opencode_sp, mut aihubmix_data) = opencode();
-    merge_data(&mut aihubmix_data, qwen_via_claude);
-    let aihubmix_sp = build_spend("aihubmix", "AihubMix", aihubmix_data);
-    let (codex_sp, kimi_via_codex) = codex(pi_codex);
-    merge_data(&mut kimi_routed, kimi_via_codex);
-    let (extra_codex_spends, kimi_via_extra_codex) = codex_extra_accounts();
-    merge_data(&mut kimi_routed, kimi_via_extra_codex);
-    let mut list = vec![
-        claude_sp,
-        codex_sp,
-        grok(),
-        opencode_sp,
-        aihubmix_sp,
-        devin(),
-        minimax(minimax_extra),
-        kimi(kimi_routed),
-        qwen(),
-    ];
-    list.extend(extra_claude_spends);
-    list.extend(extra_codex_spends);
-    list.extend(hermes_rest);
-    if let Some(csv) = cursor_csv {
-        list.push(cursor_from_csv(&csv));
-    }
-    // Models nothing prices yet (new slugs ship often): flag the catalog
-    // to look for updates hourly instead of daily.
-    if list.iter().any(|sp| sp.unpriced > 0) {
-        pricing::note_unpriced();
-    }
-    save_persisted_cache();
-    list.into_iter().filter(ProviderSpend::has_data).collect()
 }

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -102,8 +102,23 @@ impl FileData {
             self.models.insert(model.to_string());
             return model.to_string();
         }
-        OVERFLOW_MODEL_KEY.to_string()
+        overflow_key(model)
     }
+}
+
+/// The overflow bucket keeps Pi's routing prefix: take_tagged can only
+/// claim keys that still start with `{card}\u{1}`, so folding a tagged
+/// name into the bare overflow key would strand that usage between cards.
+/// Pi's card set is fixed (`claude`, `codex` — see pi_line), so this adds
+/// at most one bounded key per card.
+fn overflow_key(model: &str) -> String {
+    for card in ["claude", "codex"] {
+        let prefix = format!("{card}{PI_SEP}");
+        if model.starts_with(&prefix) {
+            return format!("{prefix}{OVERFLOW_MODEL_KEY}");
+        }
+    }
+    OVERFLOW_MODEL_KEY.to_string()
 }
 
 struct FileEntry {
@@ -3156,6 +3171,34 @@ mod tests {
         // $0 carried cost falls through to pricing; unknown model → honest ⚠.
         assert_eq!(codex.days.values().map(|v| v.1).sum::<f64>(), 500.0);
         assert_eq!(codex.unpriced.get("pi-test-model"), Some(&1));
+    }
+
+    /// Overflowed Pi keys keep their routing prefix: take_tagged must still
+    /// claim them, so capped usage lands on the right card instead of
+    /// vanishing with the discarded scan.
+    #[test]
+    fn pi_overflow_keeps_its_card_routing() {
+        let mut seen = HashSet::new();
+        let mut data = FileData::default();
+        let huge = "m".repeat(10_000);
+        for (id, provider) in [("p1", "anthropic"), ("p2", "openai-codex")] {
+            let line = json!({"type": "message", "id": id, "timestamp": "2026-08-03T10:00:00Z",
+                "message": {"role": "assistant", "provider": provider, "model": &huge,
+                            "usage": {"input": 100.0, "output": 50.0, "cacheRead": 0.0,
+                                      "cacheWrite": 0.0, "totalTokens": 150.0,
+                                      "cost": {"total": 1.0}}}})
+            .to_string();
+            pi_line(&mut seen, &line, &mut data);
+        }
+        let claude = take_tagged(&mut data, "claude");
+        let codex = take_tagged(&mut data, "codex");
+        // Nothing stranded between cards.
+        assert!(data.days.is_empty() && data.unpriced.is_empty());
+        assert_eq!(cost_sum(&claude), 1.0);
+        assert_eq!(cost_sum(&codex), 1.0);
+        assert_eq!(tokens_sum(&claude), 150.0);
+        assert!(claude.days.keys().all(|(_, m)| m == OVERFLOW_MODEL_KEY));
+        assert!(codex.days.keys().all(|(_, m)| m == OVERFLOW_MODEL_KEY));
     }
 
     #[test]

--- a/src-tauri/src/tray_projection.rs
+++ b/src-tauri/src/tray_projection.rs
@@ -405,7 +405,7 @@ mod tests {
         let mut layout = provider(&["1d", "Total quota", "5h"]);
         layout.hidden.push("5h".into());
         cfg.providers.insert(snap.id.clone(), layout);
-        let projected = project_main_tray(&[snap.clone()], &cfg, false);
+        let projected = project_main_tray(std::slice::from_ref(&snap), &cfg, false);
         assert_eq!(projected.remaining_percentages, vec![5]);
         assert_eq!(projected.tooltip, "Pane\nSite · Key 5h: 5% left");
         cfg.disabled.push("sub2api".into());


### PR DESCRIPTION
## What

Security-audit fixes for the spend engine and pricing ingest:

- **Bounded log scanning** — a hostile/compromised endpoint could emit a single JSONL line hundreds of MB long and every refresh allocated it. The scanner now skips files over 512 MiB and discards the remainder of any line over 4 MiB without storing it (legit Claude/Codex lines reach ~1 MB, so nothing real is lost).
- **Bounded model-key maps** — untrusted model strings keyed the `days`/`unpriced` maps persisted to `spend_cache.json` with no cap (the 128-char `MAX_PROBE_KEY` only guarded probes). Keys are now capped at 128 chars and 4,096 distinct models per file; overflow folds into a fixed bucket. Spend totals stay exact — only per-model attribution merges. `PERSIST_VERSION` 3 → 4 discards stale caches.
- **Supplement clamping** — the pricing supplement feed outranks LiteLLM/models.dev in `resolve()` while being trusted by URL alone. `apply_supplement` now drops non-finite/out-of-range prices (> $10k/M), fast multipliers (outside 1–10×), and alias targets that aren't plain ASCII slugs, with a single diagnostic.
- Assorted clippy fixes (tray_projection, elevenlabs).

## Tests

- New: oversize line/file skipped, huge model names fold into the overflow bucket with exact totals, unique-model cap, out-of-range supplement entries dropped (sane + boundary values survive), alias-target charset validation.
- `cargo test --lib` green on the combined branch (362 passed); this PR is a whole-file subset of it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->