### PR TITLE
Document the security hardening; gate release CI signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    # This job sees TAURI_SIGNING_PRIVATE_KEY, and without an environment
+    # gate any run of this workflow — including a dry-run
+    # workflow_dispatch — can use it. Repo admins: add required reviewers
+    # to the `release` environment (Settings → Environments) so a human
+    # approves before the signing key is exposed to a run.
+    environment: release
     permissions:
       contents: write
       # The winget dispatch step creates a workflow_dispatch event, which

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -31,6 +31,10 @@ on:
 jobs:
   winget:
     runs-on: windows-latest
+    # Minimal token scope: the job only reads this repo's release assets.
+    # The fork push and PR are made with WINGET_TOKEN, not GITHUB_TOKEN.
+    permissions:
+      contents: read
     steps:
       # Pinned to a commit SHA (was @v2): this third-party action receives
       # WINGET_TOKEN, so a hijacked tag could exfiltrate it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## Unreleased
+
+### Security
+- **Bundled SQLite moved past the public FTS5 CVEs.** Pane opens
+  databases that several CLIs own, so the SQLite vendored through
+  `rusqlite` is now a release carrying the disclosed FTS5 fixes.
+- **Every pasted-key file is owner-only and written atomically.** What
+  One/New API and Sub2API already had now covers every
+  `%APPDATA%\Pane\<provider>.json`: an owner-only ACL (Windows
+  protected DACL / Unix `0600`) never inherited from a permissive
+  parent, and a temp-file-then-rename write so a crash mid-save cannot
+  truncate your keys.
+- **Webview permissions cut to the minimum.** The main window's Tauri
+  capability is down to `core:default` — the UI only ever talks to Rust
+  through app commands, so every plugin permission is denied by
+  default.
+- **Antigravity's loopback client no longer follows redirects.** A legit
+  language server never redirects, and one could have carried the
+  client's csrf header cross-origin; redirects are now refused and
+  plaintext loopback never rides a proxy.
+- **Pricing-supplement values are range-checked.** The supplement is
+  fetched from a third-party URL, so rates and multipliers outside a
+  sane range are dropped before they touch spend math.
+- **Spend scanner caps line, file, and model-key growth.** A hostile or
+  corrupted log can no longer balloon a scan: individual lines, bytes
+  read per file, and the number of distinct model keys kept per file
+  are all bounded.
+- **Update checks throttled to the documented cadence.** The checker
+  now asks at launch and then every 4 h — what the privacy page has
+  always stated — and no more often.
+- **Assorted lows.** Provider error messages no longer echo saved keys;
+  Kimi's `*.pane-bak` token backup is deleted once the refreshed
+  credential file is safely in place; credential write-backs refuse
+  symlinked targets; the local HTTP API refuses duplicate `Host`
+  headers and answers with `nosniff`; telemetry drops free-text labels
+  from starred metrics and mints its random ID from OS entropy; the
+  updater download has a timeout; and the release pipeline's signing
+  job runs behind a GitHub `release` environment gate.
+
 ## 0.4.48 — 2026-09-09
 
 ### Fixed

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -85,11 +85,14 @@ Ground rules that apply to every provider:
 - **Calls:** `api2.cursor.sh` Connect RPCs (`GetCurrentPeriodUsage`,
   `GetPlanInfo`, `GetCreditGrantsBalance`); the dashboard's
   usage-events CSV export (for spend). `GetCreditGrantsBalance` cents
-  fields may be strings or numbers. When the RPC host is unreachable or
-  hides `planUsage` (Enterprise/team), `cursor.com/api/usage-summary`
-  (web session cookie) supplies the same plan figures; the pre-2025
-  request-count endpoint `cursor.com/api/usage` is the last resort and
-  only counts when it reports a real quota.
+  fields may be strings or numbers. A plan name missing from
+  `GetPlanInfo` falls back to `GET cursor.com/api/auth/stripe`
+  (`membershipType`, same `WorkosCursorSessionToken` web cookie). When
+  the RPC host is unreachable or hides `planUsage` (Enterprise/team),
+  `cursor.com/api/usage-summary` (web session cookie) supplies the same
+  plan figures; the pre-2025 request-count endpoint
+  `cursor.com/api/usage` is the last resort and only counts when it
+  reports a real quota.
 - **Shows:** Cursor Models / Other Models bars; a **Credits** progress
   row when the account has promo grants (`totalCents` vs remaining);
   a **Bonus** text row behind Show more when `planUsage.bonusSpend` is
@@ -204,8 +207,9 @@ Ground rules that apply to every provider:
 - **Reads:** `%USERPROFILE%\.kimi-code\credentials\kimi-code.json` (honors
   `KIMI_CODE_HOME`; falls back to `~\.kimi\credentials\kimi-code.json`).
   That is the official CLI's OAuth login. Refresh tokens rotate on use
-  and are written back beside the CLI's file (`*.pane-bak` first), same
-  as Claude/Codex. **No CLI?** Paste your Kimi For Coding plan key in
+  and are written back beside the CLI's file, like Claude/Codex — but
+  the `*.pane-bak` backup made first is deleted again once the
+  refreshed file is safely in place. **No CLI?** Paste your Kimi For Coding plan key in
   Settings → API keys → **Kimi Code** (stored in `%APPDATA%\Pane\kimi.json`,
   no env var is read). The login is used when both exist; the key is the
   fallback (issue #173). This is the plan key, not the platform.kimi.ai


### PR DESCRIPTION
## What

Docs + CI portion of the security-audit batch:

- **CHANGELOG** — new `Unreleased` → `### Security` section covering the whole hardening batch (SQLite CVE bump, owner-only key files, minimal webview permissions, Antigravity redirect refusal, supplement clamping, spend-scanner bounds, update-check throttle, and the assorted lows).
- **providers.md** — Cursor's `Calls` list was missing `GET cursor.com/api/auth/stripe` (the plan-name fallback using the same web cookie); Kimi's `.pane-bak` note now says the backup is deleted after a successful refresh.
- **release.yml** — the build job (which holds `TAURI_SIGNING_PRIVATE_KEY`) now runs in a `release` GitHub environment, so repo admins can require reviewer approval before any run — including dry-run dispatch — touches the signing key.
- **winget.yml** — explicit minimal `permissions: contents: read` (the job only needs `WINGET_TOKEN`).

## Notes

- privacy.md deliberately untouched — re-verified every claim against the post-fix code; all still accurate.
- Repo admins should add required reviewers under Settings → Environments → `release` for the gate to bite.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->