### PR TITLE
Report real fetch times and universal freshness in the local HTTP API

### DIFF
--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -3,13 +3,22 @@
 Pane serves your usage as JSON so your own scripts, widgets, and overlays
 can read it.
 
+Every entry exposes `status` (`ok` | `no_credentials` | `error`) and
+`stale` so failed refreshes cannot make historical data look current:
+`stale: true` means the numbers are the last good fetch shown because the
+newest attempt failed. `fetchedAt` is when the data was **last
+successfully fetched** — for a stale entry that is the original success
+time, not the moment it was re-served; for `error`/`no_credentials`
+entries it is the attempt time, and `status` tells you it wasn't a
+success.
+
 Sub2API cards use `GET /v1/usage/sub2api@<key-id>` and are also included
 in the collection. Each key stays independent even if its wallet or
 subscription values match another key. These entries additionally expose
-`status`, `stale`, `error`, and `warning` so failed refreshes cannot make
-historical data look current. Progress entries retain display amounts in
-`value`/`subtitle` as well as the percentage. Other providers keep their
-existing wire format.
+`error` and `warning` (their error strings are whitelisted, sanitized
+text) and their progress entries retain display amounts in `value`/
+`subtitle` as well as the percentage. Other providers keep their existing
+wire format.
 
 This reads Pane's published snapshots and never initiates a remote usage
 request. Disabled or deleted keys return 404 and disappear from the
@@ -31,6 +40,8 @@ Wire format (compatible with the macOS OpenUsage API):
   "providerId": "claude",
   "displayName": "Claude",
   "plan": "Max",
+  "status": "ok",
+  "stale": false,
   "fetchedAt": "2026-07-08T01:30:00Z",
   "lines": [{
     "type": "progress",

--- a/src-tauri/src/alerts.rs
+++ b/src-tauri/src/alerts.rs
@@ -90,14 +90,26 @@ pub fn evaluate(snapshots: &[Snapshot], cfg: &Value) -> Vec<Alert> {
     }
 
     let mut alerts = Vec::new();
-    let Ok(mut map) = states().lock() else { return alerts };
+    let Ok(mut map) = states().lock() else {
+        return alerts;
+    };
 
     for snapshot in snapshots.iter().filter(|s| s.status == "ok") {
+        // Restored snapshots are the last good fetch, not a live reading.
+        // Skipping them entirely means stale data can neither fire a new
+        // worsening alert nor reset the armed state the live data left —
+        // the next live reading is judged against the last live one.
+        if snapshot.stale {
+            continue;
+        }
         if snapshot.id.starts_with("sub2api@") {
             let disabled = cfg.get("disabled").and_then(Value::as_array);
-            if snapshot.stale || disabled.is_some_and(|ids| ids.iter().any(|id| {
-                id.as_str().is_some_and(|id| id == "sub2api" || id == snapshot.id)
-            })) {
+            if disabled.is_some_and(|ids| {
+                ids.iter().any(|id| {
+                    id.as_str()
+                        .is_some_and(|id| id == "sub2api" || id == snapshot.id)
+                })
+            }) {
                 continue;
             }
         }
@@ -110,7 +122,9 @@ pub fn evaluate(snapshots: &[Snapshot], cfg: &Value) -> Vec<Alert> {
             {
                 continue;
             }
-            let Some(used) = metric.used_percent else { continue };
+            let Some(used) = metric.used_percent else {
+                continue;
+            };
             if !used.is_finite() || used < 0.0 {
                 continue;
             }
@@ -157,9 +171,9 @@ pub fn evaluate(snapshots: &[Snapshot], cfg: &Value) -> Vec<Alert> {
                         body: match loc {
                             "zh" => format!("{name} 按当前速度重置时大约只剩 {spare:.0}%。"),
                             "ru" => format!("{name} к сбросу останется примерно {spare:.0}%."),
-                            _ => format!(
-                                "{name} is on pace to finish with only ~{spare:.0}% spare."
-                            ),
+                            _ => {
+                                format!("{name} is on pace to finish with only ~{spare:.0}% spare.")
+                            }
                         },
                     });
                 }
@@ -221,8 +235,18 @@ mod tests {
     fn sub2api_alerts_ignore_stale_disabled_and_nonfinite_observations() {
         let id = "sub2api@alert-eligibility";
         let cfg = serde_json::json!({"notifyAlmostOut": true, "locale": "en"});
-        let make = |used| Snapshot::ok(id, "Site · Key", None,
-            vec![crate::providers::Metric::progress("Total quota", used, None)]);
+        let make = |used| {
+            Snapshot::ok(
+                id,
+                "Site · Key",
+                None,
+                vec![crate::providers::Metric::progress(
+                    "Total quota",
+                    used,
+                    None,
+                )],
+            )
+        };
         forget_snapshot(id);
         assert!(evaluate(&[make(50.0)], &cfg).is_empty());
         let mut stale = make(95.0);
@@ -242,20 +266,71 @@ mod tests {
     fn sub2api_thresholds_are_independent_for_equal_keys_and_each_allowance() {
         let ids = ["sub2api@alert-a", "sub2api@alert-b"];
         let cfg = serde_json::json!({"notifyAlmostOut": true, "locale": "en"});
-        let make = |id: &str, used| Snapshot::ok(id, id, None, vec![
-            crate::providers::Metric::progress("5h", used, None),
-            crate::providers::Metric::progress("1d", used, None),
-        ]);
-        for id in ids { forget_snapshot(id); }
+        let make = |id: &str, used| {
+            Snapshot::ok(
+                id,
+                id,
+                None,
+                vec![
+                    crate::providers::Metric::progress("5h", used, None),
+                    crate::providers::Metric::progress("1d", used, None),
+                ],
+            )
+        };
+        for id in ids {
+            forget_snapshot(id);
+        }
         assert!(evaluate(&[make(ids[0], 40.0), make(ids[1], 40.0)], &cfg).is_empty());
         let alerts = evaluate(&[make(ids[0], 95.0), make(ids[1], 95.0)], &cfg);
         assert_eq!(alerts.len(), 4);
-        assert_eq!(alerts.iter().filter(|alert| alert.body.contains(ids[0])).count(), 2);
+        assert_eq!(
+            alerts
+                .iter()
+                .filter(|alert| alert.body.contains(ids[0]))
+                .count(),
+            2
+        );
         assert!(evaluate(&[make(ids[0], 95.0), make(ids[1], 95.0)], &cfg).is_empty());
-        let wallet = Snapshot::ok(ids[0], "Wallet", None,
-            vec![crate::providers::Metric::text("Balance", "$-20.00".into())]);
+        let wallet = Snapshot::ok(
+            ids[0],
+            "Wallet",
+            None,
+            vec![crate::providers::Metric::text("Balance", "$-20.00".into())],
+        );
         assert!(evaluate(&[wallet], &cfg).is_empty());
-        for id in ids { forget_snapshot(id); }
+        for id in ids {
+            forget_snapshot(id);
+        }
+    }
+
+    #[test]
+    fn stale_snapshots_of_any_provider_never_fire_or_re_arm_alerts() {
+        let id = "codex";
+        let cfg = serde_json::json!({"notifyAlmostOut": true, "locale": "en"});
+        let make = |used, stale| {
+            let mut s = Snapshot::ok(
+                id,
+                "Codex",
+                None,
+                vec![crate::providers::Metric::progress("Weekly", used, None)],
+            );
+            s.stale = stale;
+            s
+        };
+        forget_snapshot(id);
+        // Live baseline, then a stale reading must not fire…
+        assert!(evaluate(&[make(50.0, false)], &cfg).is_empty());
+        assert!(evaluate(&[make(95.0, true)], &cfg).is_empty());
+        // …and a live worsening after it still fires exactly once.
+        assert_eq!(evaluate(&[make(95.0, false)], &cfg).len(), 1);
+        // A stale "recovery" must not re-arm the alert state, so the
+        // still-bad live reading does not fire again.
+        assert!(evaluate(&[make(50.0, true)], &cfg).is_empty());
+        assert!(evaluate(&[make(95.0, false)], &cfg).is_empty());
+        // Genuine live recovery re-arms, and the next drop alerts again.
+        assert!(evaluate(&[make(50.0, false)], &cfg).is_empty());
+        assert_eq!(evaluate(&[make(95.0, false)], &cfg).len(), 1);
+        forget_snapshot(id);
     }
 
     #[test]

--- a/src-tauri/src/httpapi.rs
+++ b/src-tauri/src/httpapi.rs
@@ -30,9 +30,17 @@ pub(crate) fn publish_restored_sub2api(snapshots: &[Snapshot]) {
     let fetched_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     if let Ok(mut published) = latest().lock() {
         if let Some(values) = published.as_array_mut() {
-            values.retain(|value| !value["providerId"].as_str().is_some_and(|id| id.starts_with("sub2api@")));
-            values.extend(snapshots.iter().filter(|snapshot| snapshot.id.starts_with("sub2api@"))
-                .map(|snapshot| provider_json(snapshot, &fetched_at)));
+            values.retain(|value| {
+                !value["providerId"]
+                    .as_str()
+                    .is_some_and(|id| id.starts_with("sub2api@"))
+            });
+            values.extend(
+                snapshots
+                    .iter()
+                    .filter(|snapshot| snapshot.id.starts_with("sub2api@"))
+                    .map(|snapshot| provider_json(snapshot, &fetched_at)),
+            );
         }
     }
 }
@@ -99,16 +107,28 @@ pub(crate) fn provider_json(s: &Snapshot, fetched_at: &str) -> Value {
             }
         })
         .collect();
+    // fetchedAt is when the data was last successfully fetched — for a
+    // snapshot restored after a failed refresh that is the ORIGINAL
+    // success time, not this publish. The fallback (fresh successes,
+    // error states) is the attempt time, which the status field
+    // disambiguates from a success.
+    let fetched_at = s
+        .fetched_at
+        .map(iso8601)
+        .unwrap_or_else(|| fetched_at.to_string());
     let mut output = json!({
         "providerId": s.id,
         "displayName": s.name,
         "plan": s.plan,
         "lines": lines,
         "fetchedAt": fetched_at,
+        // Freshness for every provider — only display facts. Diagnostic
+        // text stays Sub2API-only: its errors are whitelisted strings,
+        // other families may embed remote error text that must not leak.
+        "status": s.status,
+        "stale": s.stale,
     });
     if s.id.starts_with("sub2api@") {
-        output["status"] = json!(s.status);
-        output["stale"] = json!(s.stale);
         output["error"] = json!(s.error);
         output["warning"] = json!(s.warning);
     }
@@ -211,8 +231,12 @@ mod tests {
 
     #[test]
     fn sub2api_public_projection_preserves_stale_and_display_amounts_only() {
-        let mut snap = Snapshot::ok("sub2api@http-state", "Site · Key", None,
-            vec![Metric::progress("5h", 25.0, Some("$5.00 / $20.00".into()))]);
+        let mut snap = Snapshot::ok(
+            "sub2api@http-state",
+            "Site · Key",
+            None,
+            vec![Metric::progress("5h", 25.0, Some("$5.00 / $20.00".into()))],
+        );
         snap.dashboard_url = Some("https://private.example.com".into());
         snap.stale = true;
         snap.warning = Some("HTTP 401".into());
@@ -224,7 +248,48 @@ mod tests {
         assert!(!output.to_string().contains("private.example.com"));
         let error = Snapshot::error("sub2api@http-state", "Site · Key", "HTTP 403".into());
         assert_eq!(provider_json(&error, "now")["error"], "HTTP 403");
-        assert!(provider_json(&onenewapi_snap(), "now").get("status").is_none());
+        // status/stale are universal freshness fields now; diagnostic
+        // error/warning text stays Sub2API-only (its errors are
+        // whitelisted strings, other families may embed remote text).
+        let onenewapi = provider_json(&onenewapi_snap(), "now");
+        assert_eq!(onenewapi["status"], "ok");
+        assert_eq!(onenewapi["stale"], false);
+        assert!(onenewapi.get("error").is_none());
+        assert!(onenewapi.get("warning").is_none());
+    }
+
+    #[test]
+    fn restored_snapshot_keeps_its_original_fetch_time() {
+        // A snapshot restored after a failed refresh must not pose as
+        // freshly fetched: fetchedAt is its own last-success time.
+        let mut snap = Snapshot::ok(
+            "codex",
+            "Codex",
+            None,
+            vec![Metric::progress("Weekly", 25.0, None)],
+        );
+        snap.stale = true;
+        snap.fetched_at = Some(1_800_000_000_000); // 2027-01-15T08:00:00Z
+        let output = provider_json(&snap, "2026-09-05T00:00:00Z");
+        assert_eq!(output["fetchedAt"], "2027-01-15T08:00:00Z");
+        assert_eq!(output["stale"], true);
+
+        // Fresh successes and error states have no last-success time:
+        // they fall back to the attempt time, and status says which.
+        let fresh = provider_json(
+            &Snapshot::ok("codex", "Codex", None, vec![]),
+            "2026-09-05T00:00:00Z",
+        );
+        assert_eq!(fresh["fetchedAt"], "2026-09-05T00:00:00Z");
+        assert_eq!(fresh["status"], "ok");
+        let failed = Snapshot::error("codex", "Codex", "timeout".into());
+        let failed = provider_json(&failed, "2026-09-05T00:00:00Z");
+        assert_eq!(failed["fetchedAt"], "2026-09-05T00:00:00Z");
+        assert_eq!(failed["status"], "error");
+        assert!(
+            failed.get("error").is_none(),
+            "remote error text must not leak for non-Sub2API"
+        );
     }
 
     fn onenewapi_snap() -> Snapshot {
@@ -293,29 +358,61 @@ mod tests {
     #[test]
     fn sub2api_routes_follow_publish_rename_disable_and_context_removal() {
         let _guard = route_test_lock();
-        let make = |id: &str| Snapshot::ok(id, "Site · Key", None,
-            vec![Metric::text("Balance", "$5.00".into())]);
+        let make = |id: &str| {
+            Snapshot::ok(
+                id,
+                "Site · Key",
+                None,
+                vec![Metric::text("Balance", "$5.00".into())],
+            )
+        };
         publish(&[make("sub2api@http-a"), make("sub2api@http-b")]);
         let (status, body) = route(&tiny_http::Method::Get, "/v1/usage");
         assert_eq!(status, 200);
-        assert_eq!(serde_json::from_str::<serde_json::Value>(&body).unwrap().as_array().unwrap().len(), 2);
-        super::rename_snapshots(&std::collections::HashMap::from([
-            ("sub2api@http-a".into(), "Renamed · Key".into())]));
-        assert!(route(&tiny_http::Method::Get, "/v1/usage/sub2api@http-a").1.contains("Renamed · Key"));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&body)
+                .unwrap()
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+        super::rename_snapshots(&std::collections::HashMap::from([(
+            "sub2api@http-a".into(),
+            "Renamed · Key".into(),
+        )]));
+        assert!(route(&tiny_http::Method::Get, "/v1/usage/sub2api@http-a")
+            .1
+            .contains("Renamed · Key"));
         super::forget_snapshots(&["sub2api@http-a".into()]);
-        assert_eq!(route(&tiny_http::Method::Get, "/v1/usage/sub2api@http-a").0, 404);
-        assert_eq!(route(&tiny_http::Method::Get, "/v1/usage/sub2api@http-b").0, 200);
+        assert_eq!(
+            route(&tiny_http::Method::Get, "/v1/usage/sub2api@http-a").0,
+            404
+        );
+        assert_eq!(
+            route(&tiny_http::Method::Get, "/v1/usage/sub2api@http-b").0,
+            200
+        );
         super::forget_disabled_snapshots(&["sub2api".into()]);
-        assert_eq!(route(&tiny_http::Method::Get, "/v1/usage/sub2api@http-b").0, 404);
+        assert_eq!(
+            route(&tiny_http::Method::Get, "/v1/usage/sub2api@http-b").0,
+            404
+        );
         assert_eq!(route(&tiny_http::Method::Get, "/v1/usage").1, "[]");
         let mut restored = make("sub2api@http-restored");
         restored.stale = true;
         super::publish_restored_sub2api(&[restored]);
         let (status, body) = route(&tiny_http::Method::Get, "/v1/usage/sub2api@http-restored");
         assert_eq!(status, 200);
-        assert_eq!(serde_json::from_str::<serde_json::Value>(&body).unwrap()["stale"], true);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&body).unwrap()["stale"],
+            true
+        );
         super::publish_restored_sub2api(&[]);
-        assert_eq!(route(&tiny_http::Method::Get, "/v1/usage/sub2api@http-restored").0, 404);
+        assert_eq!(
+            route(&tiny_http::Method::Get, "/v1/usage/sub2api@http-restored").0,
+            404
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1637,6 +1637,7 @@ fn restore_last_success_after_error(
     current: &mut providers::Snapshot,
     previous: &providers::Snapshot,
     age_ms: i64,
+    previous_at_ms: i64,
 ) -> bool {
     let sub2api = family_of(&current.id) == "sub2api";
     if current.status != "error" || (!sub2api && age_ms > SNAPSHOT_CACHE_MS) {
@@ -1644,11 +1645,78 @@ fn restore_last_success_after_error(
     }
     let warning = current.error.clone();
     *current = previous.clone();
+    // The restored numbers were fetched at `previous_at_ms` — keep that
+    // truth on the snapshot so no downstream consumer (local HTTP API,
+    // tray, alerts) can mistake the restore for a fresh success.
+    current.fetched_at = Some(previous_at_ms);
     if sub2api || age_ms > STALE_GRACE_MS {
         current.stale = true;
         current.warning = warning;
     }
     true
+}
+
+/// One refresh's cache write-back: caches fresh successes and restores the
+/// last good snapshot (marked stale) for transient errors. Returns true
+/// when the map changed. A credential-scoped snapshot whose generation
+/// moved since the refresh started is skipped entirely — a result the old
+/// key produced must not re-enter the cache after a rotation.
+fn apply_cache_updates(
+    map: &mut HashMap<String, CachedSnap>,
+    all: &mut [providers::Snapshot],
+    expected: &HashMap<String, u64>,
+    now_ms: i64,
+) -> bool {
+    let mut dirty = false;
+    for s in all.iter_mut() {
+        if is_credential_scoped_card(&s.id) {
+            let current = key_card_snapshot_generations([s.id.clone()]);
+            if expected.get(&s.id) != current.get(&s.id) {
+                continue;
+            }
+        }
+        // Plan bars can succeed while the folded Moonshot wallet call
+        // fails; keep last-known API/Balance rows so Almost Out and the
+        // tray pin don't blink off for one timeout. Do not re-cache the
+        // patched snapshot — that would reset `at` and keep serving the
+        // same balance forever.
+        let mut skip_cache = false;
+        if s.id == "kimi" && s.status == "ok" && s.warning.is_some() {
+            if let Some(previous) = map.get("kimi") {
+                let age = now_ms - previous.at;
+                if age <= SNAPSHOT_CACHE_MS {
+                    let n = s.metrics.len();
+                    restore_kimi_wallet_rows(s, &previous.snap);
+                    if s.metrics.len() > n {
+                        skip_cache = true;
+                        if age > STALE_GRACE_MS {
+                            s.stale = true;
+                        }
+                    }
+                }
+            }
+        }
+        if s.status == "ok" && !skip_cache {
+            // Stamp the success time on the snapshot itself: everything
+            // downstream (HTTP publication included) reports when this
+            // data was actually fetched, not when it was re-served.
+            s.fetched_at = Some(now_ms);
+            map.insert(
+                s.id.clone(),
+                CachedSnap {
+                    at: now_ms,
+                    snap: s.clone(),
+                },
+            );
+            dirty = true;
+        } else if s.status == "error" {
+            if let Some(previous) = map.get(&s.id) {
+                let age = now_ms - previous.at;
+                restore_last_success_after_error(s, &previous.snap, age, previous.at);
+            }
+        }
+    }
+    dirty
 }
 
 /// Called by the UI. Refreshes every enabled provider at the same time and
@@ -2129,6 +2197,11 @@ async fn fetch_usage(
                     }
                 }
                 if s.status == "ok" && !skip_cache {
+                    // Stamp the success time on the snapshot itself:
+                    // everything downstream (HTTP publication included)
+                    // reports when this data was actually fetched, not
+                    // when it was re-served.
+                    s.fetched_at = Some(now_ms);
                     map.insert(
                         s.id.clone(),
                         CachedSnap {
@@ -2140,7 +2213,7 @@ async fn fetch_usage(
                 } else if s.status == "error" {
                     if let Some(previous) = map.get(&s.id) {
                         let age = now_ms - previous.at;
-                        restore_last_success_after_error(s, &previous.snap, age);
+                        restore_last_success_after_error(s, &previous.snap, age, previous.at);
                     }
                 }
             }
@@ -2352,6 +2425,10 @@ fn cached_usage() -> Vec<providers::Snapshot> {
         .map(|(_, c)| {
             let mut s = c.snap;
             s.stale = true;
+            // The on-disk `at` is the last success time — old caches
+            // predate the in-snapshot field, so the wrapper's value is
+            // authoritative either way. A restore is never "fetched now".
+            s.fetched_at = Some(c.at);
             s
         })
         .collect();
@@ -3392,10 +3469,13 @@ mod tests {
             vec![Metric::progress("Total quota", 25.0, None)],
         );
         let mut current = Snapshot::error("sub2api@wallet", "Panel · Key 1", "HTTP 401".into());
-        assert!(restore_last_success_after_error(&mut current, &previous, 1_000));
+        assert!(restore_last_success_after_error(&mut current, &previous, 1_000, 500));
         assert!(current.stale);
         assert_eq!(current.warning.as_deref(), Some("HTTP 401"));
         assert_eq!(current.metrics[0].used_percent, Some(25.0));
+        // The restore keeps the ORIGINAL success time — never the failed
+        // attempt's — so no downstream consumer can mistake it for fresh.
+        assert_eq!(current.fetched_at, Some(500));
     }
 
     #[test]
@@ -3403,7 +3483,7 @@ mod tests {
         let previous = Snapshot::ok("sub2api@offline", "Panel · Offline", None,
             vec![Metric::text("Balance", "$8.00".into())]);
         let mut current = Snapshot::error("sub2api@offline", "Panel · Offline", "Network error".into());
-        assert!(restore_last_success_after_error(&mut current, &previous, SNAPSHOT_CACHE_MS + 1));
+        assert!(restore_last_success_after_error(&mut current, &previous, SNAPSHOT_CACHE_MS + 1, 10_000));
         assert!(current.stale);
         assert_eq!(current.metrics[0].value.as_deref(), Some("$8.00"));
         assert_eq!(current.warning.as_deref(), Some("Network error"));
@@ -3497,11 +3577,7 @@ mod tests {
         );
         let mut current = Snapshot::error("codex", "Codex", "timeout".into());
 
-        assert!(restore_last_success_after_error(
-            &mut current,
-            &previous,
-            1_000
-        ));
+        assert!(restore_last_success_after_error(&mut current, &previous, 1_000, 500));
         assert_eq!(current.status, "ok");
         assert!(!current.stale);
         assert_eq!(current.warning, None);
@@ -3522,6 +3598,7 @@ mod tests {
             &mut current,
             &previous,
             STALE_GRACE_MS + 1,
+            500
         ));
         assert_eq!(current.status, "ok");
         assert!(current.stale);
@@ -3543,6 +3620,7 @@ mod tests {
             &mut current,
             &previous,
             SNAPSHOT_CACHE_MS + 1,
+            500
         ));
         assert_eq!(current.status, "error");
         assert!(!current.stale);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3859,6 +3859,23 @@ mod tests {
     }
 
     #[test]
+    fn old_format_cache_without_fetched_at_still_loads() {
+        let raw = json!({
+            "kimi": {
+                "at": 123,
+                "snap": {"id": "kimi", "name": "Kimi Code", "plan": null, "status": "ok",
+                         "error": null, "metrics": [], "stale": false, "warning": null}
+            }
+        });
+        let map: HashMap<String, CachedSnap> = serde_json::from_value(raw).unwrap();
+        assert_eq!(map["kimi"].at, 123);
+        assert_eq!(
+            map["kimi"].snap.fetched_at, None,
+            "pre-upgrade caches deserialize with an unknown fetch time, never a fake one"
+        );
+    }
+
+    #[test]
     fn onenewapi_snapshot_cache_write_failure_is_reported() {
         let root =
             std::env::temp_dir().join(format!("pane-onenewapi-cache-fail-{}", std::process::id()));

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -76,7 +76,11 @@ impl Metric {
 
 /// Everything one provider reports back after a refresh. `stale` marks a
 /// snapshot that is actually the last good fetch, shown because the newest
-/// attempt failed transiently (`warning` carries that error).
+/// attempt failed transiently (`warning` carries that error). `fetched_at`
+/// is when this data was last successfully fetched (epoch ms) — it rides
+/// along so a restored snapshot can't pose as a fresh success downstream
+/// (local HTTP API, tray, notifications). `None` means "unknown", which
+/// only happens before the first success.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Snapshot {
     pub id: String,
@@ -87,6 +91,8 @@ pub struct Snapshot {
     pub metrics: Vec<Metric>,
     pub stale: bool,
     pub warning: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fetched_at: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dashboard_url: Option<String>,
 }
@@ -102,6 +108,7 @@ impl Snapshot {
             metrics,
             stale: false,
             warning: None,
+            fetched_at: None,
             dashboard_url: None,
         }
     }
@@ -116,6 +123,7 @@ impl Snapshot {
             metrics: vec![],
             stale: false,
             warning: None,
+            fetched_at: None,
             dashboard_url: None,
         }
     }
@@ -130,6 +138,7 @@ impl Snapshot {
             metrics: vec![],
             stale: false,
             warning: None,
+            fetched_at: None,
             dashboard_url: None,
         }
     }


### PR DESCRIPTION
Fixes #216.

**What was happening:** restored snapshots posed as freshly fetched — httpapi::publish stamped every entry with now(), so a widget reading /v1/usage three days into an outage saw a just-now fetchedAt on three-day-old numbers. And status/stale only existed on Sub2API entries, so for every other provider historical data was indistinguishable from a live success. Alerts had the same blind spot: stale snapshots were skipped only for sub2api@ ids, so a restored card from any other provider could still fire (or re-arm) Almost Out off last-known numbers — the Kimi wallet rows already had a special case for exactly this reason.

**What this changes:**
- Snapshot carries fetched_at (epoch ms of the last successful fetch; serde-defaulted, so caches written before this change load as None — never a faked time).
- Live successes stamp it at cache time; restores keep the cached entry's original at; the launch-time cache restore stamps the on-disk at.
- provider_json reports fetchedAt from that field (fresh successes and error states fall back to the attempt time, which the status field disambiguates) and exposes status + stale for EVERY provider. error/warning stay Sub2API-only on purpose: its error strings are whitelisted/sanitized, other families may embed remote error text that the local API must not leak.
- Alerts skip stale snapshots of any provider — no new worsening alerts and no state resets from last-known data.
- Wire format only gains fields (status, stale on non-Sub2API entries; fetchedAt becomes truthful). Nothing renamed or removed. docs/local-http-api.md updated.

**Tests:** restored snapshots keep their original fetch time in provider_json (fresh/error fall back to attempt time with status saying which), the Sub2API-only assertions flip to the new contract, old-format caches without the field deserialize as unknown-not-faked, and stale snapshots of any provider neither fire nor re-arm alerts (with live-recovery still re-arming).

Note: full-suite parallel runs on this branch show the pre-existing #209 test races (fixed in #213, not merged yet) — single-threaded run is 399/399 green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->