### PR TITLE
Never let a corrupt config.json clobber the last good backup

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,12 @@ fn config_path_in(dir: &Path) -> PathBuf {
 /// A parse failure here once silently reset all settings to defaults, so
 /// failures are now logged durably and the last good copy is used instead.
 fn note_config_error(context: &str) {
+    eprintln!("[pane] {context}");
+    // Tests run against temp dirs; they must never append into the
+    // developer's real config-error.log.
+    if cfg!(test) {
+        return;
+    }
     let line = format!(
         "{} {}\r\n",
         chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
@@ -51,7 +57,6 @@ fn note_config_error(context: &str) {
     {
         let _ = f.write_all(line.as_bytes());
     }
-    eprintln!("[pane] {context}");
 }
 
 fn parse_config_file(path: &PathBuf) -> Result<Value, String> {
@@ -195,29 +200,69 @@ fn apply_config_patch(cfg: &mut Value, patch: &Value) {
     }
 }
 
-fn persist_config_in(dir: &Path, cfg: &Value) -> Result<(), String> {
+/// Injectable filesystem operations for config persistence, so failure
+/// paths (disk full, locked file, failed replace) are repeatable tests
+/// instead of best-effort permission games.
+#[derive(Clone, Copy)]
+struct ConfigPersistIo {
+    write_tmp: fn(&Path, &str) -> std::io::Result<()>,
+    replace: fn(&Path, &Path) -> std::io::Result<()>,
+}
+
+impl ConfigPersistIo {
+    fn real() -> Self {
+        Self {
+            write_tmp: |path, raw| std::fs::write(path, raw),
+            // std::fs::rename replaces an existing destination on Windows
+            // (MoveFileEx REPLACE_EXISTING), so the swap is atomic-ish.
+            replace: |tmp, path| std::fs::rename(tmp, path),
+        }
+    }
+}
+
+/// Commit order for one config save (callers hold CONFIG_WRITE):
+///   1. write the new config to a unique temp file — failure cleans the
+///      temp and leaves the main file and backup untouched;
+///   2. refresh the backup from the main file, but ONLY while the main
+///      file still parses — a corrupt main must never clobber the last
+///      good backup, because that backup is the only thing a corrupt
+///      main recovers from;
+///   3. replace the main file with the temp — failure removes the temp
+///      and both old files survive.
+///
+/// After every step at least one parseable config exists: the old main,
+/// the backup, or (once step 1 succeeded) the temp itself.
+fn persist_config_at(dir: &Path, cfg: &Value, io: ConfigPersistIo) -> Result<(), String> {
     std::fs::create_dir_all(dir).map_err(|e| format!("create config dir: {e}"))?;
     let path = config_path_in(dir);
-    // Keep the last good copy, then write atomically (temp file + rename) so
-    // a crash or kill mid-write can never leave a truncated config behind.
-    if path.exists() {
-        let _ = std::fs::copy(&path, dir.join("config.json.bak"));
-    }
+    let backup = dir.join("config.json.bak");
     let tmp = dir.join(format!(
         "config.{}.{}.tmp",
         std::process::id(),
         CONFIG_TMP_SEQ.fetch_add(1, Ordering::Relaxed)
     ));
     let raw = serde_json::to_string_pretty(cfg).unwrap_or_default();
-    if let Err(e) = std::fs::write(&tmp, raw) {
+    if let Err(e) = (io.write_tmp)(&tmp, &raw) {
         let _ = std::fs::remove_file(&tmp);
         return Err(format!("write config: {e}"));
     }
-    if let Err(e) = std::fs::rename(&tmp, &path) {
+    if path.exists() && parse_config_file(&path).is_ok() {
+        if let Err(e) = std::fs::copy(&path, &backup) {
+            // Not fatal: the temp already holds the new valid config,
+            // and an older (or missing) backup still recovers a corrupt
+            // main. Logged so the degradation is diagnosable.
+            note_config_error(&format!("config backup refresh failed ({e})"));
+        }
+    }
+    if let Err(e) = (io.replace)(&tmp, &path) {
         let _ = std::fs::remove_file(&tmp);
         return Err(format!("replace config: {e}"));
     }
     Ok(())
+}
+
+fn persist_config_in(dir: &Path, cfg: &Value) -> Result<(), String> {
+    persist_config_at(dir, cfg, ConfigPersistIo::real())
 }
 
 fn set_config_in(dir: &Path, patch: Value) -> Result<Value, String> {
@@ -2959,6 +3004,7 @@ mod tests {
         fold_moonshot_into_kimi, forget_onenewapi_key_ids, forget_provider_snapshot,
         is_kimi_wallet_label, last_ok, onenewapi_after_site_save,
         onenewapi_apply_zero_to_one_enable, key_card_snapshot_generations, persist_last_ok_at,
+        persist_config_at, ConfigPersistIo,
         key_cards_purge_restore_patch, purge_onenewapi_cards, purge_onenewapi_cards_coordinated,
         purge_onenewapi_cards_with, purge_key_cards_from_config,
         rename_cached_snapshot, rename_cached_snapshot_in, rename_cached_snapshots_in,
@@ -3434,6 +3480,150 @@ mod tests {
             );
             assert_eq!(cfg["locale"], json!("zh"), "round {round} lost locale patch");
         }
+    }
+
+    // ---- config backup protection ----------------------------------------
+
+    fn no_tmp_leftovers(dir: &std::path::Path) -> bool {
+        std::fs::read_dir(dir)
+            .unwrap()
+            .flatten()
+            .all(|e| !e.file_name().to_string_lossy().ends_with(".tmp"))
+    }
+
+    fn fail_write(_path: &std::path::Path, _raw: &str) -> std::io::Result<()> {
+        Err(std::io::Error::other("disk full"))
+    }
+
+    fn partial_write(path: &std::path::Path, raw: &str) -> std::io::Result<()> {
+        std::fs::write(path, &raw[..raw.len() / 2])?;
+        Err(std::io::Error::other("disk full"))
+    }
+
+    fn fail_replace(_tmp: &std::path::Path, _path: &std::path::Path) -> std::io::Result<()> {
+        Err(std::io::Error::other("file in use"))
+    }
+
+    #[test]
+    fn corrupt_main_config_never_clobbers_the_good_backup() {
+        let tmp = TempConfig::new();
+        let good = json!({"locale": "zh"});
+        std::fs::write(
+            tmp.dir.join("config.json.bak"),
+            serde_json::to_string(&good).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(tmp.dir.join("config.json"), "{corrupt").unwrap();
+
+        set_config_in(&tmp.dir, json!({ "density": "compact" })).unwrap();
+
+        let backup: Value = serde_json::from_str(
+            &std::fs::read_to_string(tmp.dir.join("config.json.bak")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            backup, good,
+            "a corrupt main file must never overwrite the good backup"
+        );
+        let main = load_config_from(&tmp.dir);
+        assert_eq!(main["density"], "compact");
+        assert_eq!(
+            main["locale"], "zh",
+            "the save patches on top of the recovered backup, not defaults"
+        );
+    }
+
+    #[test]
+    fn failed_temp_write_leaves_main_and_backup_untouched() {
+        let tmp = TempConfig::new();
+        std::fs::write(tmp.dir.join("config.json"), r#"{"locale":"zh"}"#).unwrap();
+        let error = persist_config_at(
+            &tmp.dir,
+            &json!({"density": "compact"}),
+            ConfigPersistIo {
+                write_tmp: fail_write,
+                ..ConfigPersistIo::real()
+            },
+        )
+        .unwrap_err();
+        assert!(error.contains("write config"), "{error}");
+        assert_eq!(load_config_from(&tmp.dir)["locale"], "zh");
+        assert!(!tmp.dir.join("config.json.bak").exists());
+        assert!(no_tmp_leftovers(&tmp.dir));
+    }
+
+    #[test]
+    fn partial_temp_write_is_cleaned_up() {
+        let tmp = TempConfig::new();
+        std::fs::write(tmp.dir.join("config.json"), "{}").unwrap();
+        persist_config_at(
+            &tmp.dir,
+            &json!({"density": "compact"}),
+            ConfigPersistIo {
+                write_tmp: partial_write,
+                ..ConfigPersistIo::real()
+            },
+        )
+        .unwrap_err();
+        assert!(
+            no_tmp_leftovers(&tmp.dir),
+            "a half-written temp file must be removed"
+        );
+    }
+
+    #[test]
+    fn failed_replace_keeps_a_recoverable_config() {
+        let tmp = TempConfig::new();
+        std::fs::write(tmp.dir.join("config.json"), r#"{"locale":"zh"}"#).unwrap();
+        let error = persist_config_at(
+            &tmp.dir,
+            &json!({"density": "compact"}),
+            ConfigPersistIo {
+                replace: fail_replace,
+                ..ConfigPersistIo::real()
+            },
+        )
+        .unwrap_err();
+        assert!(error.contains("replace config"), "{error}");
+        assert_eq!(load_config_from(&tmp.dir)["locale"], "zh");
+        let backup: Value = serde_json::from_str(
+            &std::fs::read_to_string(tmp.dir.join("config.json.bak")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(backup["locale"], "zh");
+        assert!(no_tmp_leftovers(&tmp.dir));
+    }
+
+    #[test]
+    fn backup_update_failure_does_not_block_the_save() {
+        let tmp = TempConfig::new();
+        std::fs::write(tmp.dir.join("config.json"), r#"{"locale":"zh"}"#).unwrap();
+        // An unusable backup target (a directory) must not lose the save.
+        std::fs::create_dir_all(tmp.dir.join("config.json.bak")).unwrap();
+        set_config_in(&tmp.dir, json!({ "density": "compact" })).unwrap();
+        let main = load_config_from(&tmp.dir);
+        assert_eq!(main["density"], "compact");
+        assert_eq!(main["locale"], "zh");
+    }
+
+    #[test]
+    fn repeated_saves_keep_the_previous_valid_config_recoverable() {
+        let tmp = TempConfig::new();
+        set_config_in(&tmp.dir, json!({ "locale": "zh" })).unwrap();
+        set_config_in(&tmp.dir, json!({ "density": "regular" })).unwrap();
+        // Crash mid-write: the main file becomes garbage.
+        std::fs::write(tmp.dir.join("config.json"), "{corrupt").unwrap();
+        let recovered = load_config_from(&tmp.dir);
+        assert_eq!(
+            recovered["locale"], "zh",
+            "the backup still loads the previous valid config"
+        );
+        // Saving from the recovered state heals the main file — without
+        // letting the corrupt copy destroy the backup first.
+        set_config_in(&tmp.dir, json!({ "spendTab": "week" })).unwrap();
+        let healed = load_config_from(&tmp.dir);
+        assert_eq!(healed["spendTab"], "week");
+        assert_eq!(healed["locale"], "zh");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #203.

**What was happening:** `persist_config_in()` copied the main `config.json` over `config.json.bak` before writing the new config — unconditionally, with the copy error swallowed. When the main file had gone corrupt (exactly the case the backup exists for), the next save destroyed the good backup first; if the temp write or rename then failed (disk full, locked file), both files were bad and the recoverable state was gone.

**What this changes:** the commit order is now temp file → backup refresh (only while the main file still parses) → atomic replace. A corrupt main never touches the backup; a failed backup refresh is logged, not fatal; any step failing leaves at least one parseable config on disk. Concurrency is unchanged (the same `CONFIG_WRITE` lock covers the whole sequence; nothing new is held across IO that wasn't before).

**Tests** inject filesystem failures (ConfigPersistIo function hooks — no permission games on real dirs): failed temp write leaves everything untouched, a half-written temp is cleaned up, failed replace keeps both old files, an unusable backup target doesn't block the save, a corrupt main over a good backup never damages the backup, and multiple saves + corruption + save-again recovers and heals. Also stops `note_config_error` from appending to the developer's real `config-error.log` during `cargo test`.

Verified locally on Windows: full `cargo test` green (371 passed with the new tests).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->