### PR TITLE
Isolate cached state when a pasted API key is rotated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Pasting a new API key no longer keeps the old account's numbers.**
+  Rotating a plain key (DeepSeek, Moonshot, OpenRouter, …) now drops
+  that card's cached snapshot, cooldown, alerts, and credit high-water
+  mark. Moonshot and Kimi share a folded wallet, so rotating either
+  key clears both. In-flight results from the old key cannot bench or
+  restore the new one (closes #204).
+
 ## 0.4.49 — 2026-09-10
 
 ### Added

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -921,25 +921,45 @@ fn persist_last_ok_at(
     std::fs::write(path, serialized).map_err(|e| format!("write snapshot cache: {e}"))
 }
 
+#[cfg(test)]
+static TEST_PERSIST_LAST_OK_FAIL: AtomicBool = AtomicBool::new(false);
+static SNAPSHOT_CACHE_NEEDS_FLUSH: AtomicBool = AtomicBool::new(false);
+
 fn persist_last_ok(map: &HashMap<String, CachedSnap>) -> Result<(), String> {
+    #[cfg(test)]
+    if TEST_PERSIST_LAST_OK_FAIL.swap(false, Ordering::SeqCst) {
+        SNAPSHOT_CACHE_NEEDS_FLUSH.store(true, Ordering::Release);
+        return Err("test: persist last_ok failed".into());
+    }
     if cfg!(test) {
+        SNAPSHOT_CACHE_NEEDS_FLUSH.store(false, Ordering::Release);
         return Ok(());
     }
     let cache_file = providers::config_dir().join("last_snapshots.json");
-    persist_last_ok_at(&cache_file, map)
+    let result = persist_last_ok_at(&cache_file, map);
+    SNAPSHOT_CACHE_NEEDS_FLUSH.store(result.is_err(), Ordering::Release);
+    result
 }
 
 fn forget_provider_snapshots(ids: &[String]) -> Result<(), String> {
+    forget_provider_snapshots_inner(ids, false)
+}
+
+/// Drop cached snapshots for `ids`. Memory, fail-state, alerts, and the
+/// local HTTP publication are always cleared so a failed disk write cannot
+/// keep serving the old account. `persist_even_if_unchanged` rewrites the
+/// cache file on retry after a persist failure (memory may already be clean).
+fn forget_provider_snapshots_inner(
+    ids: &[String],
+    persist_even_if_unchanged: bool,
+) -> Result<(), String> {
     let mut map = last_ok().lock().unwrap();
     let mut next = map.clone();
     let mut changed = false;
     for id in ids {
         changed |= next.remove(id).is_some();
     }
-    if changed {
-        persist_last_ok(&next)?;
-        *map = next;
-    }
+    *map = next.clone();
     drop(map);
     let mut failures = fail_state().lock().unwrap();
     for id in ids {
@@ -947,6 +967,9 @@ fn forget_provider_snapshots(ids: &[String]) -> Result<(), String> {
         alerts::forget_snapshot(id);
     }
     httpapi::forget_snapshots(ids);
+    if changed || persist_even_if_unchanged {
+        persist_last_ok(&next)?;
+    }
     Ok(())
 }
 
@@ -1384,14 +1407,21 @@ fn is_credential_scoped_card(id: &str) -> bool {
     is_managed_key_card(id) || is_plain_api_key_provider(&family)
 }
 
-/// Moonshot's wallet folds into the Kimi card. Rotating either key must
-/// drop both snapshots and bump both generations, or the old wallet
-/// reappears on the surviving card.
-fn api_key_context_ids(provider: &str) -> Vec<String> {
+/// Snapshots to drop when this pasted key changes. Moonshot's wallet
+/// folds into the Kimi card, so rotating Moonshot must also forget the
+/// Kimi snapshot. Rotating only Kimi leaves the Moonshot snapshot —
+/// that wallet key did not change.
+fn api_key_snapshot_ids(provider: &str) -> Vec<String> {
     match provider {
-        "moonshot" | "kimi" => vec!["moonshot".into(), "kimi".into()],
+        "moonshot" => vec!["moonshot".into(), "kimi".into()],
         _ => vec![provider.to_string()],
     }
+}
+
+/// Credit high-water marks belong to one pasted key. Kimi and Moonshot
+/// do not share a pot — rotating Kimi must not zero Moonshot's meter.
+fn api_key_baseline_ids(provider: &str) -> Vec<String> {
+    vec![provider.to_string()]
 }
 
 /// Managed API families disable all their key cards together.
@@ -1419,6 +1449,7 @@ where
         .get(id)
         .copied()
         .unwrap_or(0);
+    let _credit_bind = CreditMeterBindGuard::begin(credit_meter_bind_ids(id));
     let now = now_ms() as i64;
     let benched = {
         let map = fail_state().lock().unwrap();
@@ -2311,19 +2342,82 @@ fn stored_pane_api_key(path: &Path) -> Option<String> {
         .map(str::to_string)
 }
 
+struct CreditMeterBindGuard {
+    ids: Vec<String>,
+}
+
+impl CreditMeterBindGuard {
+    fn begin(ids: Vec<String>) -> Self {
+        for id in &ids {
+            providers::bind_credit_meter_generation(
+                id,
+                providers::credit_baseline_generation(id),
+            );
+        }
+        Self { ids }
+    }
+}
+
+impl Drop for CreditMeterBindGuard {
+    fn drop(&mut self) {
+        for id in &self.ids {
+            providers::unbind_credit_meter_generation(id);
+        }
+    }
+}
+
+fn credit_meter_bind_ids(id: &str) -> Vec<String> {
+    match id {
+        "kimi" => vec!["kimi".into(), "moonshot".into()],
+        _ => vec![id.to_string()],
+    }
+}
+
+fn api_key_context_is_dirty(dir: &Path, provider: &str) -> bool {
+    let snapshot_ids = api_key_snapshot_ids(provider);
+    let baseline_ids = api_key_baseline_ids(provider);
+    if SNAPSHOT_CACHE_NEEDS_FLUSH.load(Ordering::Acquire) {
+        return true;
+    }
+    {
+        let cache = last_ok().lock().unwrap();
+        if snapshot_ids.iter().any(|id| cache.contains_key(id)) {
+            return true;
+        }
+    }
+    {
+        let failures = fail_state().lock().unwrap();
+        if snapshot_ids.iter().any(|id| failures.contains_key(id)) {
+            return true;
+        }
+    }
+    providers::credit_baselines_contain(dir, &baseline_ids)
+}
+
+fn context_cleanup_error(error: String) -> String {
+    format!("the key change is saved, but clearing the previous key's cached data failed: {error}")
+}
+
 /// A credential actually changed: everything the old key produced — the
 /// last-good snapshot (memory + disk), the local HTTP publication, the
 /// fail-state cooldown, the alert history, and the credit high-water
-/// mark — belongs to the old account. Moonshot's wallet folds into the
-/// Kimi card, so those two ids always invalidate together.
+/// mark — belongs to the old account. Moonshot rotation also drops the
+/// folded Kimi snapshot; each key's credit baseline is forgotten alone.
 fn invalidate_api_key_context(dir: &Path, provider: &str) -> Result<(), String> {
-    let ids = api_key_context_ids(provider);
-    let _mutation = KeyCardMutationGuard::begin(ids.clone());
-    forget_provider_snapshots(&ids).map_err(|e| {
-        format!("the key change is saved, but clearing the previous key's cached data failed: {e}")
-    })?;
-    providers::forget_credit_baselines_in(dir, &ids);
-    Ok(())
+    let snapshot_ids = api_key_snapshot_ids(provider);
+    let baseline_ids = api_key_baseline_ids(provider);
+    let _mutation = KeyCardMutationGuard::begin(snapshot_ids.clone());
+    let snap_err = forget_provider_snapshots_inner(&snapshot_ids, true)
+        .err()
+        .map(context_cleanup_error);
+    let base_err = providers::forget_credit_baselines_in(dir, &baseline_ids)
+        .err()
+        .map(context_cleanup_error);
+    match (snap_err, base_err) {
+        (None, None) => Ok(()),
+        (Some(error), None) | (None, Some(error)) => Err(error),
+        (Some(left), Some(right)) => Err(format!("{left}; {right}")),
+    }
 }
 
 fn set_api_key_in(dir: &Path, provider: &str, key: &str) -> Result<(), String> {
@@ -2340,7 +2434,7 @@ fn set_api_key_in(dir: &Path, provider: &str, key: &str) -> Result<(), String> {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => return Err(format!("remove key file: {e}")),
         }
-        if previous_key.is_some() {
+        if previous_key.is_some() || api_key_context_is_dirty(dir, provider) {
             invalidate_api_key_context(dir, provider)?;
         }
         return Ok(());
@@ -2348,7 +2442,9 @@ fn set_api_key_in(dir: &Path, provider: &str, key: &str) -> Result<(), String> {
     let raw = serde_json::json!({ "apiKey": key }).to_string();
     providers::onenewapi::store::atomic_write(&path, &raw)
         .map_err(|e| format!("write key file: {e}"))?;
-    if previous_key.as_deref() != Some(key) {
+    // Same-key retries still invalidate when a previous cleanup left
+    // snapshots, cooldowns, or credit baselines behind.
+    if previous_key.as_deref() != Some(key) || api_key_context_is_dirty(dir, provider) {
         invalidate_api_key_context(dir, provider)?;
     }
     Ok(())
@@ -3073,12 +3169,14 @@ mod tests {
         retain_current_key_card_results, strip_entry_application_order, strip_icon_ids_to_clear,
         strip_is_active, strip_reset_ids, telemetry_starred_id, is_stable_metric_label,
         updater_endpoint_strings, CachedSnap, FailState,
-        KeyCardMutationGuard, StripEntry, SNAPSHOT_CACHE_MS, STALE_GRACE_MS,
+        KeyCardMutationGuard, StripEntry, SNAPSHOT_CACHE_MS, SNAPSHOT_CACHE_NEEDS_FLUSH,
+        STALE_GRACE_MS, TEST_PERSIST_LAST_OK_FAIL,
     };
     use crate::alerts;
     use crate::providers::{Metric, Snapshot};
     use serde_json::{json, Value};
     use std::collections::{HashMap, HashSet};
+    use std::sync::atomic::Ordering;
 
     fn strip_entry(id: &str, value: u32) -> StripEntry {
         StripEntry {
@@ -3772,6 +3870,116 @@ mod tests {
             doc["moonshot"], 12.0,
             "an untouched provider keeps its baseline"
         );
+    }
+
+    #[test]
+    fn rotating_kimi_does_not_reset_moonshot_usage() {
+        let tmp = TempConfig::new();
+        let _kimi = SnapCacheGuard::new("kimi");
+        let _moonshot = SnapCacheGuard::new("moonshot");
+        set_api_key_in(&tmp.dir, "kimi", "kimi-a").unwrap();
+        set_api_key_in(&tmp.dir, "moonshot", "ms-a").unwrap();
+        seed_cached_ok("kimi", "Kimi Code");
+        seed_cached_ok("moonshot", "Kimi API");
+        std::fs::write(
+            tmp.dir.join("credit_baselines.json"),
+            r#"{"kimi": 5.0, "moonshot": 12.0}"#,
+        )
+        .unwrap();
+
+        set_api_key_in(&tmp.dir, "kimi", "kimi-b").unwrap();
+
+        let cache = last_ok().lock().unwrap();
+        assert!(
+            !cache.contains_key("kimi"),
+            "rotated Kimi snapshot must go"
+        );
+        assert!(
+            cache.contains_key("moonshot"),
+            "Moonshot's key did not change, so its snapshot and meter stay"
+        );
+        let doc: Value = serde_json::from_str(
+            &std::fs::read_to_string(tmp.dir.join("credit_baselines.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(doc.get("kimi").is_none());
+        assert_eq!(doc["moonshot"], 12.0);
+    }
+
+    #[test]
+    fn leftover_cache_is_cleared_when_retrying_the_same_key() {
+        let tmp = TempConfig::new();
+        let id = "openrouter";
+        let _guard = SnapCacheGuard::new(id);
+        set_api_key_in(&tmp.dir, id, "key-b").unwrap();
+        seed_cached_ok(id, "OpenRouter");
+        fail_state().lock().unwrap().insert(
+            id.into(),
+            FailState {
+                until_ms: i64::MAX,
+                note: "HTTP 429 rate limited".into(),
+            },
+        );
+
+        set_api_key_in(&tmp.dir, id, "key-b").unwrap();
+
+        assert!(
+            !last_ok().lock().unwrap().contains_key(id),
+            "retrying the already-saved key must finish a leftover cleanup"
+        );
+        assert!(fail_state().lock().unwrap().get(id).is_none());
+    }
+
+    #[test]
+    fn blocked_credit_baselines_file_is_reported() {
+        let tmp = TempConfig::new();
+        let id = "qwen";
+        let _guard = SnapCacheGuard::new(id);
+        set_api_key_in(&tmp.dir, id, "key-a").unwrap();
+        std::fs::create_dir(tmp.dir.join("credit_baselines.json")).unwrap();
+        let error = set_api_key_in(&tmp.dir, id, "key-b").expect_err("baseline IO must surface");
+        assert!(
+            error.contains("credit baselines") || error.contains("cached data"),
+            "a baseline rewrite failure must not report success: {error}"
+        );
+        assert_eq!(
+            stored_pane_api_key(&tmp.dir.join(format!("{id}.json"))).as_deref(),
+            Some("key-b")
+        );
+    }
+
+    #[test]
+    fn failed_snapshot_persist_clears_memory_and_is_retryable() {
+        let tmp = TempConfig::new();
+        let id = "deepseek";
+        let _guard = SnapCacheGuard::new(id);
+        struct PersistFailGuard;
+        impl Drop for PersistFailGuard {
+            fn drop(&mut self) {
+                TEST_PERSIST_LAST_OK_FAIL.store(false, Ordering::SeqCst);
+                SNAPSHOT_CACHE_NEEDS_FLUSH.store(false, Ordering::Release);
+            }
+        }
+        let _persist_guard = PersistFailGuard;
+        set_api_key_in(&tmp.dir, id, "key-a").unwrap();
+        seed_cached_ok(id, "DeepSeek");
+        TEST_PERSIST_LAST_OK_FAIL.store(true, Ordering::SeqCst);
+        let error = set_api_key_in(&tmp.dir, id, "key-b").expect_err("persist fail must surface");
+        assert!(
+            error.contains("cached data"),
+            "cleanup failure must not look like a successful save: {error}"
+        );
+        assert_eq!(
+            stored_pane_api_key(&tmp.dir.join(format!("{id}.json"))).as_deref(),
+            Some("key-b")
+        );
+        assert!(
+            !last_ok().lock().unwrap().contains_key(id),
+            "memory must drop the old snapshot even when disk persist fails"
+        );
+        set_api_key_in(&tmp.dir, id, "key-b").unwrap();
+        assert!(!last_ok().lock().unwrap().contains_key(id));
+        assert!(!SNAPSHOT_CACHE_NEEDS_FLUSH.load(Ordering::Acquire));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1011,7 +1011,7 @@ fn retain_current_key_card_results(
     let stale: Vec<String> = all
         .iter()
         .filter(|snapshot| {
-            is_managed_key_card(&snapshot.id)
+            is_credential_scoped_card(&snapshot.id)
                 && expected.get(&snapshot.id) != current.get(&snapshot.id)
         })
         .map(|snapshot| snapshot.id.clone())
@@ -1019,6 +1019,19 @@ fn retain_current_key_card_results(
     let stale_set: HashSet<&str> = stale.iter().map(String::as_str).collect();
     all.retain(|snapshot| !stale_set.contains(snapshot.id.as_str()));
     stale
+}
+
+/// The "current" side of the generation check: one map covering every
+/// credential-scoped snapshot in the batch. Built from the same id
+/// universe as the expected side — if this ever narrows back to managed
+/// cards only, every plain provider's `Some(0)` would compare unequal to
+/// a missing entry and each refresh would silently drop its results.
+fn current_credential_scoped_generations(all: &[providers::Snapshot]) -> HashMap<String, u64> {
+    key_card_snapshot_generations(
+        all.iter()
+            .filter(|snapshot| is_credential_scoped_card(&snapshot.id))
+            .map(|snapshot| snapshot.id.clone()),
+    )
 }
 
 static KEY_CARD_MUTATION_GENERATION: AtomicU64 = AtomicU64::new(0);
@@ -1340,6 +1353,47 @@ fn is_managed_key_card(id: &str) -> bool {
     matches!(family_of(id).as_str(), "onenewapi" | "sub2api")
 }
 
+/// The plain API-key providers set_api_key accepts, in
+/// %APPDATA%\Pane\<provider>.json. Single source of truth for both the
+/// save command's validation and the credential-context bookkeeping below.
+const API_KEY_PROVIDERS: &[&str] = &[
+    "openrouter",
+    "zai",
+    "minimax",
+    "deepseek",
+    "moonshot",
+    "kimi",
+    "elevenlabs",
+    "codebuff",
+    "kilo",
+    "aihubmix",
+    "qwen",
+];
+
+fn is_plain_api_key_provider(family: &str) -> bool {
+    API_KEY_PROVIDERS.contains(&family)
+}
+
+/// Cards whose cached snapshots, cooldowns, and alerts belong to one
+/// specific credential and must be dropped when that credential changes:
+/// managed key cards plus the plain API-key providers. Everything else
+/// (CLI-login families like claude/codex) is handled by the separate
+/// cache-identity stamp, not by generations.
+fn is_credential_scoped_card(id: &str) -> bool {
+    let family = family_of(id);
+    is_managed_key_card(id) || is_plain_api_key_provider(&family)
+}
+
+/// Moonshot's wallet folds into the Kimi card. Rotating either key must
+/// drop both snapshots and bump both generations, or the old wallet
+/// reappears on the surviving card.
+fn api_key_context_ids(provider: &str) -> Vec<String> {
+    match provider {
+        "moonshot" | "kimi" => vec!["moonshot".into(), "kimi".into()],
+        _ => vec![provider.to_string()],
+    }
+}
+
 /// Managed API families disable all their key cards together.
 /// Claude/Codex extra accounts stay independent of the bare family id.
 fn card_is_disabled(id: &str, disabled: &[String]) -> bool {
@@ -1357,6 +1411,14 @@ where
 {
     let id = id.as_str();
     let name = name.as_str();
+    // A credential rotation bumps this card's generation under the
+    // publication lock. Capturing it before the request and comparing after
+    // means a result that outlived its own key neither benches nor unbenches
+    // the replacement's fail state (fetch_usage drops it separately).
+    let expected_generation = key_card_snapshot_generations([id.to_string()])
+        .get(id)
+        .copied()
+        .unwrap_or(0);
     let now = now_ms() as i64;
     let benched = {
         let map = fail_state().lock().unwrap();
@@ -1368,6 +1430,13 @@ where
         return providers::Snapshot::error(id, name, note);
     }
     let snap = fut.await;
+    let generation_now = key_card_snapshot_generations([id.to_string()])
+        .get(id)
+        .copied()
+        .unwrap_or(0);
+    if generation_now != expected_generation {
+        return snap;
+    }
     let mut map = fail_state().lock().unwrap();
     if snap.status == "error" {
         let err = snap.error.clone().unwrap_or_default();
@@ -1730,13 +1799,24 @@ async fn fetch_usage(
             )),
         ));
     }
-    let mut expected_key_card_generations = HashMap::new();
+    // Plain API-key providers ride the same generation scheme as managed
+    // key cards: set_api_key bumps a provider's generation when its stored
+    // credential actually changes, so a request the old key started can be
+    // refused at every write-back below (cache, cooldown, publication).
+    let mut expected_key_card_generations = key_card_snapshot_generations(
+        futs.iter()
+            .map(|(id, _)| id.clone())
+            .filter(|id| is_credential_scoped_card(id) && !is_managed_key_card(id)),
+    );
     let onenewapi_generation_before = key_card_mutation_generation();
     let onenewapi_active_before = KEY_CARD_ACTIVE_MUTATIONS.load(Ordering::Acquire);
     if !disabled.iter().any(|d| d == "onenewapi") {
         if let Ok(cards) = providers::onenewapi::prepare_key_cards().await {
-            expected_key_card_generations =
-                key_card_snapshot_generations(cards.iter().map(|card| card.id.clone()));
+            for (id, generation) in
+                key_card_snapshot_generations(cards.iter().map(|card| card.id.clone()))
+            {
+                expected_key_card_generations.insert(id, generation);
+            }
             let onenewapi_generation_after = key_card_mutation_generation();
             let onenewapi_active_after = KEY_CARD_ACTIVE_MUTATIONS.load(Ordering::Acquire);
             let stable = onenewapi_active_before == 0
@@ -1760,7 +1840,7 @@ async fn fetch_usage(
                     ));
                 }
             } else {
-                expected_key_card_generations.clear();
+                expected_key_card_generations.retain(|id, _| !is_managed_key_card(id));
             }
         }
     }
@@ -1816,11 +1896,7 @@ async fn fetch_usage(
         }
     }
     let _publication = KEY_CARD_PUBLICATION.lock().unwrap_or_else(|e| e.into_inner());
-    let current_key_card_generations = key_card_snapshot_generations(
-        all.iter()
-            .filter(|snapshot| is_managed_key_card(&snapshot.id))
-            .map(|snapshot| snapshot.id.clone()),
-    );
+    let current_key_card_generations = current_credential_scoped_generations(&all);
     let stale_key_card_ids = retain_current_key_card_results(
         &mut all,
         &expected_key_card_generations,
@@ -1930,7 +2006,7 @@ async fn fetch_usage(
         if let Ok(mut map) = cache.lock() {
             let mut dirty = false;
             for s in all.iter_mut() {
-                if is_managed_key_card(&s.id) {
+                if is_credential_scoped_card(&s.id) {
                     let current = key_card_snapshot_generations([s.id.clone()]);
                     if expected_key_card_generations.get(&s.id) != current.get(&s.id) {
                         continue;
@@ -1983,11 +2059,7 @@ async fn fetch_usage(
 
     // Recheck before publishing; the publication lock keeps local mutations
     // from interleaving cache updates, HTTP publication, and alerts.
-    let current_key_card_generations = key_card_snapshot_generations(
-        all.iter()
-            .filter(|snapshot| is_managed_key_card(&snapshot.id))
-            .map(|snapshot| snapshot.id.clone()),
-    );
+    let current_key_card_generations = current_credential_scoped_generations(&all);
     let stale_key_card_ids = retain_current_key_card_results(
         &mut all,
         &expected_key_card_generations,
@@ -2224,37 +2296,69 @@ async fn fetch_spend() -> Vec<spend::ProviderSpend> {
     result
 }
 
-/// Saves (or clears, when `key` is empty) a user-pasted API key to
-/// %APPDATA%\Pane\<provider>.json.
-#[tauri::command]
-fn set_api_key(provider: String, key: String) -> Result<(), String> {
-    if !matches!(
-        provider.as_str(),
-        "openrouter"
-            | "zai"
-            | "minimax"
-            | "deepseek"
-            | "moonshot"
-            | "kimi"
-            | "elevenlabs"
-            | "codebuff"
-            | "kilo"
-            | "aihubmix"
-            | "qwen"
-    ) {
+/// The key a provider's credential file currently holds (None when the
+/// file is absent or unreadable). Used to tell a real credential change
+/// from a re-save of the identical key, so an unchanged save doesn't dump
+/// the cached snapshot. The key never leaves this comparison — not
+/// logged, not returned, not published.
+fn stored_pane_api_key(path: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let doc = serde_json::from_str::<Value>(&raw).ok()?;
+    doc.get("apiKey")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(str::to_string)
+}
+
+/// A credential actually changed: everything the old key produced — the
+/// last-good snapshot (memory + disk), the local HTTP publication, the
+/// fail-state cooldown, the alert history, and the credit high-water
+/// mark — belongs to the old account. Moonshot's wallet folds into the
+/// Kimi card, so those two ids always invalidate together.
+fn invalidate_api_key_context(dir: &Path, provider: &str) -> Result<(), String> {
+    let ids = api_key_context_ids(provider);
+    let _mutation = KeyCardMutationGuard::begin(ids.clone());
+    forget_provider_snapshots(&ids).map_err(|e| {
+        format!("the key change is saved, but clearing the previous key's cached data failed: {e}")
+    })?;
+    providers::forget_credit_baselines_in(dir, &ids);
+    Ok(())
+}
+
+fn set_api_key_in(dir: &Path, provider: &str, key: &str) -> Result<(), String> {
+    if !is_plain_api_key_provider(provider) {
         return Err(format!("unknown provider: {provider}"));
     }
-    let dir = providers::config_dir();
-    std::fs::create_dir_all(&dir).map_err(|e| format!("create config dir: {e}"))?;
+    std::fs::create_dir_all(dir).map_err(|e| format!("create config dir: {e}"))?;
     let path = dir.join(format!("{provider}.json"));
+    let previous_key = stored_pane_api_key(&path);
     let key = key.trim();
     if key.is_empty() {
-        let _ = std::fs::remove_file(&path);
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(format!("remove key file: {e}")),
+        }
+        if previous_key.is_some() {
+            invalidate_api_key_context(dir, provider)?;
+        }
         return Ok(());
     }
     let raw = serde_json::json!({ "apiKey": key }).to_string();
     providers::onenewapi::store::atomic_write(&path, &raw)
-        .map_err(|e| format!("write key file: {e}"))
+        .map_err(|e| format!("write key file: {e}"))?;
+    if previous_key.as_deref() != Some(key) {
+        invalidate_api_key_context(dir, provider)?;
+    }
+    Ok(())
+}
+
+/// Saves (or clears, when `key` is empty) a user-pasted API key to
+/// %APPDATA%\Pane\<provider>.json.
+#[tauri::command]
+fn set_api_key(provider: String, key: String) -> Result<(), String> {
+    set_api_key_in(&providers::config_dir(), &provider, &key)
 }
 
 #[tauri::command]
@@ -2954,6 +3058,8 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::{
+        current_credential_scoped_generations, guarded, is_credential_scoped_card,
+        is_plain_api_key_provider, set_api_key_in, stored_pane_api_key,
         cached_kimi_ok_from, cached_onenewapi_id_is_configured, card_is_disabled,
         commit_strip_state_after_apply, fail_state, load_config_from, set_config_in,
         fold_moonshot_into_kimi, forget_onenewapi_key_ids, forget_provider_snapshot,
@@ -3494,6 +3600,285 @@ mod tests {
             fail_state().lock().unwrap().remove(&self.0);
             last_ok().lock().unwrap().remove(&self.0);
         }
+    }
+
+    #[cfg(windows)]
+    fn hold_no_delete(path: &std::path::Path) -> std::fs::File {
+        use std::os::windows::fs::OpenOptionsExt;
+        std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(1) // FILE_SHARE_READ
+            .open(path)
+            .expect("open held key file")
+    }
+
+    fn seed_cached_ok(id: &str, name: &str) {
+        last_ok().lock().unwrap().insert(
+            id.into(),
+            CachedSnap {
+                at: 1_000,
+                snap: Snapshot::ok(
+                    id,
+                    name,
+                    None,
+                    vec![Metric::progress("Credits used", 80.0, None)],
+                ),
+            },
+        );
+    }
+
+    #[test]
+    fn api_key_context_scopes_only_key_backed_families() {
+        assert!(is_credential_scoped_card("deepseek"));
+        assert!(is_credential_scoped_card("sub2api@k1"));
+        assert!(is_credential_scoped_card("onenewapi@k1"));
+        assert!(!is_credential_scoped_card("claude"));
+        assert!(!is_credential_scoped_card("claude@abcd1234"));
+        assert!(!is_credential_scoped_card("codex"));
+        assert!(!is_credential_scoped_card("grok"));
+        assert!(!is_plain_api_key_provider("claude"));
+        assert!(is_plain_api_key_provider("kimi"));
+    }
+
+    #[test]
+    fn current_generations_cover_plain_providers_like_the_expected_side() {
+        let _deepseek = SnapCacheGuard::new("deepseek");
+        let batch = vec![
+            Snapshot::ok("deepseek", "DeepSeek", None, vec![]),
+            Snapshot::ok("claude", "Claude", None, vec![]),
+        ];
+        let current = current_credential_scoped_generations(&batch);
+        let expected = key_card_snapshot_generations(["deepseek".to_string()]);
+        assert_eq!(
+            current.get("deepseek"),
+            expected.get("deepseek"),
+            "no rotation must compare equal and survive the retain"
+        );
+        assert!(!current.contains_key("claude"));
+
+        let mut all = batch;
+        let stale = retain_current_key_card_results(&mut all, &expected, &current);
+        assert!(stale.is_empty(), "nothing dropped without a rotation");
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn rotating_plain_api_key_clears_only_that_providers_old_state() {
+        let tmp = TempConfig::new();
+        let rotated = "deepseek";
+        let bystander = "aihubmix";
+        let _rotated = SnapCacheGuard::new(rotated);
+        let _bystander = SnapCacheGuard::new(bystander);
+        set_api_key_in(&tmp.dir, rotated, "key-a").unwrap();
+        set_api_key_in(&tmp.dir, bystander, "key-z").unwrap();
+        seed_cached_ok(rotated, "DeepSeek");
+        fail_state().lock().unwrap().insert(
+            rotated.into(),
+            FailState {
+                until_ms: i64::MAX,
+                note: "HTTP 429 rate limited".into(),
+            },
+        );
+        alerts::insert_state_for_test(&format!("{rotated}:Credits used"));
+        seed_cached_ok(bystander, "AihubMix");
+
+        set_api_key_in(&tmp.dir, rotated, "key-b").unwrap();
+
+        {
+            let cache = last_ok().lock().unwrap();
+            assert!(
+                !cache.contains_key(rotated),
+                "the old account's success snapshot must not survive a rotation"
+            );
+            assert!(
+                cache.contains_key(bystander),
+                "an untouched provider keeps its cache"
+            );
+        }
+        assert!(fail_state().lock().unwrap().get(rotated).is_none());
+        assert!(!alerts::has_state_for_test(&format!(
+            "{rotated}:Credits used"
+        )));
+        assert_eq!(
+            stored_pane_api_key(&tmp.dir.join(format!("{rotated}.json"))).as_deref(),
+            Some("key-b")
+        );
+        let before = key_card_snapshot_generations([rotated.to_string()]);
+        set_api_key_in(&tmp.dir, rotated, "key-b").unwrap();
+        let after = key_card_snapshot_generations([rotated.to_string()]);
+        assert_eq!(before.get(rotated), after.get(rotated));
+    }
+
+    #[test]
+    fn rotating_moonshot_also_forgets_folded_kimi_wallet() {
+        let tmp = TempConfig::new();
+        let _moonshot = SnapCacheGuard::new("moonshot");
+        let _kimi = SnapCacheGuard::new("kimi");
+        set_api_key_in(&tmp.dir, "moonshot", "key-a").unwrap();
+        seed_cached_ok("moonshot", "Kimi API");
+        last_ok().lock().unwrap().insert(
+            "kimi".into(),
+            CachedSnap {
+                at: 1_000,
+                snap: Snapshot::ok(
+                    "kimi",
+                    "Kimi Code",
+                    None,
+                    vec![
+                        Metric::progress("Session", 10.0, None),
+                        Metric::progress("Credits used", 80.0, None),
+                    ],
+                ),
+            },
+        );
+        alerts::insert_state_for_test("kimi:Credits used");
+
+        set_api_key_in(&tmp.dir, "moonshot", "key-b").unwrap();
+
+        let cache = last_ok().lock().unwrap();
+        assert!(
+            !cache.contains_key("moonshot"),
+            "rotated Moonshot snapshot must go"
+        );
+        assert!(
+            !cache.contains_key("kimi"),
+            "folded Kimi wallet rows must not survive a Moonshot rotation"
+        );
+        assert!(!alerts::has_state_for_test("kimi:Credits used"));
+    }
+
+    #[test]
+    fn rotating_deepseek_drops_the_old_credit_baseline() {
+        let tmp = TempConfig::new();
+        let _guard = SnapCacheGuard::new("deepseek");
+        set_api_key_in(&tmp.dir, "deepseek", "key-a").unwrap();
+        std::fs::write(
+            tmp.dir.join("credit_baselines.json"),
+            r#"{"deepseek": 40.0, "moonshot": 12.0}"#,
+        )
+        .unwrap();
+
+        set_api_key_in(&tmp.dir, "deepseek", "key-b").unwrap();
+
+        let doc: Value = serde_json::from_str(
+            &std::fs::read_to_string(tmp.dir.join("credit_baselines.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(
+            doc.get("deepseek").is_none(),
+            "the new key must not inherit the old high-water mark"
+        );
+        assert_eq!(
+            doc["moonshot"], 12.0,
+            "an untouched provider keeps its baseline"
+        );
+    }
+
+    #[test]
+    fn rotated_key_late_result_is_refused_and_401_shows_no_old_data() {
+        let tmp = TempConfig::new();
+        let id = "openrouter";
+        let _guard = SnapCacheGuard::new(id);
+        set_api_key_in(&tmp.dir, id, "key-a").unwrap();
+        let expected = key_card_snapshot_generations([id.to_string()]);
+        set_api_key_in(&tmp.dir, id, "key-b").unwrap();
+        assert!(!last_ok().lock().unwrap().contains_key(id));
+        let mut publishable = vec![
+            Snapshot::ok(id, "OpenRouter", None, vec![]),
+            Snapshot::ok("claude", "Claude", None, vec![]),
+        ];
+        let current = current_credential_scoped_generations(&publishable);
+        let stale = retain_current_key_card_results(&mut publishable, &expected, &current);
+        assert_eq!(stale, vec![id.to_string()]);
+        assert_eq!(publishable.len(), 1);
+        assert_eq!(publishable[0].id, "claude");
+    }
+
+    #[test]
+    fn late_failure_after_key_rotation_cannot_bench_the_new_context() {
+        let id = "kilo";
+        let _guard = SnapCacheGuard::new(id);
+        let (started_tx, started_rx) = std::sync::mpsc::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let fut = async move {
+            started_tx.send(()).expect("test gate open");
+            release_rx.await.expect("test release");
+            Snapshot::error(id, "Kilo", "HTTP 429 rate limited".into())
+        };
+        let handle = std::thread::spawn(move || {
+            tauri::async_runtime::block_on(guarded(id.to_string(), "Kilo".into(), fut))
+        });
+        started_rx.recv().unwrap();
+        drop(KeyCardMutationGuard::begin(vec![id.to_string()]));
+        release_tx.send(()).unwrap();
+        let snap = handle.join().expect("guarded thread");
+        assert_eq!(snap.status, "error");
+        assert!(
+            fail_state().lock().unwrap().get(id).is_none(),
+            "a late failure from the old key must not bench the new key"
+        );
+    }
+
+    #[test]
+    fn fresh_failure_without_rotation_still_benches() {
+        let id = "kilo-control";
+        let _guard = SnapCacheGuard::new(id);
+        let snap = tauri::async_runtime::block_on(guarded(id.to_string(), "Kilo".into(), async {
+            Snapshot::error(id, "Kilo", "HTTP 429 rate limited".into())
+        }));
+        assert_eq!(snap.status, "error");
+        assert!(fail_state().lock().unwrap().contains_key(id));
+    }
+
+    #[test]
+    fn clearing_missing_key_file_succeeds_and_changes_nothing() {
+        let tmp = TempConfig::new();
+        let id = "qwen";
+        let _guard = SnapCacheGuard::new(id);
+        let before = key_card_snapshot_generations([id.to_string()]);
+        set_api_key_in(&tmp.dir, id, "").unwrap();
+        let after = key_card_snapshot_generations([id.to_string()]);
+        assert_eq!(before.get(id), after.get(id));
+        assert!(!tmp.dir.join(format!("{id}.json")).exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn clearing_blocked_key_file_reports_failure_and_keeps_state() {
+        let tmp = TempConfig::new();
+        let id = "zai";
+        let _guard = SnapCacheGuard::new(id);
+        set_api_key_in(&tmp.dir, id, "key-a").unwrap();
+        seed_cached_ok(id, "Z.ai");
+        let held = hold_no_delete(&tmp.dir.join(format!("{id}.json")));
+        let result = set_api_key_in(&tmp.dir, id, "");
+        drop(held);
+        let error = result.expect_err("a locked key file must not report success");
+        assert!(error.contains("remove key file"), "{error}");
+        assert!(stored_pane_api_key(&tmp.dir.join(format!("{id}.json"))).is_some());
+        assert!(last_ok().lock().unwrap().contains_key(id));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn failed_key_save_keeps_the_old_credential_and_state() {
+        let tmp = TempConfig::new();
+        let id = "minimax";
+        let _guard = SnapCacheGuard::new(id);
+        set_api_key_in(&tmp.dir, id, "key-a").unwrap();
+        seed_cached_ok(id, "MiniMax");
+        let expected = key_card_snapshot_generations([id.to_string()]);
+        let held = hold_no_delete(&tmp.dir.join(format!("{id}.json")));
+        let result = set_api_key_in(&tmp.dir, id, "key-b");
+        drop(held);
+        assert!(result.is_err(), "a failed write must not report success");
+        assert_eq!(
+            stored_pane_api_key(&tmp.dir.join(format!("{id}.json"))).as_deref(),
+            Some("key-a")
+        );
+        assert!(last_ok().lock().unwrap().contains_key(id));
+        let after = key_card_snapshot_generations([id.to_string()]);
+        assert_eq!(expected.get(id), after.get(id));
     }
 
     #[test]

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -23,8 +23,9 @@ pub mod sub2api;
 pub mod zai;
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 
 /// One row inside a provider card, e.g. "Session ▓▓▓░░ 43% left · Resets in 2h".
 /// `resets_at` (epoch ms) + `period_ms` are the structured facts the pace
@@ -347,6 +348,61 @@ pub fn credit_meter(provider: &str, sign: &str, balance: f64) -> Option<Metric> 
 /// Shared with forget_credit_baselines_in so a key rotation cannot race
 /// a refresh that is raising the high-water mark.
 static CREDIT_BASELINE_LOCK: Mutex<()> = Mutex::new(());
+static CREDIT_BASELINE_GENERATIONS: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+static CREDIT_METER_INFLIGHT: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+
+fn credit_baseline_generations() -> &'static Mutex<HashMap<String, u64>> {
+    CREDIT_BASELINE_GENERATIONS.get_or_init(Default::default)
+}
+
+/// Generation last bumped by `forget_credit_baselines_in`. A fetch that
+/// started before that bump must not persist its leftover balance.
+pub fn credit_baseline_generation(id: &str) -> u64 {
+    credit_baseline_generations()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(id)
+        .copied()
+        .unwrap_or(0)
+}
+
+fn bump_credit_baseline_generations(ids: &[String]) {
+    let mut generations = credit_baseline_generations()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    for id in ids {
+        *generations.entry(id.clone()).or_default() += 1;
+    }
+}
+
+/// Remember the baseline generation a live fetch started under. Late
+/// `credit_meter_labeled` calls then refuse to rewrite a rotated key's
+/// high-water mark. Unbind from a drop guard so panics cannot leak it.
+pub fn bind_credit_meter_generation(id: &str, gen: u64) {
+    CREDIT_METER_INFLIGHT
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(id.to_string(), gen);
+}
+
+pub fn unbind_credit_meter_generation(id: &str) {
+    CREDIT_METER_INFLIGHT
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(id);
+}
+
+fn expected_credit_meter_generation(provider: &str) -> u64 {
+    CREDIT_METER_INFLIGHT
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(provider)
+        .copied()
+        .unwrap_or_else(|| credit_baseline_generation(provider))
+}
 
 /// credit_meter with a caller-chosen row label and caption suffix —
 /// purchased-credit pools (Codex Extra credits, Devin's extra balance)
@@ -360,14 +416,34 @@ pub fn credit_meter_labeled(
     label: &str,
     caption_suffix: &str,
 ) -> Option<Metric> {
+    credit_meter_labeled_in(
+        &config_dir(),
+        provider,
+        sign,
+        balance,
+        label,
+        caption_suffix,
+    )
+}
+
+pub fn credit_meter_labeled_in(
+    dir: &Path,
+    provider: &str,
+    sign: &str,
+    balance: f64,
+    label: &str,
+    caption_suffix: &str,
+) -> Option<Metric> {
     if !balance.is_finite() || balance < 0.0 {
         return None;
     }
+    let expected_gen = expected_credit_meter_generation(provider);
     // Providers refresh concurrently and this is a read-modify-write on a
     // shared file — serialize it, or one card's just-raised high-water
     // mark can be overwritten by another's stale copy.
     let _guard = CREDIT_BASELINE_LOCK.lock();
-    let path = config_dir().join("credit_baselines.json");
+    let stale = credit_baseline_generation(provider) != expected_gen;
+    let path = dir.join("credit_baselines.json");
     let mut doc: serde_json::Value = std::fs::read_to_string(&path)
         .ok()
         .and_then(|raw| serde_json::from_str(&raw).ok())
@@ -377,14 +453,16 @@ pub fn credit_meter_labeled(
         .get(provider)
         .and_then(serde_json::Value::as_f64)
         .unwrap_or(0.0);
-    if balance > high {
+    // A late result from a rotated key must not recreate the deleted
+    // baseline from the old account's leftover balance.
+    if !stale && balance > high {
         doc[provider] = serde_json::Value::from(balance);
         let _ = std::fs::write(
             &path,
             serde_json::to_string_pretty(&doc).unwrap_or_default(),
         );
     }
-    let high = high.max(balance);
+    let high = if stale { high } else { high.max(balance) };
     if high <= 0.0 {
         return None;
     }
@@ -401,31 +479,50 @@ pub fn credit_meter_labeled(
 /// Drop persisted high-water marks for the given provider ids. A rotated
 /// API key must not inherit the previous account's credit baseline, or
 /// the new balance is compared against the old pot until it exceeds it.
-pub fn forget_credit_baselines_in(dir: &Path, ids: &[String]) {
+/// Write failures are returned so a key save cannot report success while
+/// the old pot is still on disk.
+pub fn forget_credit_baselines_in(dir: &Path, ids: &[String]) -> Result<(), String> {
     if ids.is_empty() {
-        return;
+        return Ok(());
     }
     let _guard = CREDIT_BASELINE_LOCK.lock();
+    bump_credit_baseline_generations(ids);
     let path = dir.join("credit_baselines.json");
-    let Ok(raw) = std::fs::read_to_string(&path) else {
-        return;
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(format!("read credit baselines: {e}")),
     };
-    let Ok(mut doc) = serde_json::from_str::<serde_json::Value>(&raw) else {
-        return;
-    };
+    let mut doc: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("parse credit baselines: {e}"))?;
     let Some(obj) = doc.as_object_mut() else {
-        return;
+        return Ok(());
     };
     let mut changed = false;
     for id in ids {
         changed |= obj.remove(id).is_some();
     }
     if changed {
-        let _ = std::fs::write(
+        std::fs::write(
             &path,
             serde_json::to_string_pretty(&doc).unwrap_or_default(),
-        );
+        )
+        .map_err(|e| format!("write credit baselines: {e}"))?;
     }
+    Ok(())
+}
+
+pub fn credit_baselines_contain(dir: &Path, ids: &[String]) -> bool {
+    if ids.is_empty() {
+        return false;
+    }
+    let Ok(raw) = std::fs::read_to_string(dir.join("credit_baselines.json")) else {
+        return false;
+    };
+    let Ok(doc) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return false;
+    };
+    ids.iter().any(|id| doc.get(id).is_some())
 }
 
 /// Candidate roots where a second account's CLI config dir may live:
@@ -817,5 +914,88 @@ mod sqlite_temp_tests {
         ));
         // Don't write 64MB; the helper treats a missing file as too large.
         assert!(!super::temp_sqlite_copy_allowed(&huge));
+    }
+}
+
+#[cfg(test)]
+mod credit_baseline_tests {
+    use super::{
+        bind_credit_meter_generation, credit_baseline_generation, credit_meter_labeled_in,
+        forget_credit_baselines_in, unbind_credit_meter_generation,
+    };
+    use serde_json::Value;
+    use std::path::PathBuf;
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new() -> Self {
+            let stamp = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            let dir = std::env::temp_dir().join(format!(
+                "pane-credit-{}-{stamp}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn read_baselines(dir: &std::path::Path) -> Value {
+        serde_json::from_str(&std::fs::read_to_string(dir.join("credit_baselines.json")).unwrap())
+            .unwrap()
+    }
+
+    #[test]
+    fn late_credit_meter_does_not_restore_forgotten_baseline() {
+        let tmp = TempDir::new();
+        std::fs::write(
+            tmp.0.join("credit_baselines.json"),
+            r#"{"deepseek": 40.0}"#,
+        )
+        .unwrap();
+        let started = credit_baseline_generation("deepseek");
+        bind_credit_meter_generation("deepseek", started);
+        forget_credit_baselines_in(&tmp.0, &["deepseek".into()]).unwrap();
+        assert!(
+            credit_baseline_generation("deepseek") > started,
+            "forget must bump the generation a late fetch still holds"
+        );
+        let meter = credit_meter_labeled_in(&tmp.0, "deepseek", "$", 12.0, "Credits used", "");
+        unbind_credit_meter_generation("deepseek");
+        assert!(
+            meter.is_none(),
+            "a stale leftover balance must not become the new high-water"
+        );
+        let doc = read_baselines(&tmp.0);
+        assert!(
+            doc.get("deepseek").is_none(),
+            "late credit_meter must not rewrite the deleted baseline"
+        );
+    }
+
+    #[test]
+    fn forget_credit_baselines_reports_unreadable_file() {
+        let tmp = TempDir::new();
+        std::fs::create_dir(tmp.0.join("credit_baselines.json")).unwrap();
+        let err = forget_credit_baselines_in(&tmp.0, &["deepseek".into()]).unwrap_err();
+        assert!(
+            err.contains("credit baselines"),
+            "baseline IO failures must reach the key-save caller: {err}"
+        );
+    }
+
+    #[test]
+    fn forget_credit_baselines_missing_file_is_ok() {
+        let tmp = TempDir::new();
+        forget_credit_baselines_in(&tmp.0, &["deepseek".into()]).unwrap();
     }
 }

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -23,7 +23,8 @@ pub mod sub2api;
 pub mod zai;
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 /// One row inside a provider card, e.g. "Session ▓▓▓░░ 43% left · Resets in 2h".
 /// `resets_at` (epoch ms) + `period_ms` are the structured facts the pace
@@ -343,10 +344,15 @@ pub fn credit_meter(provider: &str, sign: &str, balance: f64) -> Option<Metric> 
     credit_meter_labeled(provider, sign, balance, "Credits used", "")
 }
 
+/// Shared with forget_credit_baselines_in so a key rotation cannot race
+/// a refresh that is raising the high-water mark.
+static CREDIT_BASELINE_LOCK: Mutex<()> = Mutex::new(());
+
 /// credit_meter with a caller-chosen row label and caption suffix —
 /// purchased-credit pools (Codex Extra credits, Devin's extra balance)
 /// meter identically but shouldn't all be called "Credits used", and some
 /// carry an extra unit in the caption ("· N credits").
+
 pub fn credit_meter_labeled(
     provider: &str,
     sign: &str,
@@ -360,8 +366,7 @@ pub fn credit_meter_labeled(
     // Providers refresh concurrently and this is a read-modify-write on a
     // shared file — serialize it, or one card's just-raised high-water
     // mark can be overwritten by another's stale copy.
-    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    let _guard = LOCK.lock();
+    let _guard = CREDIT_BASELINE_LOCK.lock();
     let path = config_dir().join("credit_baselines.json");
     let mut doc: serde_json::Value = std::fs::read_to_string(&path)
         .ok()
@@ -391,6 +396,36 @@ pub fn credit_meter_labeled(
             "{sign}{balance:.2} of {sign}{high:.2} left{caption_suffix}"
         )),
     ))
+}
+
+/// Drop persisted high-water marks for the given provider ids. A rotated
+/// API key must not inherit the previous account's credit baseline, or
+/// the new balance is compared against the old pot until it exceeds it.
+pub fn forget_credit_baselines_in(dir: &Path, ids: &[String]) {
+    if ids.is_empty() {
+        return;
+    }
+    let _guard = CREDIT_BASELINE_LOCK.lock();
+    let path = dir.join("credit_baselines.json");
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    let Ok(mut doc) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return;
+    };
+    let Some(obj) = doc.as_object_mut() else {
+        return;
+    };
+    let mut changed = false;
+    for id in ids {
+        changed |= obj.remove(id).is_some();
+    }
+    if changed {
+        let _ = std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&doc).unwrap_or_default(),
+        );
+    }
 }
 
 /// Candidate roots where a second account's CLI config dir may live:


### PR DESCRIPTION
## Summary
- Rotating a pasted API key used to keep the old account's snapshot, cooldown, alerts, and credit high-water mark.
- Plain key cards now use the same generation scheme as One/New API / Sub2API, so late results from the old key cannot restore or bench the new one.
- Moonshot's wallet folds into the Kimi card, so rotating either key clears both.
- Credit baselines for the rotated provider are forgotten so the new balance is not compared against the old pot.

Closes #204.

## Test plan
- [x] `rotating_plain_api_key_clears_only_that_providers_old_state`
- [x] `rotating_moonshot_also_forgets_folded_kimi_wallet`
- [x] `rotating_deepseek_drops_the_old_credit_baseline`
- [x] `rotated_key_late_result_is_refused_and_401_shows_no_old_data`
- [x] `late_failure_after_key_rotation_cannot_bench_the_new_context`
- [x] `clearing_blocked_key_file_reports_failure_and_keeps_state` (Windows)
- [x] `failed_key_save_keeps_the_old_credential_and_state` (Windows)

Made with Cursor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->