### PR TITLE
Release 0.4.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## Unreleased
+## 0.4.49 — 2026-09-10
+
+### Added
+- **Sub2API usage tracking with multiple sites and keys.** Each saved
+  site+key pair gets a stable card with total and rolling key quotas,
+  daily/weekly/monthly subscription allowances, wallet balances
+  (including debt), expiry, and collapsible request/token/cost
+  summaries. Cards survive edits, failed refreshes keep explicitly
+  stale history, and the tightest allowance projects into the tray
+  with quota alerts.
 
 ### Changed
 - **DeepSeek V4.1 Flash repriced to the new official card.** Effective

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,11 +1,13 @@
 # Roadmap — full Mac parity (and beyond)
 
-**Status (v0.4.48, 2026-09-09): every wave below is shipped, and the
+**Status (v0.4.49, 2026-09-10): every wave below is shipped, and the
 post-launch releases keep going.** Pane has full feature parity with the
-macOS original plus 22 providers, multi-site One/New API key management,
+macOS original plus 23 providers (Sub2API multi-site key tracking
+landed), multi-site One/New API key management,
 Kimi Code plan keys without a CLI login, resilient modern Cursor plan
 fallbacks, English/Chinese/Russian UI, signed CI updates, live model
-pricing, and a Mac-parity design pass (inset cards, wedge spend donut,
+pricing (now with time-of-day peak windows), and a Mac-parity design
+pass (inset cards, wedge spend donut,
 in-popover drag reorder, curated share cards). The primary site is
 `trypane.xyz`, and recent cuts keep spend honest against fast-moving
 vendor pricing (Cognition SWE/Penguin, AihubMix DeepSeek, Devin's fast

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.48",
+  "version": "0.4.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.48",
+      "version": "0.4.49",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.48",
+  "version": "0.4.49",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.48"
+version = "0.4.49"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.48"
+version = "0.4.49"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.48",
+  "version": "0.4.49",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump + changelog for 0.4.49: Sub2API multi-site/key tracking (#188), security hardening batch (#193–#199), DeepSeek V4.1 Flash peak/off-peak pricing (#200).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->