### PR TITLE
Release 0.4.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.50 — 2026-09-11
 
 ### Changed
 - **Update checks are eager again.** Opening the popover asks the
@@ -21,6 +21,12 @@
   mark. Moonshot and Kimi share a folded wallet, so rotating either
   key clears both. In-flight results from the old key cannot bench or
   restore the new one (closes #204).
+
+### Security
+- **Vendor JSON bodies are capped while they stream in.** `json_body`
+  used to download the whole response, then check the size cap, so a
+  chunked or lying Content-Length could fill RAM. The read now stops
+  at the running cap (closes #202).
 
 ## 0.4.49 — 2026-09-10
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — full Mac parity (and beyond)
 
-**Status (v0.4.49, 2026-09-10): every wave below is shipped, and the
+**Status (v0.4.50, 2026-09-11): every wave below is shipped, and the
 post-launch releases keep going.** Pane has full feature parity with the
 macOS original plus 23 providers (Sub2API multi-site key tracking
 landed), multi-site One/New API key management,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.49",
+  "version": "0.4.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.49",
+      "version": "0.4.50",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.49",
+  "version": "0.4.50",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.49"
+version = "0.4.50"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.49"
+version = "0.4.50"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.49",
+  "version": "0.4.50",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Ships the post-0.4.49 hardening: bounded vendor JSON reads (#202 / #205), corrupt-config backup protection (#203 / #208), and API-key rotation isolation (#204 / #209).
- Update checks are eager again — opening the popover asks the server every time, with the quiet 4 h loop kept as a backup (#210).
- Version bump only: `tauri.conf.json`, `package.json`, `Cargo.toml` (+ locks), CHANGELOG retitle, ROADMAP status line.

## Test plan
- [x] Local `npm run tauri build` produced `Pane_0.4.50_x64-setup.exe`
- [x] Installed by exact name with `/S /UPDATE`; ProductVersion is `0.4.50`
- [x] Relaunched `%LOCALAPPDATA%\Pane\pane.exe`
- [ ] After merge: tag `v0.4.50`, watch release CI, confirm `trypane.xyz/api/update?v=0.4.49` serves 0.4.50

Made with Cursor

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->