### PR TITLE
Check for updates on every popover open again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **Update checks are eager again.** Opening the popover asks the
+  update server every time, like it did before 0.4.49's 4 h gate, so
+  a just-published release shows up on the next tray click. A quiet
+  background check still runs every 4 h if the popover never opens.
+
 ## 0.4.49 — 2026-09-10
 
 ### Added

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -15,7 +15,7 @@ This is the complete list. Anything not listed here does not happen.
 | User-configured One/New API origins | Status probe when saving/changing a site, plus one unauthenticated backfill if a stored site has no display unit; billing on every refresh for enabled keys | `/api/status` with no key. Subscription + usage send that site's key as Bearer, **only to that origin** — never to Pane servers. |
 | User-configured Sub2API origins | Each enabled key's scheduled refresh; saving only validates local input | `GET /v1/usage` with that key as Bearer, only to its configured origin, without redirects or fallback endpoints. |
 | `raw.githubusercontent.com` (LiteLLM), `models.dev`, `robinebers.github.io` | ~Daily | Anonymous GET for public model price tables (no identifying data) |
-| `trypane.xyz/api/update` (the legacy `pane.jazii.dev/api/update` redirects there; GitHub Releases is the final fallback) | On launch + every 4 h | Anonymous GET for the update manifest, carrying the app version. See "The update check" below for exactly what this counts. |
+| `trypane.xyz/api/update` (the legacy `pane.jazii.dev/api/update` redirects there; GitHub Releases is the final fallback) | On launch, whenever the popover opens, and every 4 h in the background | Anonymous GET for the update manifest, carrying the app version. See "The update check" below for exactly what this counts. |
 | `us.i.posthog.com` | Once per day (unless switched off) | The two anonymous daily-statistic events described in "Anonymous usage statistics" below — a random ID, version, enabled-provider list, and per-provider success/failure counts. Never usage amounts, spend, keys, or error text. |
 | `127.0.0.1:11434` (your own PC) | Every refresh, if Ollama is enabled | Local-only query of your Ollama server |
 
@@ -65,7 +65,8 @@ auditable file: [`src-tauri/src/telemetry.rs`](../src-tauri/src/telemetry.rs)
 ## The update check
 
 Pane has to ask *somewhere* "is there a newer version?" — that request
-existed from day one. New builds ask `trypane.xyz` first and use GitHub as
+existed from day one. It runs at launch, whenever you open the
+popover, and every 4 h in the background if the popover never opens. New builds ask `trypane.xyz` first and use GitHub as
 the automatic fallback. Old builds that still call `pane.jazii.dev` are
 handled by a permanent redirect to `trypane.xyz`. Every endpoint serves
 the same manifest, and every update is still signature-verified against

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2678,48 +2678,30 @@ async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
     }
 }
 
-/// The 4 h cadence documented in docs/privacy.md is enforced HERE, so the
-/// frontend's launch/popover invokes and the background loop share one
-/// scheduler: inside the window, callers get the cached answer — no network.
-/// (last attempt epoch secs, cached available version)
-static UPDATE_CHECK: Mutex<(u64, Option<String>)> = Mutex::new((0, None));
-
-async fn gated_update_check(app: &tauri::AppHandle) -> Result<Option<String>, String> {
-    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
-    {
-        let st = UPDATE_CHECK.lock().unwrap();
-        if st.0 != 0 && now.saturating_sub(st.0) < 4 * 3600 {
-            return Ok(st.1.clone());
-        }
-    }
-    // Stamp the attempt before awaiting so concurrent callers take the
-    // cached path instead of doubling the request. Failures keep the stamp:
-    // an offline machine must not retry on every popover open.
-    UPDATE_CHECK.lock().unwrap().0 = now;
-    let found = build_updater(app)?
+async fn live_update_check(app: &tauri::AppHandle) -> Result<Option<String>, String> {
+    Ok(build_updater(app)?
         .check()
         .await
         .map_err(|e| e.to_string())?
-        .map(|u| u.version);
-    *UPDATE_CHECK.lock().unwrap() = (now, found.clone());
-    Ok(found)
+        .map(|u| u.version))
 }
 
-/// Update check for the footer button. The backend gate enforces the
-/// documented cadence, so launch/popover invokes are cheap cache reads.
+/// Update check for the footer. Launch and every popover open hit the
+/// network — same as before the 0.4.49 4 h gate — so a just-published
+/// release shows up the next time you open Pane.
 #[tauri::command]
 async fn check_update(app: tauri::AppHandle) -> Result<Option<String>, String> {
-    gated_update_check(&app).await
+    live_update_check(&app).await
 }
 
-/// Startup + every 4 h: quiet update check; a hit emits "update-available"
-/// with the new version so the frontend can show its banner. 404 (no
-/// releases yet) and offline are non-events.
+/// Quiet backup if the popover never opens: check at startup, then every
+/// 4 h. A hit emits "update-available" so the footer can show the button.
+/// 404 (no releases yet) and offline are non-events.
 fn spawn_update_checker(app: &tauri::AppHandle) {
     let handle = app.clone();
     tauri::async_runtime::spawn(async move {
         loop {
-            match gated_update_check(&handle).await {
+            match live_update_check(&handle).await {
                 Ok(Some(version)) => {
                     let _ = handle.emit("update-available", version);
                 }


### PR DESCRIPTION
## Summary
- 0.4.49 cached every update check for 4 hours, so a just-published release stayed hidden until restart.
- Launch and every popover open hit the update server again, like before that gate.
- The quiet 4 h background loop stays as a backup if the popover never opens.
- privacy.md matches the real cadence.

## Test plan
- [ ] Open Pane on 0.4.49 (or this build), publish / wait for a newer tag, open the tray — Update button should appear without a restart
- [ ] Open the tray twice in a row — both checks may hit the network; no stuck Checking…
- [ ] Offline open still shows the version stamp, not an error card

Made with Cursor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->