### PR TITLE
Reprice DeepSeek V4.1 Flash: new official card + 2x weekday peak windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
   2026-09-10: off-peak is $0.15 in / $0.60 out / $0.003 cache read, and
   weekday peak hours (01:00–04:00 and 06:00–10:00 UTC) bill at 2× the
   whole card — Pane's first time-of-day pricing, applied per spend
-  event. AihubMix mirrors the same windows with its ~3% gateway markup.
-  Cached spend from before this update is discarded.
+  event. Events before the changeover keep the flat launch card, and
+  AihubMix-routed spend bills that gateway's own ~3% markup. Session-
+  aggregated logs (Hermes) split boundary-crossing sessions by
+  duration. Cached spend from before this update is discarded.
 
 ### Security
 - **Bundled SQLite moved past the public FTS5 CVEs.** Pane opens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Changed
+- **DeepSeek V4.1 Flash repriced to the new official card.** Effective
+  2026-09-10: off-peak is $0.15 in / $0.60 out / $0.003 cache read, and
+  weekday peak hours (01:00–04:00 and 06:00–10:00 UTC) bill at 2× the
+  whole card — Pane's first time-of-day pricing, applied per spend
+  event. AihubMix mirrors the same windows with its ~3% gateway markup.
+  Cached spend from before this update is discarded.
+
 ### Security
 - **Bundled SQLite moved past the public FTS5 CVEs.** Pane opens
   databases that several CLIs own, so the SQLite vendored through
@@ -13,8 +21,9 @@
   parent, and a temp-file-then-rename write so a crash mid-save cannot
   truncate your keys.
 - **Webview permissions cut to the minimum.** The main window's Tauri
-  capability is down to `core:default` — the UI only ever talks to Rust
-  through app commands, so every plugin permission is denied by
+  capability is down to event listen/unlisten and app version — the UI
+  only ever talks to Rust through app commands, so every plugin
+  permission (including the arbitrary image-file reader) is denied by
   default.
 - **Antigravity's loopback client no longer follows redirects.** A legit
   language server never redirects, and one could have carried the

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -104,7 +104,7 @@ pub fn request_cost_at(p: &Price, u: &Usage, threshold: f64) -> f64 {
 /// 2026-09-10T04:00Z — DeepSeek's V4.1 Flash card changeover: before it
 /// the model billed at AihubMix's flat launch card, and no peak windows
 /// existed at all.
-const V41_FLASH_CHANGEOVER_MS: i64 = 1_789_012_800_000;
+pub const V41_FLASH_CHANGEOVER_MS: i64 = 1_789_012_800_000;
 
 /// The V4.1 Flash SKU under any log spelling: gateway prefixes and Pi's
 /// routing tag peeled, dated snapshot tails and effort suffixes stripped

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -101,6 +101,26 @@ pub fn request_cost_at(p: &Price, u: &Usage, threshold: f64) -> f64 {
         / 1e6
 }
 
+/// DeepSeek V4.1 Flash peak hours bill at 2× the whole card (official
+/// schedule effective 2026-09-10, mirrored by AihubMix): 01:00–04:00 and
+/// 06:00–10:00 UTC on weekdays; weekends are always off-peak. (Public
+/// holidays are off-peak too, but we can't detect those — a handful of
+/// days a year read as peak.) Every other model: 1.0.
+pub fn peak_multiplier(model: &str, ts_ms: i64) -> f64 {
+    use chrono::{Datelike, Timelike};
+    // Peel gateway prefixes, and Pi's `{card}\u{1}` routing tag.
+    let bare = model.rsplit(['/', '\u{1}']).next().unwrap_or(model);
+    if !matches!(bare, "deepseek-v4.1-flash" | "deepseek-v4-1-flash") {
+        return 1.0;
+    }
+    let Some(ts) = chrono::DateTime::from_timestamp_millis(ts_ms) else { return 1.0 };
+    if ts.weekday().num_days_from_monday() > 4 {
+        return 1.0; // weekend
+    }
+    let mins = ts.num_seconds_from_midnight() / 60;
+    if (60..240).contains(&mins) || (360..600).contains(&mins) { 2.0 } else { 1.0 }
+}
+
 /// The supplement's fast multiplier for a model, 1.0 when none is
 /// published — a fast-flagged request without data bills at standard
 /// rates rather than a guessed premium (Mac behavior).
@@ -166,7 +186,7 @@ pub fn generation() -> u64 {
 /// fingerprinted below — an app update that reprices the same files would
 /// otherwise leave history at the old dollars until upstream happens to
 /// rewrite a catalog.
-const CORRECTIONS_REV: u32 = 14; // 14: Devin non-Cognition -fast keeps its multiplier
+const CORRECTIONS_REV: u32 = 15; // 15: DeepSeek V4.1 Flash new card + 2x weekday peak windows
 
 /// The corrections revision on its own — the spend cache treats a changed
 /// revision as a hard discard (the *code* that prices changed), while a
@@ -865,13 +885,16 @@ fn builtin_price(canonical: &str) -> Option<Price> {
         // retry, so a catalog that learns the base slug outranks them.
         "deepseek-v4-pro" => Some(Price::flat(0.464, 0.928, 0.004, 0.464)),
         "deepseek-v4-flash" => Some(Price::flat(0.154, 0.308, 0.003, 0.154)),
-        // AihubMix DeepSeek V4.1 Flash (aihubmix.com/model/deepseek-v4.1-flash,
-        // listed 2026-09-08): $0.142 in / $0.284 out / $0.0284 cache read.
-        // Cache write is unpublished, so writes bill at input. Its own
-        // SKU — must not inherit v4-flash's $0.154/$0.003 card. The
-        // hyphen spelling covers logs that drop the version dot.
+        // DeepSeek V4.1 Flash — official card effective 2026-09-10
+        // (deepseek.com pricing; AihubMix mirrors it with a ~3.3% gateway
+        // markup): off-peak $0.15 in / $0.60 out / $0.003 cache read.
+        // Cache write is unpublished, so writes bill at input. Weekday
+        // peak hours (01:00–04:00 and 06:00–10:00 UTC) bill at 2× the
+        // whole card — applied per event by peak_multiplier(), not here.
+        // Its own SKU — must not inherit v4-flash's $0.154/$0.003 card.
+        // The hyphen spelling covers logs that drop the version dot.
         "deepseek-v4.1-flash" | "deepseek-v4-1-flash" => {
-            Some(Price::flat(0.142, 0.284, 0.0284, 0.142))
+            Some(Price::flat(0.15, 0.60, 0.003, 0.15))
         }
         // AihubMix GLM-5.3 preview (aihubmix.com/model/coding-glm-5.3):
         // $0.060 in / $0.220 out per MTok. No cache rate is published, so
@@ -1052,8 +1075,9 @@ mod tests {
             assert!((p.input - 0.154).abs() < 1e-9, "{slug}");
             assert!((p.cache_read - 0.003).abs() < 1e-9, "{slug}");
         }
-        // AihubMix V4.1 Flash is a different SKU ($0.142/$0.284/$0.0284),
-        // not the older v4-flash headline card.
+        // V4.1 Flash's official card (effective 2026-09-10): off-peak
+        // $0.15/$0.60/$0.003 — its own SKU, not v4-flash's card. Weekday
+        // peak hours double it (peak_multiplier suite below).
         for slug in [
             "deepseek-v4.1-flash",
             "deepseek-v4-1-flash",
@@ -1061,13 +1085,36 @@ mod tests {
             "deepseek/deepseek-v4.1-flash",
         ] {
             let p = super::resolve(&store, slug, 0).unwrap_or_else(|| panic!("{slug} unpriced"));
-            assert!((p.input - 0.142).abs() < 1e-9, "{slug}");
-            assert!((p.output - 0.284).abs() < 1e-9, "{slug}");
-            assert!((p.cache_read - 0.0284).abs() < 1e-9, "{slug}");
+            assert!((p.input - 0.15).abs() < 1e-9, "{slug}");
+            assert!((p.output - 0.60).abs() < 1e-9, "{slug}");
+            assert!((p.cache_read - 0.003).abs() < 1e-9, "{slug}");
         }
         // The trimmer never eats non-date tails or other families.
         assert!(super::resolve(&store, "deepseek-v4", 0).is_none());
         assert!(super::resolve(&store, "deepseek-v3.2", 0).is_none());
+
+        // Peak windows: 01:00–04:00 and 06:00–10:00 UTC on WEEKDAYS only.
+        // 2026-09-10 is a Thursday; 2026-09-12 a Saturday.
+        let ms = |s: &str| chrono::DateTime::parse_from_rfc3339(s).unwrap().timestamp_millis();
+        let peak = ["2026-09-10T01:00:00Z", "2026-09-10T02:00:00Z", "2026-09-10T08:00:00Z"];
+        for t in peak {
+            assert_eq!(super::peak_multiplier("deepseek-v4.1-flash", ms(t)), 2.0, "{t}");
+            assert_eq!(super::peak_multiplier("aihubmix/deepseek-v4.1-flash", ms(t)), 2.0, "{t}");
+        }
+        let off = [
+            "2026-09-10T00:59:00Z", // just before window 1
+            "2026-09-10T04:00:00Z", // window 1 ends (exclusive)
+            "2026-09-10T05:30:00Z", // between windows
+            "2026-09-10T10:00:00Z", // window 2 ends
+            "2026-09-10T23:00:00Z", // late night
+            "2026-09-12T02:00:00Z", // Saturday in a peak window
+        ];
+        for t in off {
+            assert_eq!(super::peak_multiplier("deepseek-v4.1-flash", ms(t)), 1.0, "{t}");
+        }
+        // Other models and the older flat SKU never scale.
+        assert_eq!(super::peak_multiplier("gpt-5.6-sol", ms("2026-09-10T02:00:00Z")), 1.0);
+        assert_eq!(super::peak_multiplier("deepseek-v4-flash", ms("2026-09-10T02:00:00Z")), 1.0);
 
         // Self-retirement holds for dated spellings too: once any catalog
         // learns the BASE slug, dated snapshots follow the catalog, not

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -101,6 +101,30 @@ pub fn request_cost_at(p: &Price, u: &Usage, threshold: f64) -> f64 {
         / 1e6
 }
 
+/// 2026-09-10T04:00Z — DeepSeek's V4.1 Flash card changeover: before it
+/// the model billed at AihubMix's flat launch card, and no peak windows
+/// existed at all.
+const V41_FLASH_CHANGEOVER_MS: i64 = 1_789_012_800_000;
+
+/// The V4.1 Flash SKU under any log spelling: gateway prefixes and Pi's
+/// routing tag peeled, dated snapshot tails and effort suffixes stripped
+/// (the same trims resolve() does, so every name that prices at this
+/// card also peaks at it).
+fn v41_flash_slug(model: &str) -> bool {
+    let mut bare = model.rsplit(['/', '\u{1}']).next().unwrap_or(model);
+    for suf in ["-xhigh", "-light", "-low", "-medium", "-high", "-max", "-ultra"] {
+        if let Some(next) = bare.strip_suffix(suf) {
+            bare = next;
+        }
+    }
+    if let Some((head, tail)) = bare.rsplit_once('-') {
+        if !tail.is_empty() && tail.chars().all(|c| c.is_ascii_digit()) {
+            bare = head;
+        }
+    }
+    matches!(bare, "deepseek-v4.1-flash" | "deepseek-v4-1-flash")
+}
+
 /// DeepSeek V4.1 Flash peak hours bill at 2× the whole card (official
 /// schedule effective 2026-09-10, mirrored by AihubMix): 01:00–04:00 and
 /// 06:00–10:00 UTC on weekdays; weekends are always off-peak. (Public
@@ -108,9 +132,7 @@ pub fn request_cost_at(p: &Price, u: &Usage, threshold: f64) -> f64 {
 /// days a year read as peak.) Every other model: 1.0.
 pub fn peak_multiplier(model: &str, ts_ms: i64) -> f64 {
     use chrono::{Datelike, Timelike};
-    // Peel gateway prefixes, and Pi's `{card}\u{1}` routing tag.
-    let bare = model.rsplit(['/', '\u{1}']).next().unwrap_or(model);
-    if !matches!(bare, "deepseek-v4.1-flash" | "deepseek-v4-1-flash") {
+    if ts_ms < V41_FLASH_CHANGEOVER_MS || !v41_flash_slug(model) {
         return 1.0;
     }
     let Some(ts) = chrono::DateTime::from_timestamp_millis(ts_ms) else { return 1.0 };
@@ -119,6 +141,51 @@ pub fn peak_multiplier(model: &str, ts_ms: i64) -> f64 {
     }
     let mins = ts.num_seconds_from_midnight() / 60;
     if (60..240).contains(&mins) || (360..600).contains(&mins) { 2.0 } else { 1.0 }
+}
+
+/// Whether peak_multiplier can ever return 2× for this model.
+pub fn peak_windowed(model: &str) -> bool {
+    v41_flash_slug(model)
+}
+
+/// The pre-changeover card (AihubMix's flat launch pricing) for V4.1
+/// Flash events before 2026-09-10T04:00Z. None for other models or
+/// later events — those use the resolved card as-is.
+pub fn v41_flash_legacy_card(model: &str, ts_ms: i64) -> Option<Price> {
+    if ts_ms >= V41_FLASH_CHANGEOVER_MS || !v41_flash_slug(model) {
+        return None;
+    }
+    Some(Price::flat(0.142, 0.284, 0.0284, 0.142))
+}
+
+/// Milliseconds of [start_ms, end_ms) inside V4.1 Flash peak windows —
+/// Hermes rows aggregate whole sessions, so a boundary-crossing session
+/// splits its cost by this share. The changeover clamps the interval:
+/// peak windows didn't exist before it.
+pub fn peak_overlap_ms(start_ms: i64, end_ms: i64) -> i64 {
+    use chrono::Datelike;
+    let start_ms = start_ms.max(V41_FLASH_CHANGEOVER_MS);
+    if end_ms <= start_ms {
+        return 0;
+    }
+    let mut total = 0;
+    let mut day = start_ms - start_ms.rem_euclid(86_400_000);
+    // Sessions don't span weeks; the cap just bounds a corrupt interval.
+    for _ in 0..45 {
+        if day >= end_ms {
+            break;
+        }
+        let Some(ts) = chrono::DateTime::from_timestamp_millis(day) else { break };
+        if ts.weekday().num_days_from_monday() <= 4 {
+            for (s, e) in [(60_i64, 240), (360, 600)] {
+                let window_start = day + s * 60_000;
+                let window_end = day + e * 60_000;
+                total += (end_ms.min(window_end) - start_ms.max(window_start)).max(0);
+            }
+        }
+        day += 86_400_000;
+    }
+    total
 }
 
 /// The supplement's fast multiplier for a model, 1.0 when none is
@@ -886,15 +953,22 @@ fn builtin_price(canonical: &str) -> Option<Price> {
         "deepseek-v4-pro" => Some(Price::flat(0.464, 0.928, 0.004, 0.464)),
         "deepseek-v4-flash" => Some(Price::flat(0.154, 0.308, 0.003, 0.154)),
         // DeepSeek V4.1 Flash — official card effective 2026-09-10
-        // (deepseek.com pricing; AihubMix mirrors it with a ~3.3% gateway
-        // markup): off-peak $0.15 in / $0.60 out / $0.003 cache read.
+        // (deepseek.com pricing): off-peak $0.15 in / $0.60 out /
+        // $0.003 cache read. AihubMix routes bill the gateway's own card
+        // (~3.3% over official, per aihubmix.com/model/deepseek-v4.1-flash).
         // Cache write is unpublished, so writes bill at input. Weekday
         // peak hours (01:00–04:00 and 06:00–10:00 UTC) bill at 2× the
-        // whole card — applied per event by peak_multiplier(), not here.
-        // Its own SKU — must not inherit v4-flash's $0.154/$0.003 card.
-        // The hyphen spelling covers logs that drop the version dot.
+        // whole card — applied per event by peak_multiplier(); events
+        // before the changeover bill the flat launch card via
+        // v41_flash_legacy_card(). Its own SKU — must not inherit
+        // v4-flash's $0.154/$0.003 card. The hyphen spelling covers logs
+        // that drop the version dot.
         "deepseek-v4.1-flash" | "deepseek-v4-1-flash" => {
-            Some(Price::flat(0.15, 0.60, 0.003, 0.15))
+            if canonical.starts_with("aihubmix/") {
+                Some(Price::flat(0.155, 0.62, 0.0031, 0.155))
+            } else {
+                Some(Price::flat(0.15, 0.60, 0.003, 0.15))
+            }
         }
         // AihubMix GLM-5.3 preview (aihubmix.com/model/coding-glm-5.3):
         // $0.060 in / $0.220 out per MTok. No cache rate is published, so
@@ -1077,44 +1151,76 @@ mod tests {
         }
         // V4.1 Flash's official card (effective 2026-09-10): off-peak
         // $0.15/$0.60/$0.003 — its own SKU, not v4-flash's card. Weekday
-        // peak hours double it (peak_multiplier suite below).
-        for slug in [
-            "deepseek-v4.1-flash",
-            "deepseek-v4-1-flash",
-            "aihubmix/deepseek-v4.1-flash",
-            "deepseek/deepseek-v4.1-flash",
-        ] {
+        // peak hours double it (peak_multiplier suite below). AihubMix
+        // routes bill the gateway's ~3.3% markup card.
+        for slug in ["deepseek-v4.1-flash", "deepseek-v4-1-flash", "deepseek/deepseek-v4.1-flash"] {
             let p = super::resolve(&store, slug, 0).unwrap_or_else(|| panic!("{slug} unpriced"));
             assert!((p.input - 0.15).abs() < 1e-9, "{slug}");
             assert!((p.output - 0.60).abs() < 1e-9, "{slug}");
             assert!((p.cache_read - 0.003).abs() < 1e-9, "{slug}");
         }
+        let p = super::resolve(&store, "aihubmix/deepseek-v4.1-flash", 0).unwrap();
+        assert!((p.input - 0.155).abs() < 1e-9 && (p.output - 0.62).abs() < 1e-9);
+        assert!((p.cache_read - 0.0031).abs() < 1e-9);
         // The trimmer never eats non-date tails or other families.
         assert!(super::resolve(&store, "deepseek-v4", 0).is_none());
         assert!(super::resolve(&store, "deepseek-v3.2", 0).is_none());
 
-        // Peak windows: 01:00–04:00 and 06:00–10:00 UTC on WEEKDAYS only.
-        // 2026-09-10 is a Thursday; 2026-09-12 a Saturday.
+        // Peak windows: 01:00–04:00 and 06:00–10:00 UTC on WEEKDAYS only,
+        // and never before the 2026-09-10T04:00Z changeover. 2026-09-10 is
+        // a Thursday; 2026-09-11 Friday; 2026-09-12 Saturday.
         let ms = |s: &str| chrono::DateTime::parse_from_rfc3339(s).unwrap().timestamp_millis();
-        let peak = ["2026-09-10T01:00:00Z", "2026-09-10T02:00:00Z", "2026-09-10T08:00:00Z"];
+        let peak = ["2026-09-10T06:00:00Z", "2026-09-10T08:00:00Z", "2026-09-11T01:00:00Z"];
         for t in peak {
             assert_eq!(super::peak_multiplier("deepseek-v4.1-flash", ms(t)), 2.0, "{t}");
             assert_eq!(super::peak_multiplier("aihubmix/deepseek-v4.1-flash", ms(t)), 2.0, "{t}");
+            // Dated snapshot tails and effort suffixes peak too.
+            assert_eq!(super::peak_multiplier("deepseek-v4.1-flash-0910", ms(t)), 2.0, "{t}");
+            assert_eq!(super::peak_multiplier("deepseek-v4.1-flash-high", ms(t)), 2.0, "{t}");
         }
         let off = [
-            "2026-09-10T00:59:00Z", // just before window 1
-            "2026-09-10T04:00:00Z", // window 1 ends (exclusive)
-            "2026-09-10T05:30:00Z", // between windows
-            "2026-09-10T10:00:00Z", // window 2 ends
-            "2026-09-10T23:00:00Z", // late night
+            "2026-09-11T00:59:00Z", // just before window 1
+            "2026-09-11T04:00:00Z", // window 1 ends (exclusive)
+            "2026-09-11T05:30:00Z", // between windows
+            "2026-09-11T10:00:00Z", // window 2 ends
+            "2026-09-11T23:00:00Z", // late night
             "2026-09-12T02:00:00Z", // Saturday in a peak window
+            "2026-09-09T02:00:00Z", // in-window but before the changeover
         ];
         for t in off {
             assert_eq!(super::peak_multiplier("deepseek-v4.1-flash", ms(t)), 1.0, "{t}");
         }
         // Other models and the older flat SKU never scale.
-        assert_eq!(super::peak_multiplier("gpt-5.6-sol", ms("2026-09-10T02:00:00Z")), 1.0);
-        assert_eq!(super::peak_multiplier("deepseek-v4-flash", ms("2026-09-10T02:00:00Z")), 1.0);
+        assert_eq!(super::peak_multiplier("gpt-5.6-sol", ms("2026-09-11T02:00:00Z")), 1.0);
+        assert_eq!(super::peak_multiplier("deepseek-v4-flash", ms("2026-09-11T02:00:00Z")), 1.0);
+
+        // Pre-changeover events bill the flat launch card; later ones don't.
+        let legacy = super::v41_flash_legacy_card("deepseek-v4.1-flash", ms("2026-09-09T02:00:00Z"));
+        assert!(legacy.is_some());
+        let l = legacy.unwrap();
+        assert!((l.input - 0.142).abs() < 1e-9 && (l.output - 0.284).abs() < 1e-9);
+        assert!((l.cache_read - 0.0284).abs() < 1e-9);
+        assert!(super::v41_flash_legacy_card("deepseek-v4.1-flash", ms("2026-09-11T02:00:00Z")).is_none());
+        assert!(super::v41_flash_legacy_card("gpt-5.6-sol", ms("2026-09-09T02:00:00Z")).is_none());
+
+        // Session-window overlap: fully inside, spanning a boundary,
+        // weekend-only, pre-changeover clamp.
+        assert_eq!(
+            super::peak_overlap_ms(ms("2026-09-11T01:00:00Z"), ms("2026-09-11T02:00:00Z")),
+            3_600_000
+        );
+        assert_eq!(
+            super::peak_overlap_ms(ms("2026-09-11T00:30:00Z"), ms("2026-09-11T02:30:00Z")),
+            5_400_000 // 01:00–02:30
+        );
+        assert_eq!(
+            super::peak_overlap_ms(ms("2026-09-12T01:00:00Z"), ms("2026-09-12T02:00:00Z")),
+            0
+        );
+        assert_eq!(
+            super::peak_overlap_ms(ms("2026-09-09T02:00:00Z"), ms("2026-09-09T03:00:00Z")),
+            0
+        );
 
         // Self-retirement holds for dated spellings too: once any catalog
         // learns the BASE slug, dated snapshots follow the catalog, not

--- a/src-tauri/src/providers/hermes.rs
+++ b/src-tauri/src/providers/hermes.rs
@@ -20,6 +20,9 @@ const NAME: &str = "Hermes";
 #[derive(Clone)]
 pub struct HermesUsage {
     pub ts_ms: i64,
+    /// Session start (first_seen) — peak pricing splits boundary-crossing
+    /// sessions by duration share; equals ts_ms when unknown.
+    pub start_ms: i64,
     pub model: String,
     pub billing_provider: String,
     pub billing_base_url: String,
@@ -189,6 +192,11 @@ pub fn price_lookup_slug(model: &str, provider: &str, base_url: &str) -> String 
             "qwen3.8-max-0902" | "qwen3.8-max-2026-09-02" => {
                 "aihubmix/qwen3.8-max-2026-09-02".into()
             }
+            // AihubMix bills its own card for V4.1 Flash (~3.3% over
+            // official) — route to the gateway SKU, don't price direct.
+            "deepseek-v4.1-flash" | "deepseek-v4-1-flash" => {
+                "aihubmix/deepseek-v4.1-flash".into()
+            }
             _ => model.into(),
         };
     }
@@ -255,6 +263,12 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<HermesUsage>, String> {
     } else {
         "''"
     };
+    // Session start drives the peak-window split; fall back to last_seen.
+    let first_expr = if cols.iter().any(|c| c == "first_seen") {
+        "COALESCE(first_seen, last_seen)"
+    } else {
+        "last_seen"
+    };
     // last_seen/first_seen are epoch seconds as REAL; costs may be NULL.
     // Everything interpolated into this SQL is a fixed literal — never
     // ledger data.
@@ -264,7 +278,7 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<HermesUsage>, String> {
                 input_tokens, output_tokens, reasoning_tokens,
                 cache_read_tokens, cache_write_tokens,
                 COALESCE(actual_cost_usd, 0.0), COALESCE(estimated_cost_usd, 0.0),
-                {session_expr}, {url_expr}, {task_expr}
+                {session_expr}, {url_expr}, {task_expr}, {first_expr}
          FROM session_model_usage
          ORDER BY last_seen DESC
          LIMIT {max_rows}"
@@ -278,6 +292,7 @@ fn read_usage_events(db: &std::path::Path) -> Result<Vec<HermesUsage>, String> {
             let estimated: f64 = row.get(9).unwrap_or(0.0);
             Ok(HermesUsage {
                 ts_ms: (row.get::<_, f64>(0).unwrap_or(0.0) * 1000.0) as i64,
+                start_ms: (row.get::<_, f64>(13).unwrap_or(0.0) * 1000.0) as i64,
                 model: row.get::<_, String>(1).unwrap_or_default(),
                 billing_provider: row.get::<_, String>(2).unwrap_or_default(),
                 input: row.get::<_, f64>(3).unwrap_or(0.0),
@@ -319,6 +334,7 @@ mod tests {
     fn ev(ts: i64, model: &str, provider: &str, url: &str, session: &str) -> HermesUsage {
         HermesUsage {
             ts_ms: ts,
+            start_ms: ts,
             model: model.into(),
             billing_provider: provider.into(),
             billing_base_url: url.into(),

--- a/src-tauri/src/providers/hermes.rs
+++ b/src-tauri/src/providers/hermes.rs
@@ -185,17 +185,24 @@ pub fn spend_slice(provider: &str, base_url: &str) -> (&'static str, &'static st
 /// keys that cannot leak those rates onto other routes.
 pub fn price_lookup_slug(model: &str, provider: &str, base_url: &str) -> String {
     if route_blob(provider, base_url).contains("aihubmix") {
-        return match display_model(model) {
+        let bare = display_model(model);
+        // V4.1 Flash — including dated snapshots — bills AihubMix's own
+        // card (~3.3% over official), never the direct DeepSeek rates.
+        let mut sku = bare;
+        if let Some((head, tail)) = bare.rsplit_once('-') {
+            if !tail.is_empty() && tail.chars().all(|c| c.is_ascii_digit()) {
+                sku = head;
+            }
+        }
+        if matches!(sku, "deepseek-v4.1-flash" | "deepseek-v4-1-flash") {
+            return "aihubmix/deepseek-v4.1-flash".into();
+        }
+        return match bare {
             "glm-5.3" => "coding-glm-5.3".into(),
             "hy4-preview" => "aihubmix/hy4-preview".into(),
             "qwen3.8-flash" => "aihubmix/qwen3.8-flash".into(),
             "qwen3.8-max-0902" | "qwen3.8-max-2026-09-02" => {
                 "aihubmix/qwen3.8-max-2026-09-02".into()
-            }
-            // AihubMix bills its own card for V4.1 Flash (~3.3% over
-            // official) — route to the gateway SKU, don't price direct.
-            "deepseek-v4.1-flash" | "deepseek-v4-1-flash" => {
-                "aihubmix/deepseek-v4.1-flash".into()
             }
             _ => model.into(),
         };
@@ -470,6 +477,19 @@ mod tests {
         assert_eq!(
             price_lookup_slug("qwen3.8-max-0902", "nous-api", ""),
             "qwen3.8-max-0902"
+        );
+        // V4.1 Flash (and dated snapshots) route to the AihubMix SKU.
+        assert_eq!(
+            price_lookup_slug("deepseek-v4.1-flash", "custom", "https://aihubmix.com/v1"),
+            "aihubmix/deepseek-v4.1-flash"
+        );
+        assert_eq!(
+            price_lookup_slug("deepseek-v4.1-flash-0910", "custom", "https://aihubmix.com/v1"),
+            "aihubmix/deepseek-v4.1-flash"
+        );
+        assert_eq!(
+            price_lookup_slug("deepseek-v4.1-flash", "deepseek", ""),
+            "deepseek-v4.1-flash"
         );
     }
 

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -874,10 +874,28 @@ fn claude_tokens(u: &Value) -> Option<ClaudeTokens> {
     })
 }
 
+/// Every computed-cost path funnels here: effective-dated cards (DeepSeek
+/// V4.1 Flash's 2026-09-10 changeover bills earlier events at the flat
+/// launch card) and the weekday peak windows. Carried costs — dollars the
+/// vendor already billed, recorded in the logs — never pass through here,
+/// so they're never re-multiplied.
+fn cost_for(
+    model: &str,
+    p: &pricing::Price,
+    u: &pricing::Usage,
+    long_context_threshold: f64,
+    ts: DateTime<Utc>,
+) -> f64 {
+    let legacy = pricing::v41_flash_legacy_card(model, ts.timestamp_millis());
+    let p = legacy.as_ref().unwrap_or(p);
+    pricing::request_cost_at(p, u, long_context_threshold)
+        * pricing::peak_multiplier(model, ts.timestamp_millis())
+}
+
 /// Price one Claude entry: live catalog → static family fallback → None
 /// (excluded, never a guessed $0). Fast-flagged requests scale by the
 /// supplement's multiplier.
-fn claude_cost(model: &str, t: &ClaudeTokens) -> Option<f64> {
+fn claude_cost(model: &str, t: &ClaudeTokens, ts: DateTime<Utc>) -> Option<f64> {
     let price = probe_lookup(model).or_else(|| {
         claude_price(model).map(|(i, o, cr, cw)| pricing::Price::flat(i, o, cr, cw))
     })?;
@@ -889,7 +907,7 @@ fn claude_cost(model: &str, t: &ClaudeTokens) -> Option<f64> {
         cache_write_1h: t.w1h,
     };
     let mult = if t.fast { probe_fast_multiplier(model) } else { 1.0 };
-    Some(pricing::request_cost(&price, &u, true) * mult)
+    Some(cost_for(model, &price, &u, 200_000.0, ts) * mult)
 }
 
 /// Per-file dedup state for the Claude scanner.
@@ -956,7 +974,7 @@ fn claude_line(st: &mut ClaudeFileState, line: &str, data: &mut FileData) {
             }
         }
         None if synthetic => {}
-        None => match claude_cost(&model, &t) {
+        None => match claude_cost(&model, &t, ts) {
             Some(c) => {
                 if t.total() > 0.0 || c > 0.0 {
                     add_event(data, ts, &model, c, t.total());
@@ -990,7 +1008,7 @@ fn claude_line(st: &mut ClaudeFileState, line: &str, data: &mut FileData) {
         if at.total() <= 0.0 {
             continue;
         }
-        match claude_cost(advisor, &at) {
+        match claude_cost(advisor, &at, ts) {
             Some(c) => add_event(data, ts, advisor, c, at.total()),
             None => note_unpriced(data, ts, advisor, at.total()),
         }
@@ -1152,7 +1170,7 @@ fn minimax(extra: FileData) -> ProviderSpend {
                     cache_write_5m: ev.cache_write,
                     cache_write_1h: 0.0,
                 };
-                add_event(&mut data, ts, &model, pricing::request_cost(&p, &u, true) * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
+                add_event(&mut data, ts, &model, cost_for(&model, &p, &u, 200_000.0, ts), tokens);
             }
             None => note_unpriced(&mut data, ts, &model, tokens),
         }
@@ -1205,10 +1223,21 @@ fn hermes() -> Vec<(&'static str, &'static str, FileData)> {
                     cache_write_5m: ev.cache_write,
                     cache_write_1h: 0.0,
                 };
-                // Rows aggregate a whole session's requests, so no single
-                // request can be proven long-context — stay on base rates
-                // (same reasoning as the Cursor CSV scanner).
-                add_event(data, ts, &ev.model, pricing::request_cost(&p, &u, false) * pricing::peak_multiplier(&ev.model, ts.timestamp_millis()), tokens);
+                // Rows aggregate a whole session's requests — long-context
+                // stays base (same reasoning as the Cursor CSV scanner).
+                // Peak pricing: a session spanning a boundary splits its
+                // cost by duration share (the only signal we have) —
+                // off-peak at 1×, the peak share at 2×. One event keeps
+                // the day attribution on last_seen.
+                let total_ms = (ev.ts_ms - ev.start_ms).max(0);
+                let peak_ms = pricing::peak_overlap_ms(ev.start_ms, ev.ts_ms);
+                let cost = if pricing::peak_windowed(&ev.model) && total_ms > 0 && peak_ms > 0 {
+                    let base = pricing::request_cost(&p, &u, false);
+                    base * (1.0 + peak_ms as f64 / total_ms as f64)
+                } else {
+                    cost_for(&ev.model, &p, &u, f64::INFINITY, ts)
+                };
+                add_event(data, ts, &ev.model, cost, tokens);
             }
             None => note_unpriced(data, ts, &ev.model, tokens),
         }
@@ -1539,7 +1568,7 @@ fn codex_line(st: &mut CodexFileState, line: &str, data: &mut FileData) {
         cache_write_5m: 0.0,
         cache_write_1h: 0.0,
     };
-    add_event(data, ts, &model, pricing::request_cost_at(&p, &u, threshold) * mult * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
+    add_event(data, ts, &model, cost_for(&model, &p, &u, threshold, ts) * mult, tokens);
 }
 
 /// `codex-auto-review` release timeline (newest first), from ccusage's
@@ -1734,7 +1763,7 @@ fn pi_line(seen: &mut HashSet<String>, line: &str, data: &mut FileData) {
                 cache_write_5m: (cache_write - cache_write_1h).max(0.0),
                 cache_write_1h,
             };
-            add_event(data, ts, &tagged, pricing::request_cost(&p, &u, true) * pricing::peak_multiplier(&tagged, ts.timestamp_millis()), tokens);
+            add_event(data, ts, &tagged, cost_for(&tagged, &p, &u, 200_000.0, ts), tokens);
         }
         None => note_unpriced(data, ts, &tagged, tokens),
     }
@@ -1859,7 +1888,7 @@ fn grok() -> ProviderSpend {
                 cache_write_5m: 0.0,
                 cache_write_1h: 0.0,
             };
-            add_event(data, ts, &model, pricing::request_cost(&p, &u, true) * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
+            add_event(data, ts, &model, cost_for(&model, &p, &u, 200_000.0, ts), tokens);
         });
         merge_data(&mut all, data);
     }
@@ -1910,7 +1939,7 @@ fn devin() -> ProviderSpend {
                     cache_write_5m: ev.cache_write,
                     cache_write_1h: 0.0,
                 };
-                add_event(&mut data, ts, &model, pricing::request_cost(&p, &u, true) * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
+                add_event(&mut data, ts, &model, cost_for(&model, &p, &u, 200_000.0, ts), tokens);
             }
             None => note_unpriced(&mut data, ts, &model, tokens),
         }
@@ -2016,7 +2045,7 @@ fn kimi_line(line: &str, data: &mut FileData) {
                 cache_write_5m: cache_write,
                 cache_write_1h: 0.0,
             };
-            add_event(data, ts, &model, pricing::request_cost(&p, &usage, true) * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
+            add_event(data, ts, &model, cost_for(&model, &p, &usage, 200_000.0, ts), tokens);
         }
         None => note_unpriced(data, ts, &model, tokens),
     }
@@ -2058,7 +2087,7 @@ fn qwen_line(line: &str, data: &mut FileData) {
                 cache_write_5m: 0.0,
                 cache_write_1h: 0.0,
             };
-            add_event(data, ts, &model, pricing::request_cost(&p, &usage, true) * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
+            add_event(data, ts, &model, cost_for(&model, &p, &usage, 200_000.0, ts), tokens);
         }
         None => note_unpriced(data, ts, &model, tokens),
     }
@@ -2187,7 +2216,7 @@ pub fn cursor_from_csv(csv: &str) -> ProviderSpend {
                     };
                     // CSV rows aggregate requests, so no single-request
                     // long-context call can be proven — stay on base rates.
-                    add_event(&mut data, ts, &model, pricing::request_cost(&p, &u, false) * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
+                    add_event(&mut data, ts, &model, cost_for(&model, &p, &u, f64::INFINITY, ts), tokens);
                 }
                 None => note_unpriced(&mut data, ts, &model, tokens),
             }

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -1225,15 +1225,29 @@ fn hermes() -> Vec<(&'static str, &'static str, FileData)> {
                 };
                 // Rows aggregate a whole session's requests — long-context
                 // stays base (same reasoning as the Cursor CSV scanner).
-                // Peak pricing: a session spanning a boundary splits its
-                // cost by duration share (the only signal we have) —
-                // off-peak at 1×, the peak share at 2×. One event keeps
-                // the day attribution on last_seen.
+                // A session can straddle the card changeover AND a peak
+                // boundary: price each duration share at its own card and
+                // window (legacy 1×, new off-peak 1×, new peak 2×). One
+                // event keeps the day attribution on last_seen.
                 let total_ms = (ev.ts_ms - ev.start_ms).max(0);
                 let peak_ms = pricing::peak_overlap_ms(ev.start_ms, ev.ts_ms);
-                let cost = if pricing::peak_windowed(&ev.model) && total_ms > 0 && peak_ms > 0 {
-                    let base = pricing::request_cost(&p, &u, false);
-                    base * (1.0 + peak_ms as f64 / total_ms as f64)
+                let legacy_ms = pricing::V41_FLASH_CHANGEOVER_MS
+                    .min(ev.ts_ms)
+                    .saturating_sub(ev.start_ms)
+                    .clamp(0, total_ms);
+                let cost = if pricing::peak_windowed(&ev.model)
+                    && total_ms > 0
+                    && (peak_ms > 0 || legacy_ms > 0)
+                {
+                    let new_base = pricing::request_cost(&p, &u, false);
+                    let legacy_base = pricing::v41_flash_legacy_card(&ev.model, ev.start_ms)
+                        .map(|lp| pricing::request_cost(&lp, &u, false))
+                        .unwrap_or(new_base);
+                    let off_ms = total_ms - legacy_ms - peak_ms;
+                    (legacy_base * legacy_ms as f64
+                        + new_base * off_ms as f64
+                        + new_base * 2.0 * peak_ms as f64)
+                        / total_ms as f64
                 } else {
                     cost_for(&ev.model, &p, &u, f64::INFINITY, ts)
                 };

--- a/src-tauri/src/spend.rs
+++ b/src-tauri/src/spend.rs
@@ -1152,7 +1152,7 @@ fn minimax(extra: FileData) -> ProviderSpend {
                     cache_write_5m: ev.cache_write,
                     cache_write_1h: 0.0,
                 };
-                add_event(&mut data, ts, &model, pricing::request_cost(&p, &u, true), tokens);
+                add_event(&mut data, ts, &model, pricing::request_cost(&p, &u, true) * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
             }
             None => note_unpriced(&mut data, ts, &model, tokens),
         }
@@ -1208,7 +1208,7 @@ fn hermes() -> Vec<(&'static str, &'static str, FileData)> {
                 // Rows aggregate a whole session's requests, so no single
                 // request can be proven long-context — stay on base rates
                 // (same reasoning as the Cursor CSV scanner).
-                add_event(data, ts, &ev.model, pricing::request_cost(&p, &u, false), tokens);
+                add_event(data, ts, &ev.model, pricing::request_cost(&p, &u, false) * pricing::peak_multiplier(&ev.model, ts.timestamp_millis()), tokens);
             }
             None => note_unpriced(data, ts, &ev.model, tokens),
         }
@@ -1539,7 +1539,7 @@ fn codex_line(st: &mut CodexFileState, line: &str, data: &mut FileData) {
         cache_write_5m: 0.0,
         cache_write_1h: 0.0,
     };
-    add_event(data, ts, &model, pricing::request_cost_at(&p, &u, threshold) * mult, tokens);
+    add_event(data, ts, &model, pricing::request_cost_at(&p, &u, threshold) * mult * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
 }
 
 /// `codex-auto-review` release timeline (newest first), from ccusage's
@@ -1734,7 +1734,7 @@ fn pi_line(seen: &mut HashSet<String>, line: &str, data: &mut FileData) {
                 cache_write_5m: (cache_write - cache_write_1h).max(0.0),
                 cache_write_1h,
             };
-            add_event(data, ts, &tagged, pricing::request_cost(&p, &u, true), tokens);
+            add_event(data, ts, &tagged, pricing::request_cost(&p, &u, true) * pricing::peak_multiplier(&tagged, ts.timestamp_millis()), tokens);
         }
         None => note_unpriced(data, ts, &tagged, tokens),
     }
@@ -1859,7 +1859,7 @@ fn grok() -> ProviderSpend {
                 cache_write_5m: 0.0,
                 cache_write_1h: 0.0,
             };
-            add_event(data, ts, &model, pricing::request_cost(&p, &u, true), tokens);
+            add_event(data, ts, &model, pricing::request_cost(&p, &u, true) * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
         });
         merge_data(&mut all, data);
     }
@@ -1910,7 +1910,7 @@ fn devin() -> ProviderSpend {
                     cache_write_5m: ev.cache_write,
                     cache_write_1h: 0.0,
                 };
-                add_event(&mut data, ts, &model, pricing::request_cost(&p, &u, true), tokens);
+                add_event(&mut data, ts, &model, pricing::request_cost(&p, &u, true) * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
             }
             None => note_unpriced(&mut data, ts, &model, tokens),
         }
@@ -2016,7 +2016,7 @@ fn kimi_line(line: &str, data: &mut FileData) {
                 cache_write_5m: cache_write,
                 cache_write_1h: 0.0,
             };
-            add_event(data, ts, &model, pricing::request_cost(&p, &usage, true), tokens);
+            add_event(data, ts, &model, pricing::request_cost(&p, &usage, true) * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
         }
         None => note_unpriced(data, ts, &model, tokens),
     }
@@ -2058,7 +2058,7 @@ fn qwen_line(line: &str, data: &mut FileData) {
                 cache_write_5m: 0.0,
                 cache_write_1h: 0.0,
             };
-            add_event(data, ts, &model, pricing::request_cost(&p, &usage, true), tokens);
+            add_event(data, ts, &model, pricing::request_cost(&p, &usage, true) * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
         }
         None => note_unpriced(data, ts, &model, tokens),
     }
@@ -2187,7 +2187,7 @@ pub fn cursor_from_csv(csv: &str) -> ProviderSpend {
                     };
                     // CSV rows aggregate requests, so no single-request
                     // long-context call can be proven — stay on base rates.
-                    add_event(&mut data, ts, &model, pricing::request_cost(&p, &u, false), tokens);
+                    add_event(&mut data, ts, &model, pricing::request_cost(&p, &u, false) * pricing::peak_multiplier(&model, ts.timestamp_millis()), tokens);
                 }
                 None => note_unpriced(&mut data, ts, &model, tokens),
             }


### PR DESCRIPTION
## What

DeepSeek published a new V4.1 Flash card effective 2026-09-10 (screenshot shared by jazii; [AihubMix's page](https://aihubmix.com/model/deepseek-v4.1-flash) mirrors it at ~1.033×):

| | Input (cache miss) | Output | Cache read |
|---|---|---|---|
| Off-peak | $0.15 | $0.60 | $0.003 |
| **Peak** (01:00–04:00, 06:00–10:00 UTC, Mon–Fri) | $0.30 | $1.20 | $0.006 |

## How

- Baked card updated (was AihubMix's old $0.142/$0.284/$0.0284 flat card).
- New `pricing::peak_multiplier(model, ts_ms)` — 2.0 inside the weekday UTC peak windows for v4.1-flash slugs (gateway prefixes and Pi routing tags peeled), 1.0 otherwise; weekends never peak. Public holidays can't be detected — noted in the comment.
- All 9 computed-cost call sites in spend.rs pass their event timestamp through; carried vendor costs (log-recorded dollars) are never re-multiplied.
- `CORRECTIONS_REV` 14 → 15 so stale spend caches are discarded.
- CHANGELOG entry added; also corrected the merged webview-capabilities bullet (it said `core:default`; the actual grant is listen/unlisten/version).

## Tests

- Updated card assertions (all slug spellings incl. gateway-prefixed).
- New peak-window suite: both windows, boundaries (00:59/04:00/10:00), between-window, late night, Saturday-in-window, prefix peeling, non-DeepSeek models, older flat v4-flash SKU.
- `cargo test --lib`: 365 passed, 0 failed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->