### PR TITLE
Release 0.4.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.51 — 2026-09-12
+
 ### Added
 - **OpenCode extra profiles each get their own card.** `OPENCODE_HOME`
   and `~\.local\share\opencode-*` are discovered like Claude/Codex

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — full Mac parity (and beyond)
 
-**Status (v0.4.50, 2026-09-11): every wave below is shipped, and the
+**Status (v0.4.51, 2026-09-12): every wave below is shipped, and the
 post-launch releases keep going.** Pane has full feature parity with the
 macOS original plus 23 providers (Sub2API multi-site key tracking
 landed), multi-site One/New API key management,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pane",
-  "version": "0.4.50",
+  "version": "0.4.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pane",
-      "version": "0.4.50",
+      "version": "0.4.51",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pane",
   "private": true,
-  "version": "0.4.50",
+  "version": "0.4.51",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "pane"
-version = "0.4.50"
+version = "0.4.51"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pane"
-version = "0.4.50"
+version = "0.4.51"
 description = "AI subscription usage in the Windows tray"
 authors = ["jazii"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pane",
-  "version": "0.4.50",
+  "version": "0.4.51",
   "identifier": "com.jazii.pane",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Ships the spend-scan speed work so a busy Codex/OpenCode machine no longer sits on "Scanning session logs..." for minutes (#223). Growing logs only parse the tail; OpenCode/Devin query a 31-day window.
- OpenCode extra profiles each get their own card (#218 / #221). Minimal view: one starred meter per card (#212 / #222).
- HTTP API snapshots report honest `fetchedAt` / `stale` (#216 / #220). Mainland GLM keys work on the Z.ai card (#214 / #219).
- Version bump only: `tauri.conf.json`, `package.json`, `Cargo.toml` (+ locks), CHANGELOG retitle, ROADMAP status line.

## Test plan
- [x] jazii soak-tested the merged #223 local 0.4.50 build overnight (~1.5 min first scan, "yup works")
- [ ] After merge: tag `v0.4.51`, watch release CI, confirm `trypane.xyz/api/update?v=0.4.50` serves 0.4.51

Made with Cursor

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/itsjazii/pane/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->